### PR TITLE
Prevent database duplicates

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/upload_api.py
@@ -83,7 +83,6 @@ def lambda_handler(event, context):
             models.FileCatalog.file_path == s3_key_path
         )
         result = session.execute(query).first()
-        print(result)
         if result:
             response = {
                 "statusCode": 409,

--- a/sds_data_manager/lambda_code/SDSCode/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/upload_api.py
@@ -85,7 +85,7 @@ def lambda_handler(event, context):
             models.FileCatalog.file_path == s3_key_path
         )
         result = session.execute(query).first()
-        # return a 409 response if a existing file is found
+        # return a 409 response if an existing file is found
         if result:
             response = {
                 "statusCode": 409,

--- a/sds_data_manager/lambda_code/SDSCode/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/upload_api.py
@@ -4,6 +4,11 @@ import os
 
 import boto3
 from SDSCode.path_helper import InvalidScienceFileError, ScienceFilepathManager
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .database import database as db
+from .database import models
 
 logger = logging.getLogger(__name__)
 logging.basicConfig()
@@ -72,6 +77,23 @@ def lambda_handler(event, context):
         return {"statusCode": 400, "body": str(e)}
 
     s3_key_path = science_file.construct_upload_path()
+
+    with Session(db.get_engine()) as session:
+        query = select(models.FileCatalog.__table__).where(
+            models.FileCatalog.file_path == s3_key_path
+        )
+        result = session.execute(query).first()
+        print(result)
+        if result:
+            response = {
+                "statusCode": 409,
+                "body": json.dumps(f"{s3_key_path} already exists."),
+                "headers": {
+                    "Content-Type": "application/json",
+                    "Access-Control-Allow-Origin": "*",
+                },
+            }
+            return response
 
     url = _generate_signed_upload_url(s3_key_path)
 

--- a/sds_data_manager/lambda_code/SDSCode/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/upload_api.py
@@ -78,11 +78,14 @@ def lambda_handler(event, context):
 
     s3_key_path = science_file.construct_upload_path()
 
+    # Check for already existing file in the database
     with Session(db.get_engine()) as session:
+        # query and check for a matching file path
         query = select(models.FileCatalog.__table__).where(
             models.FileCatalog.file_path == s3_key_path
         )
         result = session.execute(query).first()
+        # return a 409 response if a existing file is found
         if result:
             response = {
                 "statusCode": 409,

--- a/sds_data_manager/stacks/sds_api_manager_stack.py
+++ b/sds_data_manager/stacks/sds_api_manager_stack.py
@@ -79,8 +79,12 @@ class SdsApiManager(Stack):
             runtime=lambda_.Runtime.PYTHON_3_9,
             timeout=cdk.Duration.minutes(15),
             memory_size=1000,
+            allow_public_subnet=True,
+            vpc=vpc,
+            security_groups=[rds_security_group],
             environment={
                 "S3_BUCKET": data_bucket.bucket_name,
+                "SECRET_NAME": db_secret_name,
             },
         )
         upload_api_lambda.add_to_role_policy(s3_write_policy)
@@ -166,6 +170,7 @@ class SdsApiManager(Stack):
         )
         rds_secret.grant_read(grantee=universal_spin_table_handler)
         rds_secret.grant_read(grantee=query_api_lambda)
+        rds_secret.grant_read(grantee=upload_api_lambda)
 
         api.add_route(
             route="spin_table",


### PR DESCRIPTION
# Change Summary

## Overview
Added check in upload_api to prevent duplicate entries to the database

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
- upload_api
   - added check for an already existing file entry
- sds_api_manager_stack.py
   - added secret name to upload api lambda environment
   - gave upload api lambda needed vpc / security groups
   - gave upload api lambda permission to read rds

## Testing
Deployed and attempted a duplicate file upload
