### PR TITLE
CI: Use poetry run when deploying resources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,12 +37,10 @@ jobs:
 
       - name: Synth
         run: |
-          # Activate the poetry virtualenv where we installed our package
-          poetry shell
-          cdk synth --context account_name=dev
+          # poetry run to get the environment we installed everything into
+          poetry run cdk synth --context account_name=dev
 
       - name: Deploy
         run: |
-          # Activate the poetry virtualenv where we installed our package
-          poetry shell
-          cdk deploy --all --context account_name=dev --require-approval never
+          # poetry run to get the environment we installed everything into
+          poetry run cdk deploy --all --context account_name=dev --require-approval never


### PR DESCRIPTION
We need the poetry environment activated, but can't use `poetry shell` on CI systems, so use poetry run for the single line commands to get the environment activated.

This caused a failure in our previous merge to dev: https://github.com/IMAP-Science-Operations-Center/sds-data-manager/actions/runs/6658297388/job/18094821748