### PR TITLE
Adding a way to create unique stack names each deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SDS-in-a-box
 
-Hello!  This a project that attempts to capture the minimum requirements for the core of a Science Data System.  
+This project that attempts to capture the minimum requirements for the core of a Science Data System.  
 
 Our goal with the project is that users will only need to modify the file config.json to define the data products stored on the SDC, and the rest should be mission agnostic.  
 
@@ -21,7 +21,7 @@ The development environment uses a GitHub codespace, to ensure that we're all us
 
 Everyone gets 50 free hours per month of github Codespace time.  Alternatively, your organization can pay for it to run longer than this.  
 
-Top start a new development environment, click the button for "Code" in the upper right corner of the repository, and click "Codespaces".  
+To start a new development environment, click the button for "Code" in the upper right corner of the repository, and click "Codespaces".  
 
 
 ### AWS Setup
@@ -43,7 +43,7 @@ cdk bootstrap
 
 Inside the app.py file, there are two important configuration items which you can alter:
 
-1) SDS_ID - This is just a string of 8 random letters that are appendend to each resources.  Alternatively, you can change this to something more meaningful (i.e. "bryan-testing").  Just be aware that this ID needs to be completely unique in each account.  
+1) SDS_ID - This is just a string of 8 random letters that are appended to each resource.  Alternatively, you can change this to something more meaningful (i.e. "bryan-testing").  Just be aware that this ID needs to be completely unique in each account.  
 
 To deploy the SDS, first you'll need to snyth the CDK code with the command:
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,76 @@
+# SDS-in-a-box
 
-First you need to install nodejs (make sure its newer than version 14!)
+Hello!  This a project that attempts to capture the minimum requirements for the core of a Science Data System.  
 
-https://nodejs.org/en/download/
+Our goal with the project is that users will only need to modify the file config.json to define the data products stored on the SDC, and the rest should be mission agnostic.  
 
-Then you'll need to install the cdk:
+## Architecture
 
-npm install -g aws-cdk
+The code in this repository takes the form of an AWS CDK project. It provides the architecture for:
 
-pip install boto3
-pip install aws-cdk-lib
+1. An HTTPS API to upload files to an S3 bucket (*in development*)
+2. An S3 bucket to contain uploaded files
+3. An HTTPS API to query and download files from the S3 bucket (*in development*)
+4. A lambda function that inserts file metadata into an openseach instance
+5. A Cognito User Pool that keeps track of who can access the restricted APIs.  
 
-The first thing you'll need to do is configure your aws environemnt with 
 
+## Development
+
+The development environment uses a GitHub codespace, to ensure that we're all using the proper libraries as we develop and deploy.  
+
+Everyone gets 50 free hours per month of github Codespace time.  Alternatively, your organization can pay for it to run longer than this.  
+
+Top start a new development environment, click the button for "Code" in the upper right corner of the repository, and click "Codespaces".  
+
+
+### AWS Setup
+The first thing you'll need to do is configure your aws environemnt with:
+
+```
 aws configure
+```
 
-Then you'll need to bootstrap your cdk deployment with 
+Enter in your AWS Access Key ID and AWS Secret Access Key, which can be obtained by setting up a user account in the AWS console. For region, set it to the AWS region you'd like to set up your SDS.  For IMAP, we're using "us-west-2"
 
+**NOTE**-- If this is a brand new AWS account, then you'll need to bootstrap your account to allow CDK deployment with the command: 
+
+```
 cdk bootstrap
+```
+
+### Deploy
+
+Inside the app.py file, there are two important configuration items which you can alter:
+
+1) SDS_ID - This is just a string of 8 random letters that are appendend to each resources.  Alternatively, you can change this to something more meaningful (i.e. "bryan-testing").  Just be aware that this ID needs to be completely unique in each account.  
+
+To deploy the SDS, first you'll need to snyth the CDK code with the command:
+
+```
+cdk synth --context SDSID={insert a unique ID here}
+```
+
+and then you can deploy the architecture with the following command:
+
+```
+cdk deploy --context SDSID={insert a unique ID here}
+```
+for example:
+
+```
+cdk synth --context SDSID=harter-testing
+cdk deploy --context SDSID=harter-testing
+```
+
+After about 20 minutes or so, you should have a brand new SDS set up in AWS.  
 
 
+### Virtual Desktop for Development
+Codespaces actually comes with a fully functional virtual desktop.  To open, click on the "ports" tab and then "open in new browser".  The default password is "vscode".  
 
+
+### Testing the APIs
+Inside of the "scripts" folder is a python script you can use to call the APIs.  It is completely independent of the rest of the project, so you should be able to pull this single file out and run it anywhere.  It only depends on basic python libraries.  
+
+Unfortunately right now you need to "hard code" in the lambda API URL and the Cognito App Client at the top of the file after every build.  I'm hoping in the future to determine a better way to automate this.  

--- a/app.py
+++ b/app.py
@@ -18,5 +18,5 @@ elif SDS_ID=="random":
     SDS_ID = "".join( [random.choice(string.ascii_lowercase) for i in range(8)] )
     
 
-SdsInABoxStack(app, f"SdsInABoxStack-{SDS_ID}")
+SdsInABoxStack(app, f"SdsInABoxStack-{SDS_ID}", SDS_ID)
 app.synth()

--- a/app.py
+++ b/app.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 import os
 import boto3 
+import string
+import random
 import aws_cdk as cdk
 import aws_cdk.assertions as assertions
 from sds_in_a_box.sds_in_a_box_stack import SdsInABoxStack
 
-
+### Implement the code found in "sds_in_a_box_stack.py"
 app = cdk.App()
-SdsInABoxStack(app, "SdsInABoxStack")
 
+SDS_ID = app.node.try_get_context("SDSID")
+
+if SDS_ID is None:
+    raise Exception("ERROR: Need to specify an ID to name the stack (ex - production, testing, etc)")
+elif SDS_ID=="random":
+    # A random unqiue ID for this particular instance of the SDS
+    SDS_ID = "".join( [random.choice(string.ascii_lowercase) for i in range(8)] )
+    
+
+SdsInABoxStack(app, "SdsInABoxStack"+SDS_ID)
 app.synth()
-
-#app = cdk.App()
-#stack = SdsInABoxStack(app, "sds-in-a-box")
-#template = assertions.Template.from_stack(stack)
-#print(template)

--- a/app.py
+++ b/app.py
@@ -7,17 +7,16 @@ import aws_cdk as cdk
 import aws_cdk.assertions as assertions
 from sds_in_a_box.sds_in_a_box_stack import SdsInABoxStack
 
-### Implement the code found in "sds_in_a_box_stack.py"
 app = cdk.App()
 
 SDS_ID = app.node.try_get_context("SDSID")
 
 if SDS_ID is None:
-    raise Exception("ERROR: Need to specify an ID to name the stack (ex - production, testing, etc)")
+    raise ValueError("ERROR: Need to specify an ID to name the stack (ex - production, testing, etc)")
 elif SDS_ID=="random":
     # A random unqiue ID for this particular instance of the SDS
     SDS_ID = "".join( [random.choice(string.ascii_lowercase) for i in range(8)] )
     
 
-SdsInABoxStack(app, "SdsInABoxStack"+SDS_ID)
+SdsInABoxStack(app, f"SdsInABoxStack-{SDS_ID}")
 app.synth()

--- a/sds_in_a_box/sds_in_a_box_stack.py
+++ b/sds_in_a_box/sds_in_a_box_stack.py
@@ -18,12 +18,8 @@ from aws_cdk.aws_lambda_event_sources import S3EventSource, SnsEventSource
 
 class SdsInABoxStack(Stack):
 
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, SDS_ID: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
-        
- ########### INIT
-        # Determines the initial configuration
-        SDS_ID = self.node.try_get_context("SDSID")
 
         # This is the S3 bucket where the data will be stored
         data_bucket = s3.Bucket(self, "DATA-BUCKET",

--- a/tests/unit/test_sds_in_a_box_stack.py
+++ b/tests/unit/test_sds_in_a_box_stack.py
@@ -9,8 +9,7 @@ from sds_in_a_box.sds_in_a_box_stack import SdsInABoxStack
 # example tests. To run these tests, uncomment this file along with the example
 # resource in sds_in_a_box/sds_in_a_box_stack.py
 def test_sqs_queue_created():
-    app = core.App(context={"SDS_ID": "unit-testing"})
-    app_props = core.AppProps(context={"SDS_ID": "unit-testing"})
+    app = core.App(context={"SDSID": "unit-testing"})
     stack = SdsInABoxStack(app, "sds-in-a-box")
     template = assertions.Template.from_stack(stack)
 

--- a/tests/unit/test_sds_in_a_box_stack.py
+++ b/tests/unit/test_sds_in_a_box_stack.py
@@ -4,6 +4,7 @@
 
 import aws_cdk as core
 import random
+import string
 import aws_cdk.assertions as assertions
 from sds_in_a_box.sds_in_a_box_stack import SdsInABoxStack
 

--- a/tests/unit/test_sds_in_a_box_stack.py
+++ b/tests/unit/test_sds_in_a_box_stack.py
@@ -11,6 +11,7 @@ from sds_in_a_box.sds_in_a_box_stack import SdsInABoxStack
 # This test just ensures the stack is able to be created
 # Does not currently check the products that were created
 def test_sds_in_a_box_validity():
+    app = core.App()
     SDS_ID = "".join( [random.choice(string.ascii_lowercase) for i in range(8)] )
     stack = SdsInABoxStack(app, f"sds-in-a-box-{SDS_ID}", SDS_ID)
     template = assertions.Template.from_stack(stack)

--- a/tests/unit/test_sds_in_a_box_stack.py
+++ b/tests/unit/test_sds_in_a_box_stack.py
@@ -3,16 +3,13 @@
 ###################################################
 
 import aws_cdk as core
+import random
 import aws_cdk.assertions as assertions
 from sds_in_a_box.sds_in_a_box_stack import SdsInABoxStack
 
-# example tests. To run these tests, uncomment this file along with the example
-# resource in sds_in_a_box/sds_in_a_box_stack.py
-def test_sqs_queue_created():
-    app = core.App(context={"SDSID": "unit-testing"})
-    stack = SdsInABoxStack(app, "sds-in-a-box")
+# This test just ensures the stack is able to be created
+# Does not currently check the products that were created
+def test_sds_in_a_box_validity():
+    SDS_ID = "".join( [random.choice(string.ascii_lowercase) for i in range(8)] )
+    stack = SdsInABoxStack(app, f"sds-in-a-box-{SDS_ID}", SDS_ID)
     template = assertions.Template.from_stack(stack)
-
-#     template.has_resource_properties("AWS::SQS::Queue", {
-#         "VisibilityTimeout": 300
-#     })

--- a/tests/unit/test_sds_in_a_box_stack.py
+++ b/tests/unit/test_sds_in_a_box_stack.py
@@ -9,7 +9,7 @@ from sds_in_a_box.sds_in_a_box_stack import SdsInABoxStack
 # example tests. To run these tests, uncomment this file along with the example
 # resource in sds_in_a_box/sds_in_a_box_stack.py
 def test_sqs_queue_created():
-    app = core.App()
+    app = core.App(context={"SDS_ID": "unit-testing"})
     app_props = core.AppProps(context={"SDS_ID": "unit-testing"})
     stack = SdsInABoxStack(app, "sds-in-a-box")
     template = assertions.Template.from_stack(stack)

--- a/tests/unit/test_sds_in_a_box_stack.py
+++ b/tests/unit/test_sds_in_a_box_stack.py
@@ -4,13 +4,13 @@
 
 import aws_cdk as core
 import aws_cdk.assertions as assertions
-
 from sds_in_a_box.sds_in_a_box_stack import SdsInABoxStack
 
 # example tests. To run these tests, uncomment this file along with the example
 # resource in sds_in_a_box/sds_in_a_box_stack.py
 def test_sqs_queue_created():
     app = core.App()
+    app_props = core.AppProps(context={"SDS_ID": "unit-testing"})
     stack = SdsInABoxStack(app, "sds-in-a-box")
     template = assertions.Template.from_stack(stack)
 


### PR DESCRIPTION
This pull request adds the ability to add "context" to the cdk synth and cdk deploy commands so that stack that's built appends the "SDS_ID" to the S3 buckets and lambda functions created