### PR TITLE
Return list of dicts in query API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,4 +102,3 @@ ignore = ["D203", "D212", "PLR0913", "PLR2004"]
 # TODO: Too many statements, this could be refactored to separate
 #       the single stack out into a few smaller pieces
 "sds_data_manager/stacks/sds_data_manager_stack.py" = ["PLR0915"]
-"tests/lambda_endpoints/test_query_api.py" = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,4 @@ ignore = ["D203", "D212", "PLR0913", "PLR2004"]
 # TODO: Too many statements, this could be refactored to separate
 #       the single stack out into a few smaller pieces
 "sds_data_manager/stacks/sds_data_manager_stack.py" = ["PLR0915"]
+"tests/lambda_endpoints/test_query_api.py" = ["E501"]

--- a/sds_data_manager/lambda_code/SDSCode/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/query_api.py
@@ -87,6 +87,14 @@ def lambda_handler(event, context):
     # Convert the search results (list of tuples) to a list of dicts
     search_results = [result._asdict() for result in search_results]
 
+    # Convert datetimes to string values of format 'YYYYMMDD'
+    # Also remove values that are not needed by users
+    for result in search_results:
+        result["start_date"] = result["start_date"].strftime("%Y%m%d")
+        result["end_date"] = result["end_date"].strftime("%Y%m%d")
+        del result["id"]
+        del result["status_tracking_id"]
+
     logger.info(
         "Found [%s] Query Search Results: %s", len(search_results), str(search_results)
     )
@@ -94,7 +102,7 @@ def lambda_handler(event, context):
     # Format the response
     response = {
         "statusCode": 200,
-        "body": json.dumps(str(search_results)),  # returns a list of tuples
+        "body": json.dumps(search_results),  # returns a list of tuples
         "headers": {
             "Content-Type": "application/json",
             "Access-Control-Allow-Origin": "*",  # Allow CORS

--- a/sds_data_manager/lambda_code/SDSCode/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/query_api.py
@@ -1,4 +1,5 @@
-# Standard
+"""Contains the lambda handler for the 'query' data access API"""
+
 import datetime
 import json
 import logging
@@ -81,19 +82,23 @@ def lambda_handler(event, context):
 
     engine = db.get_engine()
     with Session(engine) as session:
-        search_result = session.execute(query).all()
+        search_results = session.execute(query).all()
+
+    # Convert the search results (list of tuples) to a list of dicts
+    search_results = [result._asdict() for result in search_results]
 
     logger.info(
-        "Found [%s] Query Search Results: %s", len(search_result), str(search_result)
+        "Found [%s] Query Search Results: %s", len(search_results), str(search_results)
     )
 
     # Format the response
     response = {
         "statusCode": 200,
-        "body": json.dumps(str(search_result)),  # returns a list of tuples
+        "body": json.dumps(str(search_results)),  # returns a list of tuples
         "headers": {
             "Content-Type": "application/json",
             "Access-Control-Allow-Origin": "*",  # Allow CORS
         },
     }
+
     return response

--- a/sds_data_manager/stacks/sds_api_manager_stack.py
+++ b/sds_data_manager/stacks/sds_api_manager_stack.py
@@ -100,7 +100,7 @@ class SdsApiManager(Stack):
             id="QueryAPILambda",
             function_name="query-api-handler",
             entry=lambda_code_directory_str,
-            index="SDSCode/queries.py",
+            index="SDSCode/query_api.py",
             handler="lambda_handler",
             runtime=lambda_.Runtime.PYTHON_3_9,
             timeout=cdk.Duration.minutes(1),

--- a/tests/lambda_endpoints/test_query_api.py
+++ b/tests/lambda_endpoints/test_query_api.py
@@ -57,24 +57,29 @@ def setup_test_data(test_engine):
 @pytest.fixture()
 def expected_response():
     expected_response = json.dumps(
-        str(
-            [
-                {
-                    "id": 1,
-                    "file_path": "test/file/path/imap_hit_l0_raw_20251107_20251108_v02-01.pkts",
-                    "instrument": "hit",
-                    "data_level": "l0",
-                    "descriptor": "raw",
-                    "start_date": datetime.datetime(2025, 11, 7, 0, 0),
-                    "end_date": datetime.datetime(2025, 11, 8, 0, 0),
-                    "version": "v02-01",
-                    "extension": "pkts",
-                    "status_tracking_id": 1,
-                }
-            ]
-        )
+        [
+            {
+                "file_path": "test/file/path/imap_hit_l0_raw_20251107_20251108_v02-01.pkts",  # noqa: E501
+                "instrument": "hit",
+                "data_level": "l0",
+                "descriptor": "raw",
+                "start_date": "20251107",
+                "end_date": "20251108",
+                "version": "v02-01",
+                "extension": "pkts",
+            }
+        ]
     )
     return expected_response
+
+
+def test_query_result_body(setup_test_data):
+    """Tests that the query result body can be loaded"""
+    event = {"queryStringParameters": {}}
+
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert json.loads(returned_query["body"])
 
 
 def test_start_date_query(setup_test_data, test_engine, expected_response):
@@ -113,7 +118,7 @@ def test_start_and_end_date_query(setup_test_data, test_engine, expected_respons
 def test_empty_start_date_query(setup_test_data, test_engine):
     "Test that a start_date query with no matches returns an empty list"
     event = {"queryStringParameters": {"start_date": "20261101"}}
-    expected_response = json.dumps("[]")
+    expected_response = json.dumps([])
     returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
@@ -123,7 +128,7 @@ def test_empty_start_date_query(setup_test_data, test_engine):
 def test_empty_end_date_query(setup_test_data, test_engine):
     "Test that an end_date query with no matches returns an empty list"
     event = {"queryStringParameters": {"start_date": "20261101"}}
-    expected_response = json.dumps("[]")
+    expected_response = json.dumps([])
     returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
@@ -133,7 +138,7 @@ def test_empty_end_date_query(setup_test_data, test_engine):
 def test_empty_non_date_query(setup_test_data, test_engine):
     "Test that a non-date query with no matches returns an empty list"
     event = {"queryStringParameters": {"data_level": "l2"}}
-    expected_response = json.dumps("[]")
+    expected_response = json.dumps([])
     returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200

--- a/tests/lambda_endpoints/test_query_api.py
+++ b/tests/lambda_endpoints/test_query_api.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from sds_data_manager.lambda_code.SDSCode import queries
+from sds_data_manager.lambda_code.SDSCode import query_api
 from sds_data_manager.lambda_code.SDSCode.database import database as db
 from sds_data_manager.lambda_code.SDSCode.database import models
 from sds_data_manager.lambda_code.SDSCode.database_handler import update_status_table
@@ -59,18 +59,18 @@ def expected_response():
     expected_response = json.dumps(
         str(
             [
-                (
-                    1,
-                    "test/file/path/imap_hit_l0_raw_20251107_20251108_v02-01.pkts",
-                    "hit",
-                    "l0",
-                    "raw",
-                    datetime.datetime(2025, 11, 7, 0, 0),
-                    datetime.datetime(2025, 11, 8, 0, 0),
-                    "v02-01",
-                    "pkts",
-                    1,
-                )
+                {
+                    "id": 1,
+                    "file_path": "test/file/path/imap_hit_l0_raw_20251107_20251108_v02-01.pkts",
+                    "instrument": "hit",
+                    "data_level": "l0",
+                    "descriptor": "raw",
+                    "start_date": datetime.datetime(2025, 11, 7, 0, 0),
+                    "end_date": datetime.datetime(2025, 11, 8, 0, 0),
+                    "version": "v02-01",
+                    "extension": "pkts",
+                    "status_tracking_id": 1,
+                }
             ]
         )
     )
@@ -81,7 +81,7 @@ def test_start_date_query(setup_test_data, test_engine, expected_response):
     """Test that start date can be queried"""
     event = {"queryStringParameters": {"start_date": "20251101"}}
 
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
     assert returned_query["body"] == expected_response
@@ -92,7 +92,7 @@ def test_end_date_query(setup_test_data, test_engine, expected_response):
     event = {
         "queryStringParameters": {"start_date": "20251101"},
     }
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
     assert returned_query["body"] == expected_response
@@ -104,7 +104,7 @@ def test_start_and_end_date_query(setup_test_data, test_engine, expected_respons
         "queryStringParameters": {"start_date": "20251101", "end_date": "20251201"}
     }
 
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
     assert returned_query["body"] == expected_response
@@ -114,7 +114,7 @@ def test_empty_start_date_query(setup_test_data, test_engine):
     "Test that a start_date query with no matches returns an empty list"
     event = {"queryStringParameters": {"start_date": "20261101"}}
     expected_response = json.dumps("[]")
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
     assert returned_query["body"] == expected_response
@@ -124,7 +124,7 @@ def test_empty_end_date_query(setup_test_data, test_engine):
     "Test that an end_date query with no matches returns an empty list"
     event = {"queryStringParameters": {"start_date": "20261101"}}
     expected_response = json.dumps("[]")
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
     assert returned_query["body"] == expected_response
@@ -134,7 +134,7 @@ def test_empty_non_date_query(setup_test_data, test_engine):
     "Test that a non-date query with no matches returns an empty list"
     event = {"queryStringParameters": {"data_level": "l2"}}
     expected_response = json.dumps("[]")
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
     assert returned_query["body"] == expected_response
@@ -144,7 +144,7 @@ def test_non_date_query(setup_test_data, test_engine, expected_response):
     """Test that a non-date parameters can be queried"""
     event = {"queryStringParameters": {"instrument": "hit"}}
 
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 200
     assert returned_query["body"] == expected_response
@@ -154,7 +154,7 @@ def test_multi_param_query(setup_test_data, test_engine, expected_response):
     "Test that multiple parameters can be queried"
     event = {"queryStringParameters": {"instrument": "hit", "data_level": "l0"}}
 
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
     assert returned_query["statusCode"] == 200
     assert returned_query["body"] == expected_response
 
@@ -168,7 +168,7 @@ def test_invalid_query(setup_test_data, test_engine):
         + "['file_path', 'instrument', 'data_level', 'descriptor', "
         "'start_date', 'end_date', 'version', 'extension']"
     )
-    returned_query = queries.lambda_handler(event=event, context={})
+    returned_query = query_api.lambda_handler(event=event, context={})
 
     assert returned_query["statusCode"] == 400
     assert returned_query["body"] == expected_response


### PR DESCRIPTION
# Change Summary

## Overview
This PR modifies the query API to return a list of dicts instead of a list of tuples, thus making the responses easier to read/parse. I also renamed the module (`queries.py`) to `query_api.py` to be consistent with the other data access API modules. 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- `sds_data_manager/lambda_code/SDSCode/query_api.py`
   - Renamed from `queries.py`; converted results from list of tuples to list of dicts
- `pyproject.toml`
   - Ignoring line too long error in `test_query_api` -- Caught in a loophole where `ruff` simultaneously wants to format the dict so that each key is on its own line, but also complains that one of those lines is too long. I thought this was the best workaround.
-   `sds_data_manager/stacks/sds_api_manager_stack.py`
   - Updated `query_api` name 
- `tests/lambda_endpoints/test_query_api.py`
   - Updated tests to reflect changes  
