### PR TITLE
S3 Bucket Triggers

### DIFF
--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -1,5 +1,5 @@
 """Module containing constructs for instrumenting Lambda functions."""
-
+import json
 from pathlib import Path
 
 from aws_cdk import Duration
@@ -20,7 +20,7 @@ class InstrumentLambda(Construct):
         data_bucket: s3.Bucket,
         code_path: str or Path,
         instrument_target: str,
-        instrument_sources: str,
+        instrument_sources: list,
     ):
         """
         InstrumentLambda Constructor.
@@ -37,7 +37,7 @@ class InstrumentLambda(Construct):
             Path to the Lambda code directory
         instrument_target : str
             Target data product (i.e. expected product)
-        instrument_sources : str
+        instrument_sources : list
             Data product sources (i.e. dependencies)
         """
 
@@ -47,7 +47,7 @@ class InstrumentLambda(Construct):
         # TODO: if we need more variables change so we can pass as input
         lambda_environment = {
             "S3_BUCKET": f"{data_bucket.bucket_name}",
-            "S3_KEY_PATH": instrument_sources,
+            "S3_KEY_PATH": json.dumps(instrument_sources),
             "INSTRUMENT_TARGET": instrument_target,
             "PROCESSING_NAME": processing_step_name,
             "OUTPUT_PATH": f"s3://{data_bucket.bucket_name}/{instrument_target}",

--- a/sds_data_manager/lambda_code/SDSCode/instruments/l1b_codice.py
+++ b/sds_data_manager/lambda_code/SDSCode/instruments/l1b_codice.py
@@ -2,6 +2,7 @@
 """
 import logging
 import os
+import json
 from datetime import datetime
 
 import boto3
@@ -15,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 def lambda_handler(event: dict, context):
     """Handler function"""
-    """Handler function"""
     logger.info(f"Event: {event}")
     logger.info(f"Context: {context}")
 
@@ -24,15 +24,16 @@ def lambda_handler(event: dict, context):
 
     # Get the environment variables
     bucket = os.environ["S3_BUCKET"]
-    prefix = os.environ["S3_KEY_PATH"]
+    prefixes = json.loads(os.environ["S3_KEY_PATH"])
 
     # Retrieves objects in the S3 bucket under the given prefix
-    try:
-        s3 = boto3.client("s3")
-        object_list = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)["Contents"]
-        logger.info(f"Object list: {object_list}")
-    except KeyError:
-        logger.warning("No files present.")
+    for prefix in prefixes:
+        try:
+            s3 = boto3.client("s3")
+            object_list = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)["Contents"]
+            logger.info(f"Object list: {object_list}")
+        except KeyError:
+            logger.warning("No files present.")
 
     # TODO: this state will change based on availability of data
     # TODO: we need to think about what needs to be passed into the container

--- a/sds_data_manager/lambda_code/SDSCode/instruments/l1b_codice.py
+++ b/sds_data_manager/lambda_code/SDSCode/instruments/l1b_codice.py
@@ -1,8 +1,8 @@
 """Lambda runtime code that triggers off of arrival of data into S3 bucket.
 """
+import json
 import logging
 import os
-import json
 from datetime import datetime
 
 import boto3

--- a/sds_data_manager/lambda_code/SDSCode/instruments/l1c_codice.py
+++ b/sds_data_manager/lambda_code/SDSCode/instruments/l1c_codice.py
@@ -1,8 +1,8 @@
 """Lambda runtime code that triggers off of arrival of data into S3 bucket.
 """
+import json
 import logging
 import os
-import json
 from datetime import datetime
 
 import boto3

--- a/sds_data_manager/lambda_code/SDSCode/instruments/l1c_codice.py
+++ b/sds_data_manager/lambda_code/SDSCode/instruments/l1c_codice.py
@@ -2,6 +2,7 @@
 """
 import logging
 import os
+import json
 from datetime import datetime
 
 import boto3
@@ -23,15 +24,16 @@ def lambda_handler(event: dict, context):
 
     # Get the environment variables
     bucket = os.environ["S3_BUCKET"]
-    prefix = os.environ["S3_KEY_PATH"]
+    prefixes = json.loads(os.environ["S3_KEY_PATH"])
 
     # Retrieves objects in the S3 bucket under the given prefix
-    try:
-        s3 = boto3.client("s3")
-        object_list = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)["Contents"]
-        logger.info(f"Object list: {object_list}")
-    except KeyError:
-        logger.warning("No files present.")
+    for prefix in prefixes:
+        try:
+            s3 = boto3.client("s3")
+            object_list = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)["Contents"]
+            logger.info(f"Object list: {object_list}")
+        except KeyError:
+            logger.warning("No files present.")
 
     # TODO: this state will change based on availability of data
     # TODO: we need to think about what needs to be passed into the container

--- a/sds_data_manager/utils/dependencies.json
+++ b/sds_data_manager/utils/dependencies.json
@@ -1,0 +1,5 @@
+{
+    "l1a_Codice": ["l0_Codice"],
+    "l1b_Codice": ["l1a_Codice", "l1a_Mag"],
+    "l1c_Codice": ["l1b_Codice", "l2_Ultra", "spice"]
+}

--- a/sds_data_manager/utils/get_dependency.py
+++ b/sds_data_manager/utils/get_dependency.py
@@ -1,0 +1,12 @@
+import json
+import sys
+from pathlib import Path
+
+def get_dependency(key):
+
+    dependency_path=Path(sys.modules[__name__.split(
+        '.')[0]].__file__).parent / 'utils' / 'dependencies.json'
+
+    with open(dependency_path, 'r') as f:
+        dependencies = json.load(f)
+        return dependencies.get(key, [])

--- a/sds_data_manager/utils/get_dependency.py
+++ b/sds_data_manager/utils/get_dependency.py
@@ -3,7 +3,19 @@ import sys
 from pathlib import Path
 
 def get_dependency(key):
+    """
+    Retrieves dependencies for each instrument/level.
 
+    Parameters
+    ----------
+    key : str
+        Target name
+
+    Returns
+    -------
+    packets : list
+        List of all the dependencies
+    """
     dependency_path=Path(sys.modules[__name__.split(
         '.')[0]].__file__).parent / 'utils' / 'dependencies.json'
 

--- a/sds_data_manager/utils/get_dependency.py
+++ b/sds_data_manager/utils/get_dependency.py
@@ -2,6 +2,7 @@ import json
 import sys
 from pathlib import Path
 
+
 def get_dependency(key):
     """
     Retrieves dependencies for each instrument/level.
@@ -19,6 +20,6 @@ def get_dependency(key):
     dependency_path=Path(sys.modules[__name__.split(
         '.')[0]].__file__).parent / 'utils' / 'dependencies.json'
 
-    with open(dependency_path, 'r') as f:
+    with open(dependency_path) as f:
         dependencies = json.load(f)
         return dependencies.get(key, [])

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -1,5 +1,4 @@
 """Module with helper functions for creating standard sets of stacks"""
-# Standard
 from pathlib import Path
 
 from aws_cdk import App, Environment
@@ -16,6 +15,8 @@ from sds_data_manager.stacks import (
     sds_data_manager_stack,
     step_function_stack,
 )
+
+from sds_data_manager.utils.get_dependency import get_dependency
 
 
 def build_sds(
@@ -113,7 +114,7 @@ def build_sds(
             lambda_code_directory=lambda_code_directory_str,
             data_bucket=data_manager.data_bucket,
             instrument_target=f"l1b_{instrument}",
-            instrument_sources=f"l1a_{instrument}",
+            instrument_sources=get_dependency(f"l1b_{instrument}"),
             repo=ecr.container_repo,
         )
 
@@ -127,7 +128,7 @@ def build_sds(
             lambda_code_directory=lambda_code_directory_str,
             data_bucket=data_manager.data_bucket,
             instrument_target=f"l1c_{instrument}",
-            instrument_sources=f"l1b_{instrument}",
+            instrument_sources=get_dependency(f"l1c_{instrument}"),
             repo=ecr.container_repo,
         )
         # etc

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -15,7 +15,6 @@ from sds_data_manager.stacks import (
     sds_data_manager_stack,
     step_function_stack,
 )
-
 from sds_data_manager.utils.get_dependency import get_dependency
 
 


### PR DESCRIPTION
# Change Summary

## Overview
Simple way to kick-off the Step Functions based on objects created in s3 buckets. 

## New Files
- dependencies.json
   - Each instrument team will populate this document based on their dependencies from other instruments, their own instrument, or spice kernels. 
- get_dependency.py
   - This just provides a list of the dependencies provided in dependencies.json

## Deleted Files
None

## Updated Files
- stackbuilder.py : made a string into a list so that each instrument could have multiple dependencies
- processing_stack.py : added more rules to EventBridge
- l1b_codice.py and l1c_codice.py: can handle multiple buckets now
- instrument_lambdas.py: can handle multiple buckets now

## Testing
1. Deploy the  L1bCodiceProcessing-<sds_id>-dev and L1cCodiceProcessing-<sds_id>-dev stacks.
2. Create s3 buckets based on dependencies listed in dependencies.json (see my bucket for example: [s3://sds-data-ls9-dev])
3. Make certain step functions begin when objects are dropped in appropriate directories.

Note: The step function will fail because there is not Docker image in the ECR repos (unless you put one there). That doesn't really matter. This PR just shows that we have a way to trigger the Step Function. Also, this is not the last of the trigger code. The manual trigger will be in a near-future PR.
