### PR TITLE
Implementation of Track Data Availability

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/dynamodb_utils/processing_status.py
+++ b/sds_data_manager/lambda_code/SDSCode/dynamodb_utils/processing_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class ProcessingStatus(Enum):
+    """
+    Enum for the processing status.
+    """
+    PENDING = 0
+    IN_PROGRESS = 1
+    COMPLETED = 2
+    FAILED = 3
+    CANCELLED = 4

--- a/sds_data_manager/lambda_code/SDSCode/dynamodb_utils/processing_status.py
+++ b/sds_data_manager/lambda_code/SDSCode/dynamodb_utils/processing_status.py
@@ -5,6 +5,7 @@ class ProcessingStatus(Enum):
     """
     Enum for the processing status.
     """
+
     PENDING = 0
     IN_PROGRESS = 1
     COMPLETED = 2

--- a/sds_data_manager/lambda_code/SDSCode/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/indexer.py
@@ -8,13 +8,14 @@ import sys
 import boto3
 from opensearchpy import RequestsHttpConnection
 
+from .dynamodb_utils.processing_status import ProcessingStatus
+
 # Local
 from .opensearch_utils.action import Action
 from .opensearch_utils.client import Client
 from .opensearch_utils.document import Document
 from .opensearch_utils.index import Index
 from .opensearch_utils.payload import Payload
-from .dynamodb_utils.processing_status import ProcessingStatus
 
 # Logger setup
 logger = logging.getLogger()
@@ -122,17 +123,17 @@ def initialize_data_processing_status(filename: str):
     # Get instrument name by parsing the filename.
     # Eg. filename = imap_l0_sci_codice_20230602_v02.pkts
     # Get instrument name, codice, from the filename.
-    instrument_name = filename.split('_')[3]
+    instrument_name = filename.split("_")[3]
 
     return {
-        'instrument': instrument_name,
-        'filename': filename,
-        'processing_status': ProcessingStatus.PENDING.name,
-        'l1a_status': ProcessingStatus.PENDING.name,
-        'l1b_status': ProcessingStatus.PENDING.name,
-        'l1c_status': ProcessingStatus.PENDING.name,
-        'l2_status': ProcessingStatus.PENDING.name,
-        'l3_status': ProcessingStatus.PENDING.name
+        "instrument": instrument_name,
+        "filename": filename,
+        "processing_status": ProcessingStatus.PENDING.name,
+        "l1a_status": ProcessingStatus.PENDING.name,
+        "l1b_status": ProcessingStatus.PENDING.name,
+        "l1c_status": ProcessingStatus.PENDING.name,
+        "l2_status": ProcessingStatus.PENDING.name,
+        "l3_status": ProcessingStatus.PENDING.name,
     }
 
 
@@ -144,8 +145,8 @@ def write_data_to_dynamodb(item: dict):
     item : dict
         data for database
     """
-    dynamodb = boto3.resource('dynamodb')
-    table = dynamodb.Table(os.environ['DYNAMODB_TABLE'])
+    dynamodb = boto3.resource("dynamodb")
+    table = dynamodb.Table(os.environ["DYNAMODB_TABLE"])
     table.put_item(Item=item)
 
 
@@ -218,8 +219,8 @@ def lambda_handler(event, context):
         # TODO: Decide if we want to keep both or keep one after SIT-2
         # Right now, we can write processing status of injested data to both databases.
         # In the future, we can decide which one to write to.
-        # Initialize processing status for injested data to pending. This will be updated
-        # when the data is processed.
+        # Initialize processing status for injested data to pending. This will be
+        # updated when the data is processed.
         item = initialize_data_processing_status(filename)
 
         # Write processing status data to DynamoDB.

--- a/sds_data_manager/lambda_code/SDSCode/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/indexer.py
@@ -107,11 +107,17 @@ def _create_open_search_client():
     )
 
 
-def initialize_data_processing_status(filename: str):
+def initialize_data_processing_status(metadata: dict, filename):
     """Generate data that will be sent to database.
 
     Parameters
     ----------
+    metadata : dict
+        metadata from filename. metadata comes from this
+        _check_for_matching_filetype function call.
+        Dictionary returned from that function call
+        can be used to get data level or instrument name
+        via metadata['instrument'] and metadata['level'].
     filename : str
         filename of injested data.
 
@@ -120,16 +126,12 @@ def initialize_data_processing_status(filename: str):
     dict
         data for database
     """
-    # Get instrument name by parsing the filename.
-    # Eg. filename = imap_l0_sci_codice_20230602_v02.pkts
-    # Get instrument name, codice, from the filename.
-    instrument_name = filename.split("_")[3]
 
     return {
-        "instrument": instrument_name,
+        "instrument": metadata["instrument"],
         "filename": filename,
-        "data_level": "l0",
-        "version": "1.0.0",
+        "data_level": metadata["level"],
+        "version": metadata["version"],
         "status": ProcessingStatus.PENDING.name,
     }
 
@@ -218,7 +220,7 @@ def lambda_handler(event, context):
         # In the future, we can decide which one to write to.
         # Initialize processing status for injested data to pending. This will be
         # updated when the data is processed.
-        item = initialize_data_processing_status(filename)
+        item = initialize_data_processing_status(metadata=metadata, filename=filename)
 
         # Write processing status data to DynamoDB.
         write_data_to_dynamodb(item)

--- a/sds_data_manager/lambda_code/SDSCode/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/indexer.py
@@ -128,12 +128,9 @@ def initialize_data_processing_status(filename: str):
     return {
         "instrument": instrument_name,
         "filename": filename,
-        "processing_status": ProcessingStatus.PENDING.name,
-        "l1a_status": ProcessingStatus.PENDING.name,
-        "l1b_status": ProcessingStatus.PENDING.name,
-        "l1c_status": ProcessingStatus.PENDING.name,
-        "l2_status": ProcessingStatus.PENDING.name,
-        "l3_status": ProcessingStatus.PENDING.name,
+        "data_level": "l0",
+        "version": "1.0.0",
+        "status": ProcessingStatus.PENDING.name,
     }
 
 

--- a/sds_data_manager/lambda_code/SDSCode/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/indexer.py
@@ -178,7 +178,7 @@ def lambda_handler(event, context):
 
     # create opensearch client
     client = _create_open_search_client()
-    # create an index (AKA 'table' in other database)
+    # create index (AKA 'table' in other database)
     metadata_index = Index(os.environ["METADATA_INDEX"])
     data_tracker_index = Index(os.environ["DATA_TRACKER_INDEX"])
 
@@ -218,7 +218,7 @@ def lambda_handler(event, context):
         # TODO: Decide if we want to keep both or keep one after SIT-2
         # Right now, we can write processing status of injested data to both databases.
         # In the future, we can decide which one to write to.
-        # Initialized processing status for injested data to pending. This will be updated
+        # Initialize processing status for injested data to pending. This will be updated
         # when the data is processed.
         item = initialize_data_processing_status(filename)
 

--- a/sds_data_manager/stacks/dynamo_db_stack.py
+++ b/sds_data_manager/stacks/dynamo_db_stack.py
@@ -1,0 +1,135 @@
+# Create stack for dynamoDb
+from aws_cdk import RemovalPolicy, Stack
+from aws_cdk import aws_dynamodb as dynamodb
+from constructs import Construct
+
+
+class DynamoDB(Stack):
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        sds_id: str,
+        table_name: str,
+        partition_key: str,
+        sort_key: str,
+        env,
+        on_demand=True,
+        read_capacity=1,
+        write_capacity=1,
+        **kwargs,
+    ):
+        super().__init__(scope, construct_id, **kwargs)
+        """
+        Parameters
+        ----------
+        scope : Construct
+        construct_id : str
+        sds_id : str
+            Name suffix for stack
+        table_name : str
+            Database table name
+        partition_key : str
+            Partition key for DynamoDB table. The partition key must be unique within a table.
+            Every item in a DynamoDB table is uniquely identified by its partition key value.
+            DynamoDB uses the partition key to distribute the data across multiple partitions
+            for scalability and performance.
+
+            When performing operations such as PutItem, GetItem, or Query in DynamoDB, you need
+            to provide a unique value for the partition key to uniquely identify the item. If
+            you attempt to insert an item with a partition key value that already exists in the
+            table, it will overwrite the existing item with the new data.
+        sort_key : str
+            the sort key (also known as the range key) does not have to be unique within a partition.
+            Unlike the partition key, the sort key can have duplicate values within a partition.
+
+            The combination of the partition key and sort key together must be unique for each item
+            in a DynamoDB table. This means that while multiple items within a partition can have the
+            same sort key value, their partition key values must be different.
+        env : Environment
+            Account and region
+        on_demand : bool
+            If true, creates on demand DynamoDb table. If false, creates provisioned DynamoDb table.
+        read_capacity : int
+            Read capacity for provisioned DynamoDb table.
+            Default value is 1.
+        write_capacity : int
+            Write capacity for provisioned DynamoDb table.
+            Default value is 1.
+        """
+        self.sds_id = sds_id
+        self.table_name = table_name
+        self.partition_key = partition_key
+        self.sort_key = sort_key
+        self.on_demand = on_demand
+        if self.on_demand:
+            self._create_on_demand_dynamo_db()
+        else:
+            self._create_provisioned_dynamo_db(read_capacity, write_capacity)
+
+    def _create_on_demand_dynamo_db(self):
+        """Creates On Demand DynamoDb table. On Demand DynamoDb table is created with PAY_PER_REQUEST billing mode.
+
+        When you turn on point-in-time recovery (PITR), DynamoDB backs up your table data automatically so that you
+        can restore to any given second in the preceding 35 days.
+        Returns
+        -------
+        Construct
+            DynamoDb table construct
+        """
+        return dynamodb.Table(
+            self,
+            f"OnDemandDynamoDb-{self.sds_id}",
+            table_name=self.table_name,
+            partition_key=dynamodb.Attribute(
+                name=self.partition_key, type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(
+                name=self.sort_key, type=dynamodb.AttributeType.STRING
+            ),
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+            removal_policy=RemovalPolicy.DESTROY,
+            point_in_time_recovery=True,
+        )
+
+    def _create_provisioned_dynamo_db(self, read_capacity: int, write_capacity: int):
+        """Creates Provisioned DynamoDb table. Provisioned DynamoDb table is created with PROVISIONED billing mode.
+
+        When you turn on point-in-time recovery (PITR), DynamoDB backs up your table data automatically so that you
+        can restore to any given second in the preceding 35 days.
+
+        Parameters
+        ----------
+        read_capacity : int
+            Read capacity for provisioned DynamoDb table.
+        write_capacity : int
+            Write capacity for provisioned DynamoDb table.
+
+        Returns
+        -------
+        Construct
+            DynamoDb table construct
+        """
+        if read_capacity == 1 and write_capacity == 1:
+            raise Warning(
+                "Read capacity and write capacity are using default values. Please use a different value"
+            )
+        return dynamodb.Table(
+            self,
+            f"ProvisionedDynamoDb-{self.sds_id}",
+            table_name=self.table_name,
+            partition_key=dynamodb.Attribute(
+                name=self.partition_key, type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(
+                name=self.sort_key, type=dynamodb.AttributeType.STRING
+            ),
+            billing_mode=dynamodb.BillingMode.PROVISIONED,
+            write_capacity=write_capacity,
+            read_capacity=read_capacity,
+            removal_policy=RemovalPolicy.DESTROY,
+            point_in_time_recovery=True,
+        )
+
+    def get_table_arn(self, table_name):
+        return dynamodb.Table.from_table_name(self, table_name, table_name)

--- a/sds_data_manager/stacks/dynamodb_stack.py
+++ b/sds_data_manager/stacks/dynamodb_stack.py
@@ -1,5 +1,5 @@
-# Create stack for dynamoDb
-from aws_cdk import RemovalPolicy, Stack
+# Create stack for DynamoDB
+from aws_cdk import Environment, RemovalPolicy, Stack
 from aws_cdk import aws_dynamodb as dynamodb
 from constructs import Construct
 
@@ -13,10 +13,10 @@ class DynamoDB(Stack):
         table_name: str,
         partition_key: str,
         sort_key: str,
-        env,
-        on_demand=True,
-        read_capacity=1,
-        write_capacity=1,
+        env: Environment,
+        on_demand: bool = True,
+        read_capacity: int = None,
+        write_capacity: int = None,
         **kwargs,
     ):
         super().__init__(scope, construct_id, **kwargs)
@@ -53,12 +53,12 @@ class DynamoDB(Stack):
         env : Environment
             Account and region
         on_demand : bool
-            If true, creates on demand DynamoDb table. If false, creates provisioned DynamoDb table.
+            If true, creates on demand DynamoDB table. If false, creates provisioned DynamoDB table.
         read_capacity : int
-            Read capacity for provisioned DynamoDb table.
+            Read capacity for provisioned DynamoDB table.
             Default value is 1.
         write_capacity : int
-            Write capacity for provisioned DynamoDb table.
+            Write capacity for provisioned DynamoDB table.
             Default value is 1.
         """
         self.sds_id = sds_id
@@ -66,61 +66,25 @@ class DynamoDB(Stack):
         self.partition_key = partition_key
         self.sort_key = sort_key
         self.on_demand = on_demand
-        if self.on_demand:
-            self._create_on_demand_dynamodb()
-        else:
-            self._create_provisioned_dynamodb(read_capacity, write_capacity)
 
-    def _create_on_demand_dynamodb(self):
-        """Creates On Demand DynamoDb table. On Demand DynamoDb table is created with PAY_PER_REQUEST billing mode.
-
-        When you turn on point-in-time recovery (PITR), DynamoDB backs up your table data automatically so that you
-        can restore to any given second in the preceding 35 days.
-        Returns
-        -------
-        Construct
-            DynamoDb table construct
-        """
-        return dynamodb.Table(
-            self,
-            f"OnDemandDynamoDb-{self.sds_id}",
-            table_name=self.table_name,
-            partition_key=dynamodb.Attribute(
-                name=self.partition_key, type=dynamodb.AttributeType.STRING
-            ),
-            sort_key=dynamodb.Attribute(
-                name=self.sort_key, type=dynamodb.AttributeType.STRING
-            ),
-            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
-            removal_policy=RemovalPolicy.DESTROY,
-            point_in_time_recovery=True,
-        )
-
-    def _create_provisioned_dynamodb(self, read_capacity: int, write_capacity: int):
-        """Creates Provisioned DynamoDb table. Provisioned DynamoDb table is created with PROVISIONED billing mode.
-
-        When you turn on point-in-time recovery (PITR), DynamoDB backs up your table data automatically so that you
-        can restore to any given second in the preceding 35 days.
-
-        Parameters
-        ----------
-        read_capacity : int
-            Read capacity for provisioned DynamoDb table.
-        write_capacity : int
-            Write capacity for provisioned DynamoDb table.
-
-        Returns
-        -------
-        Construct
-            DynamoDb table construct
-        """
-        if read_capacity == 1 and write_capacity == 1:
-            raise Warning(
+        if not on_demand and read_capacity is None and write_capacity is None:
+            raise ValueError(
                 "Read capacity and write capacity are using default values. Please use a different value"
             )
-        return dynamodb.Table(
+
+        if on_demand:
+            # On Demand DynamoDB table is created with PAY_PER_REQUEST billing mode.
+            billing_mode = dynamodb.BillingMode.PAY_PER_REQUEST
+        else:
+            # Provisioned DynamoDB table is created with PROVISIONED billing mode.
+            billing_mode = dynamodb.BillingMode.PROVISIONED
+
+        # When you turn on point-in-time recovery (PITR), DynamoDB backs up your table
+        # data automatically so that you can restore to any given second in the preceding
+        # 35 days
+        dynamodb.Table(
             self,
-            f"ProvisionedDynamoDb-{self.sds_id}",
+            f"DynamoDB-{self.sds_id}",
             table_name=self.table_name,
             partition_key=dynamodb.Attribute(
                 name=self.partition_key, type=dynamodb.AttributeType.STRING
@@ -128,12 +92,9 @@ class DynamoDB(Stack):
             sort_key=dynamodb.Attribute(
                 name=self.sort_key, type=dynamodb.AttributeType.STRING
             ),
-            billing_mode=dynamodb.BillingMode.PROVISIONED,
+            billing_mode=billing_mode,
             write_capacity=write_capacity,
             read_capacity=read_capacity,
             removal_policy=RemovalPolicy.DESTROY,
             point_in_time_recovery=True,
         )
-
-    def get_table_arn(self, table_name):
-        return dynamodb.Table.from_table_name(self, table_name, table_name)

--- a/sds_data_manager/stacks/dynamodb_stack.py
+++ b/sds_data_manager/stacks/dynamodb_stack.py
@@ -30,30 +30,34 @@ class DynamoDB(Stack):
         table_name : str
             Database table name
         partition_key : str
-            Partition key for DynamoDB table. The partition key must be unique within a table.
-            Every item in a DynamoDB table is uniquely identified by its partition key value.
-            DynamoDB uses the partition key to distribute the data across multiple partitions
-            for scalability and performance.
+            Partition key for DynamoDB table. The partition key must be unique within a
+            table. Every item in a DynamoDB table is uniquely identified by its
+            partition key value. DynamoDB uses the partition key to distribute the
+            data across multiple partitions for scalability and performance.
 
-            When performing operations such as PutItem, GetItem, or Query in DynamoDB, you need
-            to provide a unique value for the partition key to uniquely identify the item. If
-            you attempt to insert an item with a partition key value that already exists in the
-            table, it will overwrite the existing item with the new data.
+            When performing operations such as PutItem, GetItem, or Query in DynamoDB,
+            you need to provide a unique value for the partition key to uniquely
+            identify the item. If you attempt to insert an item with a partition key
+            value that already exists in thetable, it will overwrite the existing
+            item with the new data.
 
-            If we want partition key to be not unique, then we need to make sure combination of
-            partition key and sort key is unique.
+            If we want partition key to be not unique, then we need to make sure
+            combination of partition key and sort key is unique.
 
         sort_key : str
-            the sort key (also known as the range key) does not have to be unique within a partition.
-            Unlike the partition key, the sort key can have duplicate values within a partition.
+            the sort key (also known as the range key) does not have to be unique
+            within a partition. Unlike the partition key, the sort key can have
+            duplicate values within a partition.
 
-            The combination of the partition key and sort key together must be unique for each item
-            in a DynamoDB table. This means that while multiple items within a partition can have the
-            same sort key value, their partition key values must be different.
+            The combination of the partition key and sort key together must be
+            unique for each item in a DynamoDB table. This means that while multiple
+            items within a partition can have the same sort key value, their partition
+            key values must be different.
         env : Environment
             Account and region
         on_demand : bool
-            If true, creates on demand DynamoDB table. If false, creates provisioned DynamoDB table.
+            If true, creates on demand DynamoDB table. If false, creates provisioned
+            DynamoDB table.
         read_capacity : int
             Read capacity for provisioned DynamoDB table.
             Default value is 1.
@@ -69,7 +73,7 @@ class DynamoDB(Stack):
 
         if not on_demand and read_capacity is None and write_capacity is None:
             raise ValueError(
-                "Read capacity and write capacity are using default values. Please use a different value"
+                "Required parameters read_capacity and write_capacity are not set"
             )
 
         if on_demand:
@@ -80,8 +84,8 @@ class DynamoDB(Stack):
             billing_mode = dynamodb.BillingMode.PROVISIONED
 
         # When you turn on point-in-time recovery (PITR), DynamoDB backs up your table
-        # data automatically so that you can restore to any given second in the preceding
-        # 35 days
+        # data automatically so that you can restore to any given second in the
+        # preceding 35 days
         dynamodb.Table(
             self,
             f"DynamoDB-{self.sds_id}",

--- a/sds_data_manager/stacks/dynamodb_stack.py
+++ b/sds_data_manager/stacks/dynamodb_stack.py
@@ -39,6 +39,10 @@ class DynamoDB(Stack):
             to provide a unique value for the partition key to uniquely identify the item. If
             you attempt to insert an item with a partition key value that already exists in the
             table, it will overwrite the existing item with the new data.
+
+            If we want partition key to be not unique, then we need to make sure combination of
+            partition key and sort key is unique.
+
         sort_key : str
             the sort key (also known as the range key) does not have to be unique within a partition.
             Unlike the partition key, the sort key can have duplicate values within a partition.
@@ -63,11 +67,11 @@ class DynamoDB(Stack):
         self.sort_key = sort_key
         self.on_demand = on_demand
         if self.on_demand:
-            self._create_on_demand_dynamo_db()
+            self._create_on_demand_dynamodb()
         else:
-            self._create_provisioned_dynamo_db(read_capacity, write_capacity)
+            self._create_provisioned_dynamodb(read_capacity, write_capacity)
 
-    def _create_on_demand_dynamo_db(self):
+    def _create_on_demand_dynamodb(self):
         """Creates On Demand DynamoDb table. On Demand DynamoDb table is created with PAY_PER_REQUEST billing mode.
 
         When you turn on point-in-time recovery (PITR), DynamoDB backs up your table data automatically so that you
@@ -92,7 +96,7 @@ class DynamoDB(Stack):
             point_in_time_recovery=True,
         )
 
-    def _create_provisioned_dynamo_db(self, read_capacity: int, write_capacity: int):
+    def _create_provisioned_dynamodb(self, read_capacity: int, write_capacity: int):
         """Creates Provisioned DynamoDb table. Provisioned DynamoDb table is created with PROVISIONED billing mode.
 
         When you turn on point-in-time recovery (PITR), DynamoDB backs up your table data automatically so that you

--- a/sds_data_manager/stacks/sds_data_manager_stack.py
+++ b/sds_data_manager/stacks/sds_data_manager_stack.py
@@ -30,8 +30,8 @@ from aws_cdk import (
 from constructs import Construct
 
 # Local
-from .opensearch_stack import OpenSearch
 from .dynamodb_stack import DynamoDB
+from .opensearch_stack import OpenSearch
 
 
 class SdsDataManager(Stack):
@@ -57,7 +57,8 @@ class SdsDataManager(Stack):
         opensearch: OpenSearch
             This class depends on opensearch, which is built with opensearch_stack.py
         dynamodb_stack: DynamoDb
-            This class depends on dynamodb_stack, which is built with opensearch_stack.py
+            This class depends on dynamodb_stack, which is built with
+            opensearch_stack.py
         env : Environment
             Account and region
         """

--- a/sds_data_manager/stacks/sds_data_manager_stack.py
+++ b/sds_data_manager/stacks/sds_data_manager_stack.py
@@ -31,6 +31,7 @@ from constructs import Construct
 
 # Local
 from .opensearch_stack import OpenSearch
+from .dynamodb_stack import DynamoDB
 
 
 class SdsDataManager(Stack):
@@ -42,6 +43,7 @@ class SdsDataManager(Stack):
         construct_id: str,
         sds_id: str,
         opensearch: OpenSearch,
+        dynamodb_stack: DynamoDB,
         env: Environment,
         **kwargs,
     ) -> None:
@@ -54,6 +56,8 @@ class SdsDataManager(Stack):
         sds_id: str
         opensearch: OpenSearch
             This class depends on opensearch, which is built with opensearch_stack.py
+        dynamodb_stack: DynamoDb
+            This class depends on dynamodb_stack, which is built with opensearch_stack.py
         env : Environment
             Account and region
         """
@@ -141,7 +145,9 @@ class SdsDataManager(Stack):
                 "OS_ADMIN_USERNAME": "master-user",
                 "OS_DOMAIN": opensearch.sds_metadata_domain.domain_endpoint,
                 "OS_PORT": "443",
-                "OS_INDEX": "metadata",
+                "METADATA_INDEX": "metadata",
+                "DATA_TRACKER_INDEX": "data_tracker",
+                "DYNAMODB_TABLE": dynamodb_stack.table_name,
                 "S3_DATA_BUCKET": data_bucket.s3_url_for_object(),
                 "S3_CONFIG_BUCKET_NAME": f"sds-config-bucket-{sds_id}",
                 "SECRET_ID": opensearch.secret_name,

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -4,6 +4,7 @@ from aws_cdk import App, Environment
 
 # Local
 from sds_data_manager.stacks import (
+    dynamodb_stack,
     api_gateway_stack,
     domain_stack,
     opensearch_stack,
@@ -30,8 +31,18 @@ def build_sds(
         scope, f"OpenSearch-{sds_id}", sds_id, env=env
     )
 
+    dynamodb = dynamodb_stack.DynamoDB(
+        scope,
+        construct_id=f"DynamoDB-{sds_id}",
+        sds_id=sds_id,
+        table_name=f"imap-data-watcher-{sds_id}",
+        partition_key="instrument",
+        sort_key="filename",
+        env=env
+    )
+
     data_manager = sds_data_manager_stack.SdsDataManager(
-        scope, f"SdsDataManager-{sds_id}", sds_id, open_search, env=env
+        scope, f"SdsDataManager-{sds_id}", sds_id, open_search, dynamodb, env=env
     )
 
     domain = domain_stack.Domain(

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -4,9 +4,9 @@ from aws_cdk import App, Environment
 
 # Local
 from sds_data_manager.stacks import (
-    dynamodb_stack,
     api_gateway_stack,
     domain_stack,
+    dynamodb_stack,
     opensearch_stack,
     sds_data_manager_stack,
 )
@@ -38,7 +38,7 @@ def build_sds(
         table_name=f"imap-data-watcher-{sds_id}",
         partition_key="instrument",
         sort_key="filename",
-        env=env
+        env=env,
     )
 
     data_manager = sds_data_manager_stack.SdsDataManager(

--- a/tests/infrastructure/test_dynamo_db_stack.py
+++ b/tests/infrastructure/test_dynamo_db_stack.py
@@ -1,7 +1,6 @@
 import aws_cdk as cdk
 import pytest
-from aws_cdk.assertions import Match as match
-from aws_cdk.assertions import Template
+from aws_cdk.assertions import Match, Template
 
 from sds_data_manager.stacks.dynamodb_stack import DynamoDB
 
@@ -56,13 +55,13 @@ def test_billing_mode(on_demand_dynamodb, provisioned_dynamodb):
     )
     # If provisioned, it doesn't have BillingMode in resource properties. It instead has
     # read and write capacity units.
-    # Note: match.any_value() matches any non-null value at the target.
+    # Note: Match.any_value() matches any non-null value at the target.
     provisioned_dynamodb.has_resource_properties(
         "AWS::DynamoDB::Table",
         {
             "ProvisionedThroughput": {
-                "ReadCapacityUnits": match.any_value(),
-                "WriteCapacityUnits": match.any_value(),
+                "ReadCapacityUnits": Match.any_value(),
+                "WriteCapacityUnits": Match.any_value(),
             }
         },
     )

--- a/tests/infrastructure/test_dynamo_db_stack.py
+++ b/tests/infrastructure/test_dynamo_db_stack.py
@@ -1,0 +1,47 @@
+import pytest
+from aws_cdk.assertions import Template
+
+from sds_data_manager.stacks.dynamo_db_stack import DynamoDB
+
+
+@pytest.fixture(scope="module")
+def template(app, sds_id):
+    stack_name = f"stack-{sds_id}"
+    stack = DynamoDB(
+        app,
+        stack_name,
+        sds_id,
+        table_name=f"table-{sds_id}",
+        partition_key="filename",
+        sort_key="instrument",
+        env=None,
+    )
+    template = Template.from_stack(stack)
+    return template
+
+
+def test_table_name(template):
+    template.resource_count_is("AWS::DynamoDB::Table", 1)
+
+
+def test_billing_mode(template):
+    template.has_resource_properties(
+        "AWS::DynamoDB::Table", {"BillingMode": "PAY_PER_REQUEST"}
+    )
+
+
+def test_point_in_time_recovery(template):
+    template.has_resource_properties(
+        "AWS::DynamoDB::Table",
+        {"PointInTimeRecoverySpecification": {"PointInTimeRecoveryEnabled": True}},
+    )
+
+
+def test_delete_table_policy(template):
+    template.has_resource(
+        "AWS::DynamoDB::Table",
+        {
+            "DeletionPolicy": "Delete",
+            "UpdateReplacePolicy": "Delete",
+        },
+    )

--- a/tests/infrastructure/test_dynamo_db_stack.py
+++ b/tests/infrastructure/test_dynamo_db_stack.py
@@ -1,7 +1,7 @@
 import pytest
 from aws_cdk.assertions import Template
 
-from sds_data_manager.stacks.dynamo_db_stack import DynamoDB
+from sds_data_manager.stacks.dynamodb_stack import DynamoDB
 
 
 @pytest.fixture(scope="module")
@@ -20,7 +20,7 @@ def template(app, sds_id):
     return template
 
 
-def test_table_name(template):
+def test_table_count(template):
     template.resource_count_is("AWS::DynamoDB::Table", 1)
 
 

--- a/tests/infrastructure/test_dynamo_db_stack.py
+++ b/tests/infrastructure/test_dynamo_db_stack.py
@@ -1,12 +1,16 @@
+import aws_cdk as cdk
 import pytest
+from aws_cdk.assertions import Match as match
 from aws_cdk.assertions import Template
 
 from sds_data_manager.stacks.dynamodb_stack import DynamoDB
 
 
-@pytest.fixture(scope="module")
-def template(app, sds_id):
-    stack_name = f"stack-{sds_id}"
+@pytest.fixture()
+def on_demand_dynamodb(sds_id="test"):
+    app = cdk.App()
+
+    stack_name = f"on-demand-stack-{sds_id}"
     stack = DynamoDB(
         app,
         stack_name,
@@ -20,25 +24,70 @@ def template(app, sds_id):
     return template
 
 
-def test_table_count(template):
-    template.resource_count_is("AWS::DynamoDB::Table", 1)
+@pytest.fixture()
+def provisioned_dynamodb(sds_id="test"):
+    app = cdk.App()
+
+    stack_name = f"provisioned-stack-{sds_id}"
+    stack = DynamoDB(
+        app,
+        stack_name,
+        sds_id,
+        table_name=f"table-{sds_id}",
+        partition_key="filename",
+        sort_key="instrument",
+        env=None,
+        on_demand=False,
+        write_capacity=100,
+        read_capacity=100,
+    )
+    template = Template.from_stack(stack)
+    return template
 
 
-def test_billing_mode(template):
-    template.has_resource_properties(
+def test_table_count(on_demand_dynamodb, provisioned_dynamodb):
+    on_demand_dynamodb.resource_count_is("AWS::DynamoDB::Table", 1)
+    provisioned_dynamodb.resource_count_is("AWS::DynamoDB::Table", 1)
+
+
+def test_billing_mode(on_demand_dynamodb, provisioned_dynamodb):
+    on_demand_dynamodb.has_resource_properties(
         "AWS::DynamoDB::Table", {"BillingMode": "PAY_PER_REQUEST"}
+    )
+    # If provisioned, it doesn't have BillingMode in resource properties. It instead has
+    # read and write capacity units.
+    # Note: match.any_value() matches any non-null value at the target.
+    provisioned_dynamodb.has_resource_properties(
+        "AWS::DynamoDB::Table",
+        {
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": match.any_value(),
+                "WriteCapacityUnits": match.any_value(),
+            }
+        },
     )
 
 
-def test_point_in_time_recovery(template):
-    template.has_resource_properties(
+def test_point_in_time_recovery(on_demand_dynamodb, provisioned_dynamodb):
+    on_demand_dynamodb.has_resource_properties(
+        "AWS::DynamoDB::Table",
+        {"PointInTimeRecoverySpecification": {"PointInTimeRecoveryEnabled": True}},
+    )
+    provisioned_dynamodb.has_resource_properties(
         "AWS::DynamoDB::Table",
         {"PointInTimeRecoverySpecification": {"PointInTimeRecoveryEnabled": True}},
     )
 
 
-def test_delete_table_policy(template):
-    template.has_resource(
+def test_delete_table_policy(on_demand_dynamodb, provisioned_dynamodb):
+    on_demand_dynamodb.has_resource(
+        "AWS::DynamoDB::Table",
+        {
+            "DeletionPolicy": "Delete",
+            "UpdateReplacePolicy": "Delete",
+        },
+    )
+    provisioned_dynamodb.has_resource(
         "AWS::DynamoDB::Table",
         {
             "DeletionPolicy": "Delete",


### PR DESCRIPTION
# Change Summary
This is initial implementation of issue [Data Tracket Implementation](https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/96)

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
We need a database to track processing. In this review, there are two ways to track processing.
1. Use DynamDB to track processing
2. Use existing opensearch database

## New Dependencies

## New Files
- sds_data_manager/lambda_code/SDSCode/dynamodb_utils/processing_status.py
   - Defines processing status enum
- sds_data_manager/stacks/dynamodb_stack.py
   - Creates DynamoDB resources using this stack
  
## Deleted Files


## Updated Files
- sds_data_manager/lambda_code/SDSCode/indexer.py
   - Added code in indexer lambda to take injested data information and initialized data-tracker with default processing status.
   - Created new opensearch index to send same default processing status.
- updated file 2
   - descipriton of change 1 in file 2
- sds_data_manager/stacks/sds_data_manager_stack.py
   - Updated it take DynamoDB stack as input and use it to get and set environment variable of table name for indexer lambda
- sds_data_manager/utils/stackbuilder.py
   - Updated stack builder to create DynamoDB stack and updated input parameter of sds_data_manager_stack.
## Testing
- tests/infrastructure/test_dynamo_db_stack.py
   - This tests if DynamoDB stack creates resources as expected and checks some required settings.
