### PR TITLE
CI: Remove version pin on npm cdk version installation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install cdk
         run: |
-          npm install -g aws-cdk@2.100.0
+          npm install -g aws-cdk
 
       # https://github.com/aws-actions/configure-aws-credentials
       - name: Configure AWS credentials


### PR DESCRIPTION
# Change Summary

This was out of sync with the Python cdk code version and couldn't be used together. Unpin for now to hope that the latest updates keep us in sync. We can pin again later if needed.

https://github.com/IMAP-Science-Operations-Center/sds-data-manager/actions/runs/7121173929/job/19389864426#step:8:795