### PR TITLE
SIT-2 Release [dev]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "sds-data-manager"
-version = "0.1.0"
+version = "2.0.0"
 description = "IMAP Science Operations Center AWS data manager"
 authors = ["IMAP SDS Developers <imap.sdc@lists.lasp.colorado.edu>"]
 readme = "README.md"


### PR DESCRIPTION
This PR marks the release of version `2.0.0`, which corresponds to the completion of SIT-2. This PR is being merged back into `dev` per the nominal [git & GitHub workflow](https://imap-processing.readthedocs.io/en/latest/development/style-guide/git-and-github-workflow.html#git-and-github-workflow) and [release workflow](https://imap-processing.readthedocs.io/en/latest/development/release-workflow.html).

These are the release notes that will go into the GitHub release:

## Features
* Ability to deploy and test software in the SDC Staging environment.
* Software can be successfully promoted from the SDC Staging Environment to the SDC Data Production Environment.
* Delivery of data files to the SPDF for routine archival purposes.
    * Backing up both OpenSearch and the data bucket to the backup account.
* Use of the API data interfaces by both SDC personnel as well as instrument teams. APIs:
    * The `/upoad` endpoint for uploading new data to SDC
    * The `/download` endpoint for downloading data from SDC
    * The `/query` endpoint for querying information about data and data location.
* Demonstrate the SDC's ability to trigger jobs based on data availability and launch necessary processing containers.
    * Implementing a data watcher (Database) that keeps track of processing status.
    * Establishing a processing pipeline that initiates processing tasks.
  