### PR TITLE
Changing the Upload API to use a GET rather than a POST

### DIFF
--- a/sds_data_manager/stacks/sds_data_manager_stack.py
+++ b/sds_data_manager/stacks/sds_data_manager_stack.py
@@ -233,8 +233,7 @@ class SdsDataManager(Stack):
         download_query_api.add_to_role_policy(s3_read_policy)
 
         self.lambda_functions = {
-            "upload": {"function": upload_api_lambda, "httpMethod": "POST"},
+            "upload": {"function": upload_api_lambda, "httpMethod": "GET"},
             "query": {"function": query_api_lambda, "httpMethod": "GET"},
             "download": {"function": download_query_api, "httpMethod": "GET"},
-            "indexer": {"function": indexer_lambda, "httpMethod": "POST"},
         }


### PR DESCRIPTION
# Change Summary
Updating the API Gateway functions 

## Overview
Removed the "indexer" API, and changed the "upload" API to GET

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
- api_gateway_stack.py
   - Removed the "indexer" API.  The indexer lambda function triggers from new files arriving in the bucket, so it only gets invoked internally and doesn't need an API
   - Changed the upload from a "POST" to a "GET".  The reason why it is a "GET" is because the upload API actually returns a signed url to the user to upload a data file.  

## Testing
