### PR TITLE
MNT: Standardize logging across the package

### DIFF
--- a/sds_data_manager/batch/efs-access-batch/read_from_efs.py
+++ b/sds_data_manager/batch/efs-access-batch/read_from_efs.py
@@ -1,6 +1,10 @@
 import logging
 from pathlib import Path
 
+# Logger setup
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 # Define the paths
 attitude_symlink_path = "/mnt/spice/latest_attitude_kernel.ah.a"
 ephemeris_symlink_path = "/mnt/spice/latest_ephemeris_kernel.bsp"
@@ -24,12 +28,12 @@ def spice_handler():
         # Path.resolve() returns the absolute path of the symlink
         with open(Path(attitude_symlink_path).resolve()) as f:
             content = f.read()
-            logging.info("Attitude kernel:\n%s", content)
+            logger.info("Attitude kernel:\n%s", content)
 
     if Path(ephemeris_symlink_path).is_symlink():
         with open(Path(ephemeris_symlink_path).resolve()) as f:
             content = f.read()
-            logging.info("Ephemeris kernel:\n%s", content)
+            logger.info("Ephemeris kernel:\n%s", content)
 
     return {"statusCode": 200, "body": "Found symlink"}
 

--- a/sds_data_manager/lambda_code/SDSCode/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/batch_starter.py
@@ -13,8 +13,8 @@ from .database import models
 from .lambda_custom_events import IMAPLambdaPutEvent
 
 # Logger setup
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def query_instrument(session, upstream_dependency, start_date, end_date):
@@ -203,14 +203,14 @@ def query_upstream_dependencies(
                 all_dependencies_available = (
                     False  # Set flag to false if any dependency is missing
                 )
-                logging.info(
+                logger.info(
                     f"Missing dependency: {upstream_dependency['instrument']}, "
                     f"{upstream_dependency['level']}, "
                     f"{upstream_dependency['version']}"
                 )
                 break  # Exit the loop early as we already found a missing dependency
             else:
-                logging.info(
+                logger.info(
                     f"Dependency found: {upstream_dependency['instrument']}, "
                     f"{upstream_dependency['level']}, "
                     f"{upstream_dependency['version']}"
@@ -228,9 +228,9 @@ def query_upstream_dependencies(
             instruments_to_process.append(
                 {"filename": filename, "prepared_data": prepared_data}
             )
-            logging.info(f"All dependencies for {instrument} present.")
+            logger.info(f"All dependencies for {instrument} present.")
         else:
-            logging.info(f"Some dependencies for {instrument} are missing.")
+            logger.info(f"Some dependencies for {instrument} are missing.")
 
     return instruments_to_process
 

--- a/sds_data_manager/lambda_code/SDSCode/create_schema.py
+++ b/sds_data_manager/lambda_code/SDSCode/create_schema.py
@@ -2,16 +2,14 @@
 
 import json
 import logging
-import sys
 
 import requests
 from SDSCode.database import database as db
 from SDSCode.database.models import Base
 
 # Logger setup
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
 def send_response(event, context, response_status):

--- a/sds_data_manager/lambda_code/SDSCode/database_handler.py
+++ b/sds_data_manager/lambda_code/SDSCode/database_handler.py
@@ -1,6 +1,5 @@
 """Common functions to write to database"""
 import logging
-import sys
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -9,9 +8,8 @@ from .database import database as db
 from .database import models
 
 # Logger setup
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
 def update_status_table(status_params):
@@ -29,7 +27,7 @@ def update_status_table(status_params):
             session.add(models.StatusTracking(**status_params))
             session.commit()
     except IntegrityError as e:
-        logger.info(str(e))
+        logger.error(str(e))
 
 
 def update_file_catalog_table(metadata_params):
@@ -47,4 +45,4 @@ def update_file_catalog_table(metadata_params):
             session.add(models.FileCatalog(**metadata_params))
             session.commit()
     except IntegrityError as e:
-        logger.info(str(e))
+        logger.error(str(e))

--- a/sds_data_manager/lambda_code/SDSCode/download_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/download_api.py
@@ -8,8 +8,7 @@ import boto3
 import botocore
 
 # Logger setup
-logger = logging.getLogger()
-logging.basicConfig()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 

--- a/sds_data_manager/lambda_code/SDSCode/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/indexer.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import logging
 import os
-import sys
 
 import boto3
 from sqlalchemy import select
@@ -15,9 +14,8 @@ from .lambda_custom_events import IMAPLambdaPutEvent
 from .path_helper import InvalidScienceFileError, ScienceFilepathManager
 
 # Logger setup
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 s3 = boto3.client("s3")
 

--- a/sds_data_manager/lambda_code/SDSCode/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/query_api.py
@@ -3,7 +3,6 @@
 import datetime
 import json
 import logging
-import sys
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -14,7 +13,6 @@ from .database import models
 # Logger setup
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
 def lambda_handler(event, context):

--- a/sds_data_manager/lambda_code/SDSCode/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/upload_api.py
@@ -11,8 +11,7 @@ from .database import database as db
 from .database import models
 
 logger = logging.getLogger(__name__)
-logging.basicConfig()
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 
 s3 = boto3.client("s3")
 

--- a/sds_data_manager/lambda_code/efs_lambda/lambda_function.py
+++ b/sds_data_manager/lambda_code/efs_lambda/lambda_function.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 import boto3
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 # Define the paths
 mount_path = Path(os.environ.get("EFS_MOUNT_PATH"))
 
@@ -49,11 +52,11 @@ def write_data_to_efs(s3_key: str, s3_bucket: str):
     try:
         # Download the file from S3
         s3_client.download_file(s3_bucket, s3_key, download_path)
-        logging.debug(f"File downloaded: {download_path}")
+        logger.debug(f"File downloaded: {download_path}")
     except Exception as e:
-        logging.info(f"Error downloading file: {e!s}")
+        logger.error(f"Error downloading file: {e!s}")
 
-    logging.debug("After downloading file: %s", os.listdir(mount_path))
+    logger.debug("After downloading file: %s", os.listdir(mount_path))
 
     # TODO: we only want historical attitude kernels delivery
     #  following each track (3/wk)
@@ -138,7 +141,7 @@ def lambda_handler(event, context):
     # Retrieve the S3 bucket and key from the event
     s3_bucket = event["detail"]["bucket"]["name"]
     s3_key = event["detail"]["object"]["key"]
-    logging.debug(event)
+    logger.debug(event)
 
     write_data_to_efs(s3_key, s3_bucket)
 

--- a/tests/docker_images/imap_api.py
+++ b/tests/docker_images/imap_api.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import requests
 
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def _parse_args():
@@ -72,7 +73,7 @@ def download(s3_uri, api_endpoint="https://api.dev.imap-mission.com"):
     file_name_and_path : str
         The file path where the downloaded file is saved.
     """
-    logging.info(f"Starting download from S3 URI: {s3_uri}")
+    logger.info(f"Starting download from S3 URI: {s3_uri}")
 
     url_with_parameters = f"{api_endpoint}/download?{s3_uri}"
     response = requests.get(url_with_parameters)
@@ -92,7 +93,7 @@ def download(s3_uri, api_endpoint="https://api.dev.imap-mission.com"):
     with open(file_name_and_path, "wb") as file:
         file.write(response.content)
 
-    logging.info(f"File downloaded and saved to: {file_name_and_path}")
+    logger.info(f"File downloaded and saved to: {file_name_and_path}")
 
     return str(file_name_and_path)
 
@@ -108,7 +109,7 @@ def upload(local_file_location, api_endpoint="https://api.dev.imap-mission.com")
     api_endpoint : str, optional
         The API endpoint to use for uploading the file.
     """
-    logging.info(f"Starting upload for file: {local_file_location}")
+    logger.info(f"Starting upload for file: {local_file_location}")
 
     local_file_path = Path(local_file_location)
     remote_file_name = local_file_path.name
@@ -123,7 +124,7 @@ def upload(local_file_location, api_endpoint="https://api.dev.imap-mission.com")
     upload_url = get_response.json()
     requests.put(upload_url)
 
-    logging.info(f"File uploaded: {modified_file_name}")
+    logger.info(f"File uploaded: {modified_file_name}")
 
 
 def main():
@@ -138,7 +139,7 @@ def main():
     file_name_and_path = download(args.s3_uri, endpoint)
     upload(file_name_and_path, endpoint)
 
-    logging.info("Process completed successfully")
+    logger.info("Process completed successfully")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Change Summary

We should get an explicit logger in the module and set that log level rather than the global log level. If we set the global logger's level we get a lot of external boto debug logs that aren't of interest and pollute our logs.

* If we are logging from a caught exception log that at the error level
* Set INFO log level rather than debug. Debug should be for when we are actively debugging or want to go look into things later.