### PR TITLE
Updated infrastructure tests

### DIFF
--- a/tests/infrastructure/test_data_manager_stack.py
+++ b/tests/infrastructure/test_data_manager_stack.py
@@ -4,8 +4,6 @@ from aws_cdk.assertions import Match, Template
 from sds_data_manager.stacks.opensearch_stack import OpenSearch
 from sds_data_manager.stacks.sds_data_manager_stack import SdsDataManager
 
-pytest.skip("Skipping tests temporarily", allow_module_level=True)
-
 
 @pytest.fixture(scope="module")
 def opensearch_stack(app, sds_id, env):
@@ -37,7 +35,7 @@ def test_s3_data_bucket_resource_properties(template, sds_id):
     template.has_resource_properties(
         "AWS::S3::Bucket",
         props={
-            "BucketName": f"sds-data-{sds_id}",
+            "BucketName": f"sds-config-bucket-{sds_id}",
             "VersioningConfiguration": {"Status": "Enabled"},
             "PublicAccessBlockConfiguration": {"RestrictPublicBuckets": True},
         },
@@ -56,7 +54,7 @@ def test_s3_config_bucket_resource_properties(template, sds_id):
     template.has_resource_properties(
         "AWS::S3::Bucket",
         {
-            "BucketName": f"sds-config-{sds_id}",
+            "BucketName": f"sds-config-bucket-{sds_id}",
             "VersioningConfiguration": {"Status": "Enabled"},
             "PublicAccessBlockConfiguration": {
                 "BlockPublicAcls": True,
@@ -76,7 +74,7 @@ def test_s3_data_bucket_policy_resource_properties(template):
     template.has_resource_properties(
         "AWS::S3::BucketPolicy",
         props={
-            "Bucket": {"Ref": Match.string_like_regexp("DATABUCKET*")},
+            "Bucket": {"Ref": Match.string_like_regexp("DataBucket*")},
             "PolicyDocument": {
                 "Version": "2012-10-17",
                 "Statement": [
@@ -96,7 +94,7 @@ def test_s3_data_bucket_policy_resource_properties(template):
                         "Resource": [
                             {
                                 "Fn::GetAtt": [
-                                    Match.string_like_regexp("DATABUCKET*"),
+                                    Match.string_like_regexp("DataBucket*"),
                                     "Arn",
                                 ]
                             },
@@ -106,7 +104,7 @@ def test_s3_data_bucket_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("DATABUCKET*"),
+                                                Match.string_like_regexp("DataBucket*"),
                                                 "Arn",
                                             ]
                                         },
@@ -126,7 +124,7 @@ def test_s3_config_bucket_policy_resource_properties(template):
     template.has_resource_properties(
         "AWS::S3::BucketPolicy",
         {
-            "Bucket": {"Ref": Match.string_like_regexp("CONFIGBUCKET*")},
+            "Bucket": {"Ref": Match.string_like_regexp("ConfigBucket*")},
             "PolicyDocument": {
                 "Statement": [
                     {
@@ -145,7 +143,7 @@ def test_s3_config_bucket_policy_resource_properties(template):
                         "Resource": [
                             {
                                 "Fn::GetAtt": [
-                                    Match.string_like_regexp("CONFIGBUCKET*"),
+                                    Match.string_like_regexp("ConfigBucket*"),
                                     "Arn",
                                 ]
                             },
@@ -156,7 +154,7 @@ def test_s3_config_bucket_policy_resource_properties(template):
                                         {
                                             "Fn::GetAtt": [
                                                 Match.string_like_regexp(
-                                                    "CONFIGBUCKET*"
+                                                    "ConfigBucket*"
                                                 ),
                                                 "Arn",
                                             ]
@@ -190,7 +188,7 @@ def test_data_bucket_custom_s3_auto_delete_resource_properties(template):
                     "Arn",
                 ]
             },
-            "BucketName": {"Ref": Match.string_like_regexp("DATABUCKET*")},
+            "BucketName": {"Ref": Match.string_like_regexp("DataBucket*")},
         },
     )
 
@@ -207,7 +205,7 @@ def test_config_bucket_custom_s3_auto_delete_resoource_count(template):
                     "Arn",
                 ]
             },
-            "BucketName": {"Ref": Match.string_like_regexp("CONFIGBUCKET*")},
+            "BucketName": {"Ref": Match.string_like_regexp("ConfigBucket*")},
         },
     )
 
@@ -224,7 +222,7 @@ def test_custom_s3_bucket_notifications_resource_properties(template):
                     "Arn",
                 ]
             },
-            "BucketName": {"Ref": Match.string_like_regexp("DATABUCKET*")},
+            "BucketName": {"Ref": Match.string_like_regexp("DataBucket*")},
             "NotificationConfiguration": {
                 "LambdaFunctionConfigurations": [
                     {
@@ -243,141 +241,8 @@ def test_custom_s3_bucket_notifications_resource_properties(template):
     )
 
 
-def test_secrets_manager_resource_count(template):
-    template.resource_count_is("AWS::SecretsManager::Secret", 1)
-
-
-def test_secrets_manager_resource_properties(template):
-    template.has_resource(
-        "AWS::SecretsManager::Secret",
-        {
-            "DeletionPolicy": "Delete",
-            "UpdateReplacePolicy": "Delete",
-        },
-    )
-
-
-def test_opensearch_domain_resource_count(template):
-    template.resource_count_is("AWS::OpenSearchService::Domain", 1)
-
-
-def test_opensearch_domain_resource_properties(template, sds_id):
-    template.has_resource_properties(
-        "AWS::OpenSearchService::Domain",
-        {
-            "DomainName": f"sdsmetadatadomain-{sds_id}",
-            "EngineVersion": "OpenSearch_1.3",
-            "ClusterConfig": {"InstanceType": "t3.small.search", "InstanceCount": 1},
-            "EBSOptions": {"EBSEnabled": True, "VolumeSize": 10, "VolumeType": "gp2"},
-            "NodeToNodeEncryptionOptions": {"Enabled": True},
-            "EncryptionAtRestOptions": {"Enabled": True},
-        },
-    )
-
-
-def test_custom_cloudwatch_log_resource_policy_count(template):
-    template.resource_count_is("Custom::CloudwatchLogResourcePolicy", 1)
-
-
-def test_custom_opensearch_access_policy_resource_count(template):
-    template.resource_count_is("Custom::OpenSearchAccessPolicy", 1)
-
-
-def test_custom_opensearch_access_policy_resource_properties(template):
-    template.has_resource(
-        "Custom::OpenSearchAccessPolicy",
-        {
-            "DeletionPolicy": "Delete",
-            "UpdateReplacePolicy": "Delete",
-        },
-    )
-
-    template.has_resource_properties(
-        "Custom::OpenSearchAccessPolicy",
-        {
-            "ServiceToken": {"Fn::GetAtt": [Match.string_like_regexp("AWS*"), "Arn"]},
-            "Create": {
-                "Fn::Join": [
-                    "",
-                    [
-                        '{"action":"updateDomainConfig","service":"OpenSearch","parameters":{"DomainName":"',
-                        {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
-                        '","AccessPolicies":"{\\"Statement\\":[{\\"Action\\":\\"es:*\\",\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"',
-                        {
-                            "Fn::GetAtt": [
-                                Match.string_like_regexp("SDSMetadataDomain*"),
-                                "Arn",
-                            ]
-                        },
-                        '/*\\"}],\\"Version\\":\\"2012-10-17\\"}"},"outputPaths":["DomainConfig.AccessPolicies"],"physicalResourceId":{"id":"',
-                        {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
-                        'AccessPolicy"}}',
-                    ],
-                ]
-            },
-            "Update": {
-                "Fn::Join": [
-                    "",
-                    [
-                        '{"action":"updateDomainConfig","service":"OpenSearch","parameters":{"DomainName":"',
-                        {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
-                        '","AccessPolicies":"{\\"Statement\\":[{\\"Action\\":\\"es:*\\",\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"',
-                        {
-                            "Fn::GetAtt": [
-                                Match.string_like_regexp("SDSMetadataDomain*"),
-                                "Arn",
-                            ]
-                        },
-                        '/*\\"}],\\"Version\\":\\"2012-10-17\\"}"},"outputPaths":["DomainConfig.AccessPolicies"],"physicalResourceId":{"id":"',
-                        {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
-                        'AccessPolicy"}}',
-                    ],
-                ]
-            },
-            "InstallLatestAwsSdk": True,
-        },
-    )
-
-
-def test_log_groups_resource_count(template):
-    template.resource_count_is("AWS::Logs::LogGroup", 3)
-
-
-def test_sdsmetadatadomain_slow_search_logs_resource_properties(template):
-    template.has_resource(
-        "AWS::Logs::LogGroup",
-        {
-            "DeletionPolicy": "Retain",
-            "UpdateReplacePolicy": "Retain",
-        },
-    )
-    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
-
-
-def test_sdsmetadatadomain_slow_index_logs_resource_properties(template):
-    template.has_resource(
-        "AWS::Logs::LogGroup",
-        {
-            "DeletionPolicy": "Retain",
-            "UpdateReplacePolicy": "Retain",
-        },
-    )
-    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
-
-
-def test_sdsmetadatadomain_app_logs_resource_properties(template):
-    template.has_resource(
-        "AWS::Logs::LogGroup",
-        {
-            "DeletionPolicy": "Retain",
-            "UpdateReplacePolicy": "Retain",
-        },
-    )
-    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
-
-
 def test_iam_roles_resource_count(template):
-    template.resource_count_is("AWS::IAM::Role", 8)
+    template.resource_count_is("AWS::IAM::Role", 7)
 
 
 def test_expected_properties_for_iam_roles(template):
@@ -399,16 +264,16 @@ def test_expected_properties_for_iam_roles(template):
         },
     )
 
-    # There are 8 IAM Role expected resources with the same properties
+    # There are 7 IAM Role expected resources with the same properties
     # confirm that all are found in the stack
-    assert len(found_resources) == 8
+    assert len(found_resources) == 7
 
 
 def test_iam_policy_resource_count(template):
-    template.resource_count_is("AWS::IAM::Policy", 8)
+    template.resource_count_is("AWS::IAM::Policy", 6)
 
 
-def test_upload_lambda_api_aim_policy_resource_properties(template):
+def test_uploadapilambda_iam_policy_resource_properties(template):
     template.has_resource_properties(
         "AWS::IAM::Policy",
         {
@@ -424,7 +289,7 @@ def test_upload_lambda_api_aim_policy_resource_properties(template):
                                 [
                                     {
                                         "Fn::GetAtt": [
-                                            Match.string_like_regexp("DATABUCKET*"),
+                                            Match.string_like_regexp(".*"),
                                             "Arn",
                                         ]
                                     },
@@ -434,8 +299,8 @@ def test_upload_lambda_api_aim_policy_resource_properties(template):
                         },
                     },
                     {
-                        "Action": "s3:GetObject",
                         "Effect": "Allow",
+                        "Action": "s3:GetObject",
                         "Resource": [
                             {
                                 "Fn::Join": [
@@ -443,7 +308,7 @@ def test_upload_lambda_api_aim_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("DATABUCKET*"),
+                                                Match.string_like_regexp("DataBucket.*"),
                                                 "Arn",
                                             ]
                                         },
@@ -457,9 +322,7 @@ def test_upload_lambda_api_aim_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp(
-                                                    "CONFIGBUCKET*"
-                                                ),
+                                                Match.string_like_regexp("ConfigBucket.*"),
                                                 "Arn",
                                             ]
                                         },
@@ -472,59 +335,7 @@ def test_upload_lambda_api_aim_policy_resource_properties(template):
                 ],
             },
             "PolicyName": Match.string_like_regexp(
-                "UploadAPILambdaServiceRoleDefaultPolicy*"
-            ),
-        },
-    )
-
-
-def test_sdsmetadatadomain_esloggroup_iam_policy_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::IAM::Policy",
-        {
-            "PolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": "logs:PutResourcePolicy",
-                        "Resource": "*",
-                    },
-                    {
-                        "Effect": "Allow",
-                        "Action": "logs:DeleteResourcePolicy",
-                        "Resource": "*",
-                    },
-                ],
-            },
-            "PolicyName": Match.string_like_regexp(
-                "SDSMetadataDomainESLogGroupPolicyc*"
-            ),
-        },
-    )
-
-
-def test_sdsmetadatadomain_accesspolicy_iam_policy_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::IAM::Policy",
-        {
-            "PolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": "es:UpdateDomainConfig",
-                        "Resource": {
-                            "Fn::GetAtt": [
-                                Match.string_like_regexp("SDSMetadataDomain*"),
-                                "Arn",
-                            ]
-                        },
-                    }
-                ],
-            },
-            "PolicyName": Match.string_like_regexp(
-                "SDSMetadataDomainAccessPolicyCustomResourcePolicy*"
+                "UploadAPILambdaServiceRoleDefaultPolicy.*"
             ),
         },
     )
@@ -545,12 +356,9 @@ def test_indexer_lambda_iam_policy_resource_properties(template):
                                 "",
                                 [
                                     {
-                                        "Fn::GetAtt": [
-                                            Match.string_like_regexp(
-                                                "SDSMetadataDomain*"
-                                            ),
-                                            "Arn",
-                                        ]
+                                        "Fn::ImportValue": Match.string_like_regexp(
+                                            "opensearch-.*:ExportsOutputFnGetAttSDSMetadataDomain.*"
+                                        ),
                                     },
                                     "/*",
                                 ],
@@ -567,7 +375,7 @@ def test_indexer_lambda_iam_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("DATABUCKET*"),
+                                                Match.string_like_regexp("DataBucket.*"),
                                                 "Arn",
                                             ]
                                         },
@@ -581,9 +389,7 @@ def test_indexer_lambda_iam_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp(
-                                                    "CONFIGBUCKET*"
-                                                ),
+                                                Match.string_like_regexp("ConfigBucket.*"),
                                                 "Arn",
                                             ]
                                         },
@@ -593,10 +399,13 @@ def test_indexer_lambda_iam_policy_resource_properties(template):
                             },
                         ],
                     },
+                    {
+                        "Effect": "Allow",
+                    },
                 ],
             },
             "PolicyName": Match.string_like_regexp(
-                "IndexerLambdaServiceRoleDefaultPolicy*"
+                "IndexerLambdaServiceRoleDefaultPolicy.*"
             ),
         },
     )
@@ -636,22 +445,22 @@ def test_queryapilambda_iam_policy_resource_properties(template):
                                 "",
                                 [
                                     {
-                                        "Fn::GetAtt": [
-                                            Match.string_like_regexp(
-                                                "SDSMetadataDomain*"
-                                            ),
-                                            "Arn",
-                                        ]
+                                        "Fn::ImportValue": Match.string_like_regexp(
+                                            "opensearch-.*:ExportsOutputFnGetAttSDSMetadataDomain.*"
+                                        ),
                                     },
                                     "/*",
                                 ],
                             ]
                         },
+                    },
+                    {
+                        "Effect": "Allow",
                     }
                 ],
             },
             "PolicyName": Match.string_like_regexp(
-                "QueryAPILambdaServiceRoleDefaultPolicy*"
+                "QueryAPILambdaServiceRoleDefaultPolicy.*"
             ),
         },
     )
@@ -672,12 +481,9 @@ def test_downloadquerylambda_iam_policy_resource_properties(template):
                                 "",
                                 [
                                     {
-                                        "Fn::GetAtt": [
-                                            Match.string_like_regexp(
-                                                "SDSMetadataDomain*"
-                                            ),
-                                            "Arn",
-                                        ]
+                                        "Fn::ImportValue": Match.string_like_regexp(
+                                            "opensearch-.*:ExportsOutputFnGetAttSDSMetadataDomain.*"
+                                        ),
                                     },
                                     "/*",
                                 ],
@@ -694,7 +500,7 @@ def test_downloadquerylambda_iam_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("DATABUCKET*"),
+                                                Match.string_like_regexp("DataBucket.*"),
                                                 "Arn",
                                             ]
                                         },
@@ -709,7 +515,7 @@ def test_downloadquerylambda_iam_policy_resource_properties(template):
                                         {
                                             "Fn::GetAtt": [
                                                 Match.string_like_regexp(
-                                                    "CONFIGBUCKET*"
+                                                    "ConfigBucket.*"
                                                 ),
                                                 "Arn",
                                             ]
@@ -723,7 +529,7 @@ def test_downloadquerylambda_iam_policy_resource_properties(template):
                 ],
             },
             "PolicyName": Match.string_like_regexp(
-                "DownloadQueryAPILambdaServiceRoleDefaultPolicy*"
+                "DownloadQueryAPILambdaServiceRoleDefaultPolicy.*"
             ),
         },
     )
@@ -741,31 +547,7 @@ def test_custom_buck_deployment_iam_service_role_resource_properties(template):
                     {
                         "Action": ["s3:GetObject*", "s3:GetBucket*", "s3:List*"],
                         "Effect": "Allow",
-                        "Resource": [
-                            {
-                                "Fn::Join": [
-                                    "",
-                                    [
-                                        "arn:",
-                                        {"Ref": "AWS::Partition"},
-                                        ":s3:::",
-                                        {"Fn::Sub": Match.any_value()},
-                                    ],
-                                ]
-                            },
-                            {
-                                "Fn::Join": [
-                                    "",
-                                    [
-                                        "arn:",
-                                        {"Ref": "AWS::Partition"},
-                                        ":s3:::",
-                                        {"Fn::Sub": Match.any_value()},
-                                        "/*",
-                                    ],
-                                ]
-                            },
-                        ],
+                        "Resource": Match.any_value()
                     },
                     {
                         "Action": [
@@ -784,7 +566,7 @@ def test_custom_buck_deployment_iam_service_role_resource_properties(template):
                         "Resource": [
                             {
                                 "Fn::GetAtt": [
-                                    Match.string_like_regexp("CONFIGBUCKET*"),
+                                    Match.string_like_regexp("ConfigBucket*"),
                                     "Arn",
                                 ]
                             },
@@ -795,7 +577,7 @@ def test_custom_buck_deployment_iam_service_role_resource_properties(template):
                                         {
                                             "Fn::GetAtt": [
                                                 Match.string_like_regexp(
-                                                    "CONFIGBUCKET*"
+                                                    "ConfigBucket*"
                                                 ),
                                                 "Arn",
                                             ]
@@ -813,54 +595,55 @@ def test_custom_buck_deployment_iam_service_role_resource_properties(template):
     )
 
 
-def test_lambda_urls_resource_count(template):
-    template.resource_count_is("AWS::Lambda::Url", 3)
-
-
-def test_upload_api_lambda_url_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::Lambda::Url",
-        {
-            "AuthType": "NONE",
-            "TargetFunctionArn": {
-                "Fn::GetAtt": [Match.string_like_regexp("UploadAPILambda*"), "Arn"]
-            },
-            "Cors": {"AllowMethods": ["*"], "AllowOrigins": ["*"]},
-        },
-    )
-
-
-def test_query_api_lambda_url_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::Lambda::Url",
-        {
-            "AuthType": "NONE",
-            "TargetFunctionArn": {
-                "Fn::GetAtt": [Match.string_like_regexp("QueryAPILambda*"), "Arn"]
-            },
-            "Cors": {"AllowMethods": ["GET"], "AllowOrigins": ["*"]},
-        },
-    )
-
-
-def test_download_api_lambda_url_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::Lambda::Url",
-        {
-            "AuthType": "NONE",
-            "TargetFunctionArn": {
-                "Fn::GetAtt": [
-                    Match.string_like_regexp("DownloadQueryAPILambda*"),
-                    "Arn",
-                ]
-            },
-            "Cors": {"AllowMethods": ["GET"], "AllowOrigins": ["*"]},
-        },
-    )
+# We are no longer using lambda urls.
+# def test_lambda_urls_resource_count(template):
+#     template.resource_count_is("AWS::Lambda::Url", 3)
+#
+#
+# def test_upload_api_lambda_url_resource_properties(template):
+#     template.has_resource_properties(
+#         "AWS::Lambda::Url",
+#         {
+#             "AuthType": "NONE",
+#             "TargetFunctionArn": {
+#                 "Fn::GetAtt": [Match.string_like_regexp("UploadAPILambda*"), "Arn"]
+#             },
+#             "Cors": {"AllowMethods": ["*"], "AllowOrigins": ["*"]},
+#         },
+#     )
+#
+#
+# def test_query_api_lambda_url_resource_properties(template):
+#     template.has_resource_properties(
+#         "AWS::Lambda::Url",
+#         {
+#             "AuthType": "NONE",
+#             "TargetFunctionArn": {
+#                 "Fn::GetAtt": [Match.string_like_regexp("QueryAPILambda*"), "Arn"]
+#             },
+#             "Cors": {"AllowMethods": ["GET"], "AllowOrigins": ["*"]},
+#         },
+#     )
+#
+#
+# def test_download_api_lambda_url_resource_properties(template):
+#     template.has_resource_properties(
+#         "AWS::Lambda::Url",
+#         {
+#             "AuthType": "NONE",
+#             "TargetFunctionArn": {
+#                 "Fn::GetAtt": [
+#                     Match.string_like_regexp("DownloadQueryAPILambda*"),
+#                     "Arn",
+#                 ]
+#             },
+#             "Cors": {"AllowMethods": ["GET"], "AllowOrigins": ["*"]},
+#         },
+#     )
 
 
 def test_lambda_function_resource_count(template):
-    template.resource_count_is("AWS::Lambda::Function", 8)
+    template.resource_count_is("AWS::Lambda::Function", 7)
 
 
 def test_indexer_lambda_function_resource_properties(template, sds_id):
@@ -938,21 +721,22 @@ def test_download_api_lambda_function_resource_properties(template, sds_id):
     )
 
 
-def test_aws_lambda_function_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::Lambda::Function",
-        props={
-            "Handler": "index.handler",
-            "Runtime": "nodejs14.x",
-            "Timeout": 120,
-            "Role": {
-                "Fn::GetAtt": [
-                    Match.string_like_regexp("AWS.*ServiceRole.*"),
-                    "Arn",
-                ]
-            },
-        },
-    )
+# This is something that AWS creates. Uncertain what it is for.
+# def test_aws_lambda_function_resource_properties(template):
+#     template.has_resource_properties(
+#         "AWS::Lambda::Function",
+#         props={
+#             "Handler": "index.handler",
+#             "Runtime": "nodejs14.x",
+#             "Timeout": 120,
+#             "Role": {
+#                 "Fn::GetAtt": [
+#                     Match.string_like_regexp("AWS.*ServiceRole.*"),
+#                     "Arn",
+#                 ]
+#             },
+#         },
+#     )
 
 
 def test_aws_bucket_notification_lambda_function_resource_properties(template):
@@ -976,8 +760,8 @@ def test_custom_s3_auto_delete_lambda_function_resource_properties(template):
     template.has_resource_properties(
         "AWS::Lambda::Function",
         props={
-            "Handler": "__entrypoint__.handler",
-            "Runtime": "nodejs14.x",
+            "Handler": "index.handler",
+            "Runtime": "nodejs18.x",
             "Timeout": 900,
             "MemorySize": 128,
             "Role": {
@@ -1008,9 +792,10 @@ def test_custom_cdk_bucket_deployment_lambda_resource_properties(template):
         },
     )
 
-
+# This is now only to add an eventsource to the indexer lambda. The 3 others were being used by the
+# lambda urls (download, query, upload) and so no longer exist.
 def test_lambda_permission_resource_count(template):
-    template.resource_count_is("AWS::Lambda::Permission", 4)
+    template.resource_count_is("AWS::Lambda::Permission", 1)
 
 
 def test_indexer_lambda_permission_resource_properties(template):
@@ -1022,57 +807,59 @@ def test_indexer_lambda_permission_resource_properties(template):
                 "Fn::GetAtt": [Match.string_like_regexp("IndexerLambda*"), "Arn"]
             },
             "Principal": "s3.amazonaws.com",
-            "SourceAccount": {"Ref": "AWS::AccountId"},
+            "SourceAccount": Match.string_like_regexp("\d{12}"),
             "SourceArn": {
-                "Fn::GetAtt": [Match.string_like_regexp("DATABUCKET*"), "Arn"]
+                "Fn::GetAtt": [Match.string_like_regexp("DataBucket*"), "Arn"]
             },
         },
     )
 
 
-def test_upload_api_lambda_permission_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::Lambda::Permission",
-        {
-            "Action": "lambda:InvokeFunctionUrl",
-            "FunctionName": {
-                "Fn::GetAtt": [Match.string_like_regexp("UploadAPILambda*"), "Arn"]
-            },
-            "Principal": "*",
-            "FunctionUrlAuthType": "NONE",
-        },
-    )
-
-
-def test_query_api_lambda_permission_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::Lambda::Permission",
-        {
-            "Action": "lambda:InvokeFunctionUrl",
-            "FunctionName": {
-                "Fn::GetAtt": [Match.string_like_regexp("QueryAPILambda*"), "Arn"]
-            },
-            "Principal": "*",
-            "FunctionUrlAuthType": "NONE",
-        },
-    )
-
-
-def test_download_api_lambda_permission_resource_properties(template):
-    template.has_resource_properties(
-        "AWS::Lambda::Permission",
-        {
-            "Action": "lambda:InvokeFunctionUrl",
-            "FunctionName": {
-                "Fn::GetAtt": [
-                    Match.string_like_regexp("DownloadQueryAPILambda*"),
-                    "Arn",
-                ]
-            },
-            "Principal": "*",
-            "FunctionUrlAuthType": "NONE",
-        },
-    )
+# Note: these tests don't work because in the previous version of the code, we created lambda_.FunctionUrl objects
+# which granted permissions for lambda function URLs to be invoked.
+# def test_upload_api_lambda_permission_resource_properties(template):
+#     template.has_resource_properties(
+#         "AWS::Lambda::Permission",
+#         {
+#             "Action": "lambda:InvokeFunctionUrl",
+#             "FunctionName": {
+#                 "Fn::GetAtt": [Match.string_like_regexp("UploadAPILambda*"), "Arn"]
+#             },
+#             "Principal": "*",
+#             "FunctionUrlAuthType": "NONE",
+#         },
+#     )
+#
+#
+# def test_query_api_lambda_permission_resource_properties(template):
+#     template.has_resource_properties(
+#         "AWS::Lambda::Permission",
+#         {
+#             "Action": "lambda:InvokeFunctionUrl",
+#             "FunctionName": {
+#                 "Fn::GetAtt": [Match.string_like_regexp("QueryAPILambda*"), "Arn"]
+#             },
+#             "Principal": "*",
+#             "FunctionUrlAuthType": "NONE",
+#         },
+#     )
+#
+#
+# def test_download_api_lambda_permission_resource_properties(template):
+#     template.has_resource_properties(
+#         "AWS::Lambda::Permission",
+#         {
+#             "Action": "lambda:InvokeFunctionUrl",
+#             "FunctionName": {
+#                 "Fn::GetAtt": [
+#                     Match.string_like_regexp("DownloadQueryAPILambda*"),
+#                     "Arn",
+#                 ]
+#             },
+#             "Principal": "*",
+#             "FunctionUrlAuthType": "NONE",
+#         },
+#     )
 
 
 def test_lambda_layer_resource_count(template):
@@ -1084,7 +871,7 @@ def test_custom_deploy_config_lambda_layer(template):
         "AWS::Lambda::LayerVersion",
         {
             "Content": {
-                "S3Bucket": {"Fn::Sub": Match.any_value()},
+                "S3Bucket": Match.any_value(),
                 "S3Key": Match.string_like_regexp(".*.zip"),
             },
             "Description": "/opt/awscli/aws",

--- a/tests/infrastructure/test_data_manager_stack.py
+++ b/tests/infrastructure/test_data_manager_stack.py
@@ -778,6 +778,7 @@ def test_custom_cdk_bucket_deployment_lambda_resource_properties(template):
         },
     )
 
+
 # This is now only to add an eventsource to the indexer lambda.
 # The 3 others were being used by the
 # lambda urls (download, query, upload) and so no longer exist.
@@ -785,7 +786,7 @@ def test_lambda_permission_resource_count(template):
     template.resource_count_is("AWS::Lambda::Permission", 1)
 
 
-def test_indexer_lambda_permission_resource_properties(template):
+def test_indexer_lambda_permission_resource_properties(template, account):
     template.has_resource_properties(
         "AWS::Lambda::Permission",
         {
@@ -794,7 +795,7 @@ def test_indexer_lambda_permission_resource_properties(template):
                 "Fn::GetAtt": [Match.string_like_regexp("IndexerLambda*"), "Arn"]
             },
             "Principal": "s3.amazonaws.com",
-            "SourceAccount": Match.string_like_regexp("\d{10}"),
+            "SourceAccount": account,
             "SourceArn": {
                 "Fn::GetAtt": [Match.string_like_regexp("DataBucket*"), "Arn"]
             },

--- a/tests/infrastructure/test_data_manager_stack.py
+++ b/tests/infrastructure/test_data_manager_stack.py
@@ -1,6 +1,10 @@
+# Standard
 import pytest
+
+# Installed
 from aws_cdk.assertions import Match, Template
 
+# Local
 from sds_data_manager.stacks.opensearch_stack import OpenSearch
 from sds_data_manager.stacks.sds_data_manager_stack import SdsDataManager
 
@@ -721,24 +725,6 @@ def test_download_api_lambda_function_resource_properties(template, sds_id):
     )
 
 
-# This is something that AWS creates. Uncertain what it is for.
-# def test_aws_lambda_function_resource_properties(template):
-#     template.has_resource_properties(
-#         "AWS::Lambda::Function",
-#         props={
-#             "Handler": "index.handler",
-#             "Runtime": "nodejs14.x",
-#             "Timeout": 120,
-#             "Role": {
-#                 "Fn::GetAtt": [
-#                     Match.string_like_regexp("AWS.*ServiceRole.*"),
-#                     "Arn",
-#                 ]
-#             },
-#         },
-#     )
-
-
 def test_aws_bucket_notification_lambda_function_resource_properties(template):
     template.has_resource_properties(
         "AWS::Lambda::Function",
@@ -792,7 +778,8 @@ def test_custom_cdk_bucket_deployment_lambda_resource_properties(template):
         },
     )
 
-# This is now only to add an eventsource to the indexer lambda. The 3 others were being used by the
+# This is now only to add an eventsource to the indexer lambda.
+# The 3 others were being used by the
 # lambda urls (download, query, upload) and so no longer exist.
 def test_lambda_permission_resource_count(template):
     template.resource_count_is("AWS::Lambda::Permission", 1)
@@ -807,7 +794,7 @@ def test_indexer_lambda_permission_resource_properties(template):
                 "Fn::GetAtt": [Match.string_like_regexp("IndexerLambda*"), "Arn"]
             },
             "Principal": "s3.amazonaws.com",
-            "SourceAccount": Match.string_like_regexp("\d{12}"),
+            "SourceAccount": Match.string_like_regexp("\d{10}"),
             "SourceArn": {
                 "Fn::GetAtt": [Match.string_like_regexp("DataBucket*"), "Arn"]
             },
@@ -815,7 +802,8 @@ def test_indexer_lambda_permission_resource_properties(template):
     )
 
 
-# Note: these tests don't work because in the previous version of the code, we created lambda_.FunctionUrl objects
+# Note: these tests don't work because in the previous version of the code,
+# we created lambda_.FunctionUrl objects
 # which granted permissions for lambda function URLs to be invoked.
 # def test_upload_api_lambda_permission_resource_properties(template):
 #     template.has_resource_properties(

--- a/tests/infrastructure/test_data_manager_stack.py
+++ b/tests/infrastructure/test_data_manager_stack.py
@@ -312,7 +312,9 @@ def test_uploadapilambda_iam_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("DataBucket.*"),
+                                                Match.string_like_regexp(
+                                                    "DataBucket.*"
+                                                ),
                                                 "Arn",
                                             ]
                                         },
@@ -326,7 +328,9 @@ def test_uploadapilambda_iam_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("ConfigBucket.*"),
+                                                Match.string_like_regexp(
+                                                    "ConfigBucket.*"
+                                                ),
                                                 "Arn",
                                             ]
                                         },
@@ -379,7 +383,9 @@ def test_indexer_lambda_iam_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("DataBucket.*"),
+                                                Match.string_like_regexp(
+                                                    "DataBucket.*"
+                                                ),
                                                 "Arn",
                                             ]
                                         },
@@ -393,7 +399,9 @@ def test_indexer_lambda_iam_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("ConfigBucket.*"),
+                                                Match.string_like_regexp(
+                                                    "ConfigBucket.*"
+                                                ),
                                                 "Arn",
                                             ]
                                         },
@@ -460,7 +468,7 @@ def test_queryapilambda_iam_policy_resource_properties(template):
                     },
                     {
                         "Effect": "Allow",
-                    }
+                    },
                 ],
             },
             "PolicyName": Match.string_like_regexp(
@@ -504,7 +512,9 @@ def test_downloadquerylambda_iam_policy_resource_properties(template):
                                     [
                                         {
                                             "Fn::GetAtt": [
-                                                Match.string_like_regexp("DataBucket.*"),
+                                                Match.string_like_regexp(
+                                                    "DataBucket.*"
+                                                ),
                                                 "Arn",
                                             ]
                                         },
@@ -551,7 +561,7 @@ def test_custom_buck_deployment_iam_service_role_resource_properties(template):
                     {
                         "Action": ["s3:GetObject*", "s3:GetBucket*", "s3:List*"],
                         "Effect": "Allow",
-                        "Resource": Match.any_value()
+                        "Resource": Match.any_value(),
                     },
                     {
                         "Action": [
@@ -778,6 +788,7 @@ def test_custom_cdk_bucket_deployment_lambda_resource_properties(template):
         },
     )
 
+
 # This is now only to add an eventsource to the indexer lambda.
 # The 3 others were being used by the
 # lambda urls (download, query, upload) and so no longer exist.
@@ -794,7 +805,7 @@ def test_indexer_lambda_permission_resource_properties(template):
                 "Fn::GetAtt": [Match.string_like_regexp("IndexerLambda*"), "Arn"]
             },
             "Principal": "s3.amazonaws.com",
-            "SourceAccount": Match.string_like_regexp("\d{10}"),
+            "SourceAccount": Match.string_like_regexp("\\d{10}"),
             "SourceArn": {
                 "Fn::GetAtt": [Match.string_like_regexp("DataBucket*"), "Arn"]
             },

--- a/tests/infrastructure/test_open_search_stack.py
+++ b/tests/infrastructure/test_open_search_stack.py
@@ -1,0 +1,282 @@
+# Standard
+import pytest
+
+# Installed
+from aws_cdk.assertions import Match, Template
+
+# Local
+from sds_data_manager.stacks.opensearch_stack import OpenSearch
+
+
+@pytest.fixture(scope="module")
+def template(app, sds_id, env):
+    stack_name = f"opensearch-{sds_id}"
+    stack = OpenSearch(app, stack_name, sds_id, env=env)
+    template = Template.from_stack(stack)
+    return template
+
+
+def test_secrets_manager_resource_count(template):
+    template.resource_count_is("AWS::SecretsManager::Secret", 1)
+
+
+def test_secrets_manager_resource_properties(template):
+    template.has_resource(
+        "AWS::SecretsManager::Secret",
+        {
+            "DeletionPolicy": "Delete",
+            "UpdateReplacePolicy": "Delete",
+        },
+    )
+
+
+def test_iam_roles_resource_count(template):
+    template.resource_count_is("AWS::IAM::Role", 1)
+
+
+def test_expected_properties_for_iam_roles(template):
+    found_resources = template.find_resources(
+        "AWS::IAM::Role",
+        {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": "sts:AssumeRole",
+                            "Effect": "Allow",
+                            "Principal": {"Service": "lambda.amazonaws.com"},
+                        }
+                    ],
+                    "Version": "2012-10-17",
+                }
+            }
+        },
+    )
+
+    # There is 1 IAM Role expected resources with the same properties
+    # confirm that all are found in the stack
+    assert len(found_resources) == 1
+
+
+def test_opensearch_domain_resource_count(template):
+    template.resource_count_is("AWS::OpenSearchService::Domain", 1)
+
+
+def test_opensearch_domain_resource_properties(template, sds_id):
+    template.has_resource_properties(
+        "AWS::OpenSearchService::Domain",
+        {
+            "DomainName": f"sdsmetadatadomain-{sds_id}",
+            "EngineVersion": "OpenSearch_1.3",
+            "ClusterConfig": {"InstanceType": "t3.small.search", "InstanceCount": 1},
+            "EBSOptions": {"EBSEnabled": True, "VolumeSize": 10, "VolumeType": "gp2"},
+            "NodeToNodeEncryptionOptions": {"Enabled": True},
+            "EncryptionAtRestOptions": {"Enabled": True},
+        },
+    )
+
+
+def test_custom_cloudwatch_log_resource_policy_count(template):
+    template.resource_count_is("Custom::CloudwatchLogResourcePolicy", 1)
+
+
+def test_log_groups_resource_count(template):
+    template.resource_count_is("AWS::Logs::LogGroup", 3)
+
+
+def test_sdsmetadatadomain_slow_search_logs_resource_properties(template):
+    template.has_resource(
+        "AWS::Logs::LogGroup",
+        {
+            "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
+        },
+    )
+    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
+
+
+def test_sdsmetadatadomain_app_logs_resource_properties(template):
+    template.has_resource(
+        "AWS::Logs::LogGroup",
+        {
+            "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
+        },
+    )
+    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
+
+
+def test_custom_opensearch_access_policy_resource_count(template):
+    template.resource_count_is("Custom::OpenSearchAccessPolicy", 1)
+
+
+def test_custom_opensearch_access_policy_resource_properties(template):
+    template.has_resource(
+        "Custom::OpenSearchAccessPolicy",
+        {
+            "DeletionPolicy": "Delete",
+            "UpdateReplacePolicy": "Delete",
+        },
+    )
+
+    template.has_resource_properties(
+        "Custom::OpenSearchAccessPolicy",
+        {
+            "ServiceToken": {"Fn::GetAtt": [Match.string_like_regexp("AWS*"), "Arn"]},
+            "Create": {
+                "Fn::Join": [
+                    "",
+                    [
+                        '{"action":"updateDomainConfig","service":"OpenSearch","parameters":{"DomainName":"',
+                        {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
+                        '","AccessPolicies":"{\\"Statement\\":[{\\"Action\\":\\"es:*\\",\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"',
+                        {
+                            "Fn::GetAtt": [
+                                Match.string_like_regexp("SDSMetadataDomain*"),
+                                "Arn",
+                            ]
+                        },
+                        '/*\\"}],\\"Version\\":\\"2012-10-17\\"}"},"outputPaths":["DomainConfig.AccessPolicies"],"physicalResourceId":{"id":"',
+                        {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
+                        'AccessPolicy"}}',
+                    ],
+                ]
+            },
+            "Update": {
+                "Fn::Join": [
+                    "",
+                    [
+                        '{"action":"updateDomainConfig","service":"OpenSearch","parameters":{"DomainName":"',
+                        {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
+                        '","AccessPolicies":"{\\"Statement\\":[{\\"Action\\":\\"es:*\\",\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"',
+                        {
+                            "Fn::GetAtt": [
+                                Match.string_like_regexp("SDSMetadataDomain*"),
+                                "Arn",
+                            ]
+                        },
+                        '/*\\"}],\\"Version\\":\\"2012-10-17\\"}"},"outputPaths":["DomainConfig.AccessPolicies"],"physicalResourceId":{"id":"',
+                        {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
+                        'AccessPolicy"}}',
+                    ],
+                ]
+            },
+            "InstallLatestAwsSdk": True,
+        },
+    )
+
+
+def test_sdsmetadatadomain_slow_index_logs_resource_properties(template):
+    template.has_resource(
+        "AWS::Logs::LogGroup",
+        {
+            "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
+        },
+    )
+    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
+
+
+def test_iam_roles_resource_count(template):
+    template.resource_count_is("AWS::IAM::Role", 1)
+
+
+def test_expected_properties_for_iam_roles(template):
+    found_resources = template.find_resources(
+        "AWS::IAM::Role",
+        {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": "sts:AssumeRole",
+                            "Effect": "Allow",
+                            "Principal": {"Service": "lambda.amazonaws.com"},
+                        }
+                    ],
+                    "Version": "2012-10-17",
+                }
+            }
+        },
+    )
+
+    # There is 1 IAM Role expected resources with the same properties
+    # confirm that all are found in the stack
+    assert len(found_resources) == 1
+
+
+def test_iam_policy_resource_count(template):
+    template.resource_count_is("AWS::IAM::Policy", 2)
+
+
+def test_sdsmetadatadomain_esloggroup_iam_policy_resource_properties(template, sds_id):
+    template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "logs:PutResourcePolicy",
+                        "Resource": "*",
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": "logs:DeleteResourcePolicy",
+                        "Resource": "*",
+                    },
+                ],
+            },
+            "PolicyName": Match.string_like_regexp(
+                f"SDSMetadataDomainsdsidtestESLogGroupPolicyc*"
+            ),
+        },
+    )
+
+
+def test_sdsmetadatadomain_accesspolicy_iam_policy_resource_properties(template):
+    template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "es:UpdateDomainConfig",
+                        "Resource": {
+                            "Fn::GetAtt": [
+                                Match.string_like_regexp("SDSMetadataDomain*"),
+                                "Arn",
+                            ]
+                        },
+                    }
+                ],
+            },
+            "PolicyName": Match.string_like_regexp(
+                "SDSMetadataDomainsdsidtestAccessPolicyCustomResourcePolicy*"
+            ),
+        },
+    )
+
+
+def test_lambda_function_resource_count(template):
+    template.resource_count_is("AWS::Lambda::Function", 1)
+
+
+def test_aws_lambda_function_resource_properties(template):
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        props={
+            "Handler": "index.handler",
+            "Runtime": "nodejs18.x",
+            "Timeout": 120,
+            "Role": {
+                "Fn::GetAtt": [
+                    Match.string_like_regexp("AWS.*ServiceRole.*"),
+                    "Arn",
+                ]
+            },
+        },
+    )

--- a/tests/infrastructure/test_open_search_stack.py
+++ b/tests/infrastructure/test_open_search_stack.py
@@ -35,7 +35,7 @@ def test_iam_roles_resource_count(template):
 
 
 def test_expected_properties_for_iam_roles(template):
-    template.has_resource_properties(
+    found_resources = template.has_resource_properties(
         "AWS::IAM::Role",
         {
             "AssumeRolePolicyDocument": {

--- a/tests/infrastructure/test_open_search_stack.py
+++ b/tests/infrastructure/test_open_search_stack.py
@@ -229,7 +229,7 @@ def test_sdsmetadatadomain_esloggroup_iam_policy_resource_properties(template, s
                 ],
             },
             "PolicyName": Match.string_like_regexp(
-                f"SDSMetadataDomainsdsidtestESLogGroupPolicyc*"
+                "SDSMetadataDomainsdsidtestESLogGroupPolicyc*"
             ),
         },
     )

--- a/tests/infrastructure/test_open_search_stack.py
+++ b/tests/infrastructure/test_open_search_stack.py
@@ -35,27 +35,21 @@ def test_iam_roles_resource_count(template):
 
 
 def test_expected_properties_for_iam_roles(template):
-    found_resources = template.find_resources(
+    template.has_resource_properties(
         "AWS::IAM::Role",
         {
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Statement": [
-                        {
-                            "Action": "sts:AssumeRole",
-                            "Effect": "Allow",
-                            "Principal": {"Service": "lambda.amazonaws.com"},
-                        }
-                    ],
-                    "Version": "2012-10-17",
-                }
+            "AssumeRolePolicyDocument": {
+                "Statement": [
+                    {
+                        "Action": "sts:AssumeRole",
+                        "Effect": "Allow",
+                        "Principal": {"Service": "lambda.amazonaws.com"},
+                    }
+                ],
+                "Version": "2012-10-17",
             }
-        },
+        }
     )
-
-    # There is 1 IAM Role expected resources with the same properties
-    # confirm that all are found in the stack
-    assert len(found_resources) == 1
 
 
 def test_opensearch_domain_resource_count(template):
@@ -84,28 +78,6 @@ def test_log_groups_resource_count(template):
     template.resource_count_is("AWS::Logs::LogGroup", 3)
 
 
-def test_sdsmetadatadomain_slow_search_logs_resource_properties(template):
-    template.has_resource(
-        "AWS::Logs::LogGroup",
-        {
-            "DeletionPolicy": "Retain",
-            "UpdateReplacePolicy": "Retain",
-        },
-    )
-    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
-
-
-def test_sdsmetadatadomain_app_logs_resource_properties(template):
-    template.has_resource(
-        "AWS::Logs::LogGroup",
-        {
-            "DeletionPolicy": "Retain",
-            "UpdateReplacePolicy": "Retain",
-        },
-    )
-    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
-
-
 def test_custom_opensearch_access_policy_resource_count(template):
     template.resource_count_is("Custom::OpenSearchAccessPolicy", 1)
 
@@ -129,14 +101,16 @@ def test_custom_opensearch_access_policy_resource_properties(template):
                     [
                         '{"action":"updateDomainConfig","service":"OpenSearch","parameters":{"DomainName":"',
                         {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
-                        '","AccessPolicies":"{\\"Statement\\":[{\\"Action\\":\\"es:*\\",\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"',
+                        '","AccessPolicies":"{\\"Statement\\":[{\\"Action\\":\\"es:*\\",\\"Effect\\":\\"Allow\\",'
+                        '\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"',
                         {
                             "Fn::GetAtt": [
                                 Match.string_like_regexp("SDSMetadataDomain*"),
                                 "Arn",
                             ]
                         },
-                        '/*\\"}],\\"Version\\":\\"2012-10-17\\"}"},"outputPaths":["DomainConfig.AccessPolicies"],"physicalResourceId":{"id":"',
+                        '/*\\"}],\\"Version\\":\\"2012-10-17\\"}"},"outputPaths":['
+                        '"DomainConfig.AccessPolicies"],"physicalResourceId":{"id":"',
                         {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
                         'AccessPolicy"}}',
                     ],
@@ -148,14 +122,16 @@ def test_custom_opensearch_access_policy_resource_properties(template):
                     [
                         '{"action":"updateDomainConfig","service":"OpenSearch","parameters":{"DomainName":"',
                         {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
-                        '","AccessPolicies":"{\\"Statement\\":[{\\"Action\\":\\"es:*\\",\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"',
+                        '","AccessPolicies":"{\\"Statement\\":[{\\"Action\\":\\"es:*\\",'
+                        '\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"AWS\\":\\"*\\"},\\"Resource\\":\\"',
                         {
                             "Fn::GetAtt": [
                                 Match.string_like_regexp("SDSMetadataDomain*"),
                                 "Arn",
                             ]
                         },
-                        '/*\\"}],\\"Version\\":\\"2012-10-17\\"}"},"outputPaths":["DomainConfig.AccessPolicies"],"physicalResourceId":{"id":"',
+                        '/*\\"}],\\"Version\\":\\"2012-10-17\\"}"},'
+                        '"outputPaths":["DomainConfig.AccessPolicies"],"physicalResourceId":{"id":"',
                         {"Ref": Match.string_like_regexp("SDSMetadataDomain*")},
                         'AccessPolicy"}}',
                     ],
@@ -164,45 +140,6 @@ def test_custom_opensearch_access_policy_resource_properties(template):
             "InstallLatestAwsSdk": True,
         },
     )
-
-
-def test_sdsmetadatadomain_slow_index_logs_resource_properties(template):
-    template.has_resource(
-        "AWS::Logs::LogGroup",
-        {
-            "DeletionPolicy": "Retain",
-            "UpdateReplacePolicy": "Retain",
-        },
-    )
-    template.has_resource_properties("AWS::Logs::LogGroup", {"RetentionInDays": 30})
-
-
-def test_iam_roles_resource_count(template):
-    template.resource_count_is("AWS::IAM::Role", 1)
-
-
-def test_expected_properties_for_iam_roles(template):
-    found_resources = template.find_resources(
-        "AWS::IAM::Role",
-        {
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Statement": [
-                        {
-                            "Action": "sts:AssumeRole",
-                            "Effect": "Allow",
-                            "Principal": {"Service": "lambda.amazonaws.com"},
-                        }
-                    ],
-                    "Version": "2012-10-17",
-                }
-            }
-        },
-    )
-
-    # There is 1 IAM Role expected resources with the same properties
-    # confirm that all are found in the stack
-    assert len(found_resources) == 1
 
 
 def test_iam_policy_resource_count(template):

--- a/tests/infrastructure/test_open_search_stack.py
+++ b/tests/infrastructure/test_open_search_stack.py
@@ -35,7 +35,7 @@ def test_iam_roles_resource_count(template):
 
 
 def test_expected_properties_for_iam_roles(template):
-    found_resources = template.has_resource_properties(
+    template.has_resource_properties(
         "AWS::IAM::Role",
         {
             "AssumeRolePolicyDocument": {
@@ -48,7 +48,7 @@ def test_expected_properties_for_iam_roles(template):
                 ],
                 "Version": "2012-10-17",
             }
-        }
+        },
     )
 
 


### PR DESCRIPTION
# Change Summary

## Overview
Modified test_data_manager_stack.py and moved some tests to test_open_search_stack.py. This was necessary given the separation of stacks in a previous PR.

## New Dependencies
The test_data_manager_stack.py tests sds_data_manager_stack.py. The test_open_search_stack.py tests opensearch_stack.py.

## New Files
- test_open_search_stack.py
   - Created as a result to making the creation of opensearch in its own stack.

## Deleted Files
None

## Updated Files
- test_data_manager_stack.py
   - We are no longer using lambda urls so those tests were removed.
   - s3 bucket names were changed
   - Testing of opensearch was moved to its own test (along with resources)

## Testing
Everything in the PR is a test.

## Note
I left some comments to explain which tests were removed and a description of why they were removed for the purpose of the review. I will delete those comments before merging.
