### PR TITLE
MNT: Ignore deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,8 @@ classifiers = [
 python = ">=3.9,<4"
 
 [tool.poetry.group.cdk-install.dependencies]
-# Required for aws-cdk.aws-lambda-python-alpha
+# 2.66+ required for aws-cdk.aws-lambda-python-alpha
 aws-cdk-lib = ">=2.66.0,<3.0.0"
-#aws-cdk-lib = "2.48.0"
 "aws-cdk.aws-lambda-python-alpha" = "^2.66.0a0"
 constructs = ">=10.0.0,<11.0.0"
 
@@ -66,6 +65,10 @@ testpaths = [
 addopts = "-ra"
 markers = [
     "network: Test that requires network access",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning:importlib*",
+    "ignore::DeprecationWarning:jsii*",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Ignore deprecation warnings from `importlib` and `jsii` that we can't control. I put in a PR to `jsii` to fix it upstream https://github.com/aws/jsii/pull/3986, but until that is fixed, just ignore them for now.
