### PR TITLE
Infrastructure changes to match filename convention updates

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -749,12 +749,12 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.4.0"
+version = "0.5.0"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap-data-access-0.4.0.tar.gz", hash = "sha256:8d0091f379896b74819b25015cdf6d580d13551f0bd1d8808bf485b5d9bbbade"},
+    {file = "imap-data-access-0.5.0.tar.gz", hash = "sha256:bb161b363e81bb23c1f6900a02292f7002423febe280453fe145e4d4a54921da"},
 ]
 
 [package.extras]
@@ -2017,4 +2017,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "c0218744ba1fda07df0a72f3e04c49d300f34d1b0d73ab800a142ba1d78e12cb"
+content-hash = "630cc939a4c5da4709cdb07bcad47359e56b578bf323859b10de2e4b454623c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ freezegun = "^1.2.2"
 sphinx = {version="^7.1.0", optional=true}
 myst-parser = {version="^2.0.0", optional=true}
 pydata-sphinx-theme = {version="^0.13.3", optional=true}
-imap-data-access = "^0.4.0"
+imap-data-access = "^0.5.0"
 
 [tool.poetry.group.cdk-install.dependencies]
 # 2.66+ required for aws-cdk.aws-lambda-python-alpha
@@ -68,7 +68,7 @@ requests-aws4auth = "^1.2.3"
 psycopg2-binary = "^2.9.9"
 urllib3 = "<2.0.0"
 SQLAlchemy = "<=3.0.0"
-imap-data-access = ">=0.4.0"
+imap-data-access = ">=0.5.0"
 
 # Used for installing with pip
 [tool.poetry.extras]

--- a/sds_data_manager/lambda_code/SDSCode/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/batch_starter.py
@@ -85,13 +85,20 @@ def query_instrument(session, upstream_dependency, start_date, version):
     instrument = upstream_dependency["instrument"]
     data_level = upstream_dependency["data_level"]
 
+    # TODO: narrow down the query using end_date.
+    # This will give ability to query range of time.
+    # Eg. when we are query 3 months of data to create
+    # 3 months map, end_date will help narrow search.
+    # When we have the end_date, we can query
+    # using table.start_date >= start_date and
+    # table.end_date <= end_date.
     record = (
         session.query(models.FileCatalog)
         .filter(
             models.FileCatalog.instrument == instrument,
             models.FileCatalog.data_level == data_level,
             models.FileCatalog.version == version,
-            models.FileCatalog.start_date >= datetime.strptime(start_date, "%Y%m%d"),
+            models.FileCatalog.start_date == datetime.strptime(start_date, "%Y%m%d"),
         )
         .first()
     )
@@ -271,7 +278,7 @@ def prepare_data(instrument, data_level, start_date, version, upstream_dependenc
     #             'start_date': '20231212',
     #             'version': 'v001',
     #         }]""",
-    #    "--repointing", "None | int",
+    #    "--repointing", 1,
     #     "--upload-to-sdc"
     # ]
     prepared_data = [

--- a/sds_data_manager/lambda_code/SDSCode/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/batch_starter.py
@@ -62,8 +62,8 @@ def get_dependency(instrument, data_level, descriptor, direction, relationship):
     return dependency
 
 
-def query_instrument(session, upstream_dependency, start_date, end_date, version):
-    """Append information to downstream dependents.
+def query_instrument(session, upstream_dependency, start_date, version):
+    """Query to database to get the first FileCatalog record.
 
     Parameters
     ----------
@@ -73,8 +73,6 @@ def query_instrument(session, upstream_dependency, start_date, end_date, version
         Dictionary of upstream dependency.
     start_date : str
         Start date of the event data.
-    end_date : str
-        End date of the event data.
     version : str
         Version of the event data.
 
@@ -94,7 +92,6 @@ def query_instrument(session, upstream_dependency, start_date, end_date, version
             models.FileCatalog.data_level == data_level,
             models.FileCatalog.version == version,
             models.FileCatalog.start_date >= datetime.strptime(start_date, "%Y%m%d"),
-            models.FileCatalog.end_date <= datetime.strptime(end_date, "%Y%m%d"),
         )
         .first()
     )
@@ -132,11 +129,9 @@ def query_downstream_dependencies(session, filename_components):
         dependent["version"] = filename_components["version"]  # placeholder
 
         # TODO: add repointing table query if dependent is ENA or GLOWS
-        #  Use start_date and end_date to query repointing table.
-        # Use pointing start_time and end_time in place of start_date and end_date.
+        # Use start_date to query repointing table.
         # Add pointing number to dependent.
         dependent["start_date"] = filename_components["start_date"]
-        dependent["end_date"] = filename_components["end_date"]
 
     return downstream_dependents
 
@@ -165,10 +160,9 @@ def query_upstream_dependencies(session, downstream_dependents):
     for dependent in downstream_dependents:
         instrument = dependent["instrument"]
         data_level = dependent["data_level"]
-        version = dependent["version"]
-        start_date = dependent["start_date"]
-        end_date = dependent["end_date"]
         descriptor = dependent["descriptor"]
+        start_date = dependent["start_date"]
+        version = dependent["version"]
 
         # For each downstream dependent, find its upstream dependencies
         upstream_dependencies = get_dependency(
@@ -182,9 +176,7 @@ def query_upstream_dependencies(session, downstream_dependents):
         all_dependencies_available = True  # Initialize the flag
         for upstream_dependency in upstream_dependencies:
             # Check to see if each upstream dependency is available
-            record = query_instrument(
-                session, upstream_dependency, start_date, end_date, version
-            )
+            record = query_instrument(session, upstream_dependency, start_date, version)
             if record is None:
                 all_dependencies_available = (
                     False  # Set flag to false if any dependency is missing
@@ -206,7 +198,6 @@ def query_upstream_dependencies(session, downstream_dependents):
                 # Add additional information to the upstream dependency
                 additional_info = {
                     "start_date": start_date,
-                    "end_date": end_date,
                     "version": version,
                 }
                 upstream_dependency.update(additional_info)
@@ -219,14 +210,12 @@ def query_upstream_dependencies(session, downstream_dependents):
             #     'data_level': 'l0',
             #     'descriptor': 'lveng-hk',
             #     'start_date': '20231212',
-            #     'end_date': '20231212',
             #     'version': 'v01-00',
             # },
             prepared_data = prepare_data(
                 instrument=instrument,
                 data_level=data_level,
                 start_date=start_date,
-                end_date=end_date,
                 version=version,
                 upstream_dependencies=upstream_dependencies,
             )
@@ -238,9 +227,7 @@ def query_upstream_dependencies(session, downstream_dependents):
     return instruments_to_process
 
 
-def prepare_data(
-    instrument, data_level, start_date, end_date, version, upstream_dependencies
-):
+def prepare_data(instrument, data_level, start_date, version, upstream_dependencies):
     """Prepare data for batch job.
 
     Parameters
@@ -250,8 +237,6 @@ def prepare_data(
     data_level : str
         Data level.
     start_date : str
-        Data start date.
-    end_date : str
         Data start date.
     version : str
         version.
@@ -270,7 +255,6 @@ def prepare_data(
     #     "--instrument", "mag",
     #     "--data-level", "l1a",
     #     "--start-date", "20231212",
-    #     "--end-date", "20231212",
     #     "--version", "v00-01",
     #     "--dependency", """[
     #         {
@@ -278,7 +262,6 @@ def prepare_data(
     #             'data_level': 'l0',
     #             'descriptor': 'lveng-hk',
     #             'start_date': '20231212',
-    #             'end_date': '20231212',
     #             'version': 'v01-00',
     #         },
     #         {
@@ -286,7 +269,6 @@ def prepare_data(
     #             'data_level': 'l0',
     #             'descriptor': 'lveng-hk',
     #             'start_date': '20231212',
-    #             'end_date': '20231212',
     #             'version': 'v00-01',
     #         }]""",
     #     "--upload-to-sdc"
@@ -298,8 +280,6 @@ def prepare_data(
         data_level,
         "--start-date",
         start_date,
-        "--end-date",
-        end_date,
         "--version",
         version,
         "--dependency",
@@ -335,7 +315,6 @@ def send_lambda_put_event(command_parameters):
             "--instrument", "mag",
             "--data-level", "l1a",
             "--start-date", "20231212",
-            "--end-date", "20231212",
             "--version", "v00-01",
             "--dependency", \"""[
                 {
@@ -343,7 +322,6 @@ def send_lambda_put_event(command_parameters):
                     'data_level': 'l0',
                     'descriptor': 'lveng-hk',
                     'start_date': '20231212',
-                    'end_date': '20231212',
                     'version': 'v01-00',
                 },
                 {
@@ -351,7 +329,6 @@ def send_lambda_put_event(command_parameters):
                     'data_level': 'l0',
                     'descriptor': 'lveng-hk',
                     'start_date': '20231212',
-                    'end_date': '20231212',
                     'version': 'v00-01',
                 }]\""",
             "--upload-to-sdc"
@@ -368,9 +345,8 @@ def send_lambda_put_event(command_parameters):
     instrument = command_parameters[1]
     data_level = command_parameters[3]
     start_date = command_parameters[5]
-    end_date = command_parameters[7]
-    version = command_parameters[9]
-    dependency = command_parameters[11]
+    version = command_parameters[7]
+    dependency = command_parameters[9]
 
     # Create event["detail"] information
     detail = {
@@ -378,7 +354,6 @@ def send_lambda_put_event(command_parameters):
         "instrument": instrument,
         "data_level": data_level,
         "start_date": start_date,
-        "end_date": end_date,
         "version": version,
         "dependency": dependency,
     }

--- a/sds_data_manager/lambda_code/SDSCode/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/batch_starter.py
@@ -210,7 +210,7 @@ def query_upstream_dependencies(session, downstream_dependents):
             #     'data_level': 'l0',
             #     'descriptor': 'lveng-hk',
             #     'start_date': '20231212',
-            #     'version': 'v01-00',
+            #     'version': 'v001',
             # },
             prepared_data = prepare_data(
                 instrument=instrument,
@@ -255,21 +255,21 @@ def prepare_data(instrument, data_level, start_date, version, upstream_dependenc
     #     "--instrument", "mag",
     #     "--data-level", "l1a",
     #     "--start-date", "20231212",
-    #     "--version", "v00-01",
+    #     "--version", "v001",
     #     "--dependency", """[
     #         {
     #             'instrument': 'swe',
     #             'data_level': 'l0',
     #             'descriptor': 'lveng-hk',
     #             'start_date': '20231212',
-    #             'version': 'v01-00',
+    #             'version': 'v001',
     #         },
     #         {
     #             'instrument': 'mag',
     #             'data_level': 'l0',
     #             'descriptor': 'lveng-hk',
     #             'start_date': '20231212',
-    #             'version': 'v00-01',
+    #             'version': 'v001',
     #         }]""",
     #    "--repointing", "None | int",
     #     "--upload-to-sdc"
@@ -317,21 +317,21 @@ def send_lambda_put_event(command_parameters):
             "--instrument", "mag",
             "--data-level", "l1a",
             "--start-date", "20231212",
-            "--version", "v00-01",
+            "--version", "v001",
             "--dependency", \"""[
                 {
                     'instrument': 'swe',
                     'data_level': 'l0',
                     'descriptor': 'lveng-hk',
                     'start_date': '20231212',
-                    'version': 'v01-00',
+                    'version': 'v001',
                 },
                 {
                     'instrument': 'mag',
                     'data_level': 'l0',
                     'descriptor': 'lveng-hk',
                     'start_date': '20231212',
-                    'version': 'v00-01',
+                    'version': 'v001',
                 }]\""",
             "--upload-to-sdc"
         ]

--- a/sds_data_manager/lambda_code/SDSCode/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/batch_starter.py
@@ -271,6 +271,7 @@ def prepare_data(instrument, data_level, start_date, version, upstream_dependenc
     #             'start_date': '20231212',
     #             'version': 'v00-01',
     #         }]""",
+    #    "--repointing", "None | int",
     #     "--upload-to-sdc"
     # ]
     prepared_data = [
@@ -286,6 +287,7 @@ def prepare_data(instrument, data_level, start_date, version, upstream_dependenc
         f"{upstream_dependencies}",
         "--upload-to-sdc",
     ]
+    # TODO: Add repointing information to the command
 
     return prepared_data
 

--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -66,6 +66,12 @@ EXTENSIONS = SqlEnum("pkts", "cdf", name="extensions")
 # instrument's processing
 DEPENDENCY_DIRECTIONS = SqlEnum("UPSTREAM", "DOWNSTREAM", name="dependency_direction")
 
+# 'hard' dependency means that the dependent instrument's processing cannot
+# proceed without the primary instrument's data. 'soft' dependency means that
+# the dependent instrument's processing can proceed without the primary
+# instrument's data. It's nice to have but not necessary.
+DEPENDENCY_RELATIONSHIPS = SqlEnum("SOFT", "HARD", name="dependency_relationship")
+
 
 class Status(Enum):
     """Enum to store the status."""
@@ -150,7 +156,7 @@ class FileCatalog(Base):
     data_level = Column(DATA_LEVELS, nullable=False)
     descriptor = Column(String(20), nullable=False)
     start_date = Column(DateTime, nullable=False)
-    repointing = Column(String(11), nullable=True)  # repointXXXXX
+    repointing = Column(Integer, nullable=True)
     version = Column(String(4), nullable=False)  # vXXX
     extension = Column(EXTENSIONS, nullable=False)
     ingestion_date = Column(DateTime)
@@ -183,7 +189,7 @@ class PreProcessingDependency(Base):
     dependent_instrument = Column(INSTRUMENTS, nullable=False)
     dependent_data_level = Column(DATA_LEVELS, nullable=False)
     dependent_descriptor = Column(String, nullable=False)
-    relationship = Column(String, nullable=False)
+    relationship = Column(DEPENDENCY_RELATIONSHIPS, nullable=False)
     direction = Column(DEPENDENCY_DIRECTIONS, nullable=False)
 
 

--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -118,7 +118,6 @@ class StatusTracking(Base):
     instrument = Column(INSTRUMENTS, nullable=False)
     data_level = Column(DATA_LEVELS, nullable=False)
     start_date = Column(DateTime, nullable=False)
-    end_date = Column(DateTime, nullable=False)
     version = Column(String(8), nullable=False)
     # TODO:
     # Didn't make it required field yet. Revisit this
@@ -151,7 +150,7 @@ class FileCatalog(Base):
     data_level = Column(DATA_LEVELS, nullable=False)
     descriptor = Column(String(20), nullable=False)
     start_date = Column(DateTime, nullable=False)
-    repointing_number = Column(String(11), nullable=True)  # repointXXXXX
+    repointing = Column(String(11), nullable=True)  # repointXXXXX
     version = Column(String(4), nullable=False)  # vXXX
     extension = Column(EXTENSIONS, nullable=False)
     ingestion_date = Column(DateTime)

--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -140,7 +140,6 @@ class FileCatalog(Base):
             "instrument",
             "data_level",
             "start_date",
-            "end_date",
             name="file_catalog_uc",
         ),
     )
@@ -152,8 +151,8 @@ class FileCatalog(Base):
     data_level = Column(DATA_LEVELS, nullable=False)
     descriptor = Column(String(20), nullable=False)
     start_date = Column(DateTime, nullable=False)
-    end_date = Column(DateTime, nullable=False)
-    version = Column(String(8), nullable=False)
+    repointing_number = Column(String(11), nullable=True)  # repointXXXXX
+    version = Column(String(4), nullable=False)  # vXXX
     extension = Column(EXTENSIONS, nullable=False)
     ingestion_date = Column(DateTime)
 
@@ -209,8 +208,11 @@ class Version(Base):
     id = Column(Integer, Identity(start=1, increment=1), primary_key=True)
     instrument = Column(INSTRUMENTS, nullable=False)
     data_level = Column(DATA_LEVELS, nullable=False)
+    # TODO: determine cap for strings based on what software version
+    # will look like
     software_version = Column(String(2), nullable=False)
-    data_version = Column(String(2), nullable=False)
+    # Data version is a string of the form vXXX
+    data_version = Column(String(4), nullable=False)
     updated_date = Column(DateTime, nullable=False)
 
 

--- a/sds_data_manager/lambda_code/SDSCode/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/indexer.py
@@ -224,13 +224,13 @@ def batch_event_handler(event):
                     "--instrument", "swapi",
                     "--level", "l1",
                     "--start-date", "20230724",
-                    "--version", "v02-01",
+                    "--version", "v001",
                     "--dependency", \"""[
                         {
                             'instrument': 'swapi',
                             'level': 'l0',
                             'start_date': 20230724,
-                            'version': 'v02-01'
+                            'version': 'v001'
                         }
                     ]\""",
                     "--use-remote",
@@ -330,13 +330,13 @@ def custom_event_handler(event):
             "instrument": "swapi",
             "level": "l1",
             "start_date": "20230724",
-            "version": "v02-01",
+            "version": "v001",
             "status": "INPROGRESS",
             "dependency": json.dumps([
                 {
                     "instrument": "swe",
                     "level": "l0",
-                    "version": "v00-01"
+                    "version": "v001"
                 }]),
         }}
 

--- a/sds_data_manager/lambda_code/SDSCode/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/indexer.py
@@ -158,7 +158,7 @@ def s3_event_handler(event):
     #     "data_level": self.data_level,
     #     "descriptor": self.descriptor,
     #     "start_date": datetime.strptime(self.startdate, "%Y%m%d"),
-    #     "end_date": datetime.strptime(self.enddate, "%Y%m%d"),
+    #     "repointing": self.repointing,
     #     "version": self.version,
     #     "extension": self.extension,
     #     "ingestion_date": date_object,
@@ -170,7 +170,6 @@ def s3_event_handler(event):
     file_params["start_date"] = datetime.strptime(
         file_params.pop("start_date"), "%Y%m%d"
     )
-    file_params["end_date"] = datetime.strptime(file_params.pop("end_date"), "%Y%m%d")
 
     file_params["file_path"] = s3_filepath
 
@@ -225,14 +224,12 @@ def batch_event_handler(event):
                     "--instrument", "swapi",
                     "--level", "l1",
                     "--start-date", "20230724",
-                    "--end-date", "20230724",
                     "--version", "v02-01",
                     "--dependency", \"""[
                         {
                             'instrument': 'swapi',
                             'level': 'l0',
                             'start_date': 20230724,
-                            'end_date': 20230724,
                             'version': 'v02-01'
                         }
                     ]\""",
@@ -258,8 +255,7 @@ def batch_event_handler(event):
     instrument = command[1]
     data_level = command[3]
     start_date = datetime.strptime(command[5], "%Y%m%d")
-    end_date = datetime.strptime(command[7], "%Y%m%d")
-    version = command[9]
+    version = command[7]
 
     # Get job status
     job_status = (
@@ -278,7 +274,6 @@ def batch_event_handler(event):
             .filter(models.StatusTracking.instrument == instrument)
             .filter(models.StatusTracking.data_level == data_level)
             .filter(models.StatusTracking.start_date == start_date)
-            .filter(models.StatusTracking.end_date == end_date)
             .filter(models.StatusTracking.version == version)
             .first()
         )
@@ -287,14 +282,13 @@ def batch_event_handler(event):
             logger.info(
                 "No existing record found, creating"
                 f" new record for {instrument},{data_level},"
-                f"{start_date},{end_date},{version}"
+                f"{start_date},{version}"
             )
             status_params = {
                 "status": job_status,
                 "instrument": instrument,
                 "data_level": data_level,
                 "start_date": start_date,
-                "end_date": end_date,
                 "version": version,
             }
             update_status_table(status_params)
@@ -303,7 +297,6 @@ def batch_event_handler(event):
                 .filter(models.StatusTracking.instrument == instrument)
                 .filter(models.StatusTracking.data_level == data_level)
                 .filter(models.StatusTracking.start_date == start_date)
-                .filter(models.StatusTracking.end_date == end_date)
                 .filter(models.StatusTracking.version == version)
                 .first()
             )
@@ -337,7 +330,6 @@ def custom_event_handler(event):
             "instrument": "swapi",
             "level": "l1",
             "start_date": "20230724",
-            "end_date": "20230724",
             "version": "v02-01",
             "status": "INPROGRESS",
             "dependency": json.dumps([
@@ -361,7 +353,6 @@ def custom_event_handler(event):
         "instrument": event_details["instrument"],
         "data_level": event_details["data_level"],
         "start_date": datetime.strptime(event_details["start_date"], "%Y%m%d"),
-        "end_date": datetime.strptime(event_details["end_date"], "%Y%m%d"),
         "version": event_details["version"],
         "job_definition": None,
     }

--- a/sds_data_manager/lambda_code/SDSCode/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/query_api.py
@@ -66,8 +66,10 @@ def lambda_handler(event, context):
                     "Access-Control-Allow-Origin": "*",  # Allow CORS
                 },
             }
-            logger.debug(f"valid_parameters: {valid_parameters}")
-            logger.debug(f"Invalid query parameter: {param}")
+            logger.debug(
+                f"Received an invalid query parameter [{param}],"
+                " valid options are: {valid_parameters}"
+            )
             return response
         # check if we're search for start_date or end date to
         # setup the correct "where" time condition

--- a/sds_data_manager/lambda_code/SDSCode/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/query_api.py
@@ -45,6 +45,12 @@ def lambda_handler(event, context):
         for column in models.FileCatalog.__table__.columns
         if column.key not in ["id"]
     ]
+    # Up until this point, valid_parameters are the same as the
+    # columns in the FileCatalog table. And looks like we removed
+    # the "id" column from the list. But we also need to add
+    # 'end_date' to the list of valid_parameters.
+    valid_parameters.append("end_date")
+
     # go through each query parameter to set up sqlalchemy query conditions
     for param, value in query_params.items():
         # confirm that the query parameter is valid
@@ -60,6 +66,8 @@ def lambda_handler(event, context):
                     "Access-Control-Allow-Origin": "*",  # Allow CORS
                 },
             }
+            logger.debug(f"valid_parameters: {valid_parameters}")
+            logger.debug(f"Invalid query parameter: {param}")
             return response
         # check if we're search for start_date or end date to
         # setup the correct "where" time condition
@@ -90,7 +98,6 @@ def lambda_handler(event, context):
     # Also remove values that are not needed by users
     for result in search_results:
         result["start_date"] = result["start_date"].strftime("%Y%m%d")
-        result["end_date"] = result["end_date"].strftime("%Y%m%d")
         result["ingestion_date"] = result["ingestion_date"].strftime(
             "%Y-%m-%d %H:%M:%S%z"
         )

--- a/sds_data_manager/lambda_code/requirements.txt
+++ b/sds_data_manager/lambda_code/requirements.txt
@@ -154,8 +154,8 @@ greenlet==3.0.3 ; python_version >= "3.9" and python_version < "4" and (platform
 idna==3.6 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
-imap-data-access==0.4.0 ; python_version >= "3.9" and python_version < "4" \
-    --hash=sha256:8d0091f379896b74819b25015cdf6d580d13551f0bd1d8808bf485b5d9bbbade
+imap-data-access==0.5.0 ; python_version >= "3.9" and python_version < "4" \
+    --hash=sha256:bb161b363e81bb23c1f6900a02292f7002423febe280453fe145e4d4a54921da
 psycopg2-binary==2.9.9 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:03ef7df18daf2c4c07e2695e8cfd5ee7f748a1d54d802330985a78d2a5a6dca9 \
     --hash=sha256:0a602ea5aff39bb9fac6308e9c9d82b9a35c2bf288e184a816002c9fae930b77 \

--- a/sds_data_manager/stacks/ecr_stack.py
+++ b/sds_data_manager/stacks/ecr_stack.py
@@ -2,7 +2,6 @@
 
 from aws_cdk import RemovalPolicy, Stack
 from aws_cdk import aws_ecr as ecr
-from aws_cdk import aws_iam as iam
 from constructs import Construct
 
 
@@ -40,19 +39,26 @@ class EcrStack(Stack):
             image_scan_on_push=True,
         )
 
-        # Grant access to developers to push ECR Images to be used by the batch job
-        ecr_authenticators = iam.Group(self, "EcrAuthenticators")
+        # TODO: remove these lines or find replacement. This is causing an error.
+        # # Grant access to developers to push ECR Images to be used by the batch job
+        # ecr_authenticators = iam.Group(self, "EcrAuthenticators")
 
-        # Allows members of this group to get the auth token for `docker login`
-        ecr.AuthorizationToken.grant_read(ecr_authenticators)
+        # # Allows members of this group to get the auth token for `docker login`
+        # ecr.AuthorizationToken.grant_read(ecr_authenticators)
 
-        # Grant permissions to the group to pull and push images
-        self.container_repo.grant_pull_push(ecr_authenticators)
+        # # Grant permissions to the group to pull and push images
+        # self.container_repo.grant_pull_push(ecr_authenticators)
 
         # Add each of the SDC devs to the newly created group
         # TODO: should we remove this?
-        for username in self.node.try_get_context("usernames"):
-            user = iam.User.from_user_name(self, username, user_name=username)
-            ecr_authenticators.add_user(user)
+        # Error from this line:
+        # The stack named loEcr failed creation, it may need to
+        # be manually deleted from the AWS console: ROLLBACK_COMPLETE:
+        # The maximum number of groups per user is exceeded for user: sandoval.
+        # (Service: AmazonIdentityManagement; Status Code: 409; Error Code:
+        # LimitExceeded; Request ID: 71ba3c0c-2be1-45e8-87cd-f1645fa49a94; Proxy: null)
+        # for username in self.node.try_get_context("usernames"):
+        #     user = iam.User.from_user_name(self, username, user_name=username)
+        #     ecr_authenticators.add_user(user)
 
         self.container_repo.apply_removal_policy(RemovalPolicy.DESTROY)

--- a/sds_data_manager/stacks/indexer_lambda_stack.py
+++ b/sds_data_manager/stacks/indexer_lambda_stack.py
@@ -149,7 +149,6 @@ class IndexerLambda(Stack):
                     "instrument": [{"exists": True}],
                     "data_level": [{"exists": True}],
                     "start_date": [{"exists": True}],
-                    "end_date": [{"exists": True}],
                     "version": [{"exists": True}],
                     "status": ["INPROGRESS"],
                     "dependency": [{"exists": True}],

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import imap_data_access
 from aws_cdk import App, Environment
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_rds as rds
@@ -120,13 +121,11 @@ def build_sds(
     # create EFS
     efs_instance = efs_stack.EFSStack(scope, "EFSStack", networking.vpc, env=env)
 
-    # TODO: import this from imap-data-access
-    instrument_list = ["codice", "swe", "mag"]  # etc
-
     lambda_code_directory = Path(__file__).parent.parent / "lambda_code"
     lambda_code_directory_str = str(lambda_code_directory.resolve())
 
-    for instrument in instrument_list:
+    # This valid instrument list is from imap-data-access package
+    for instrument in imap_data_access.VALID_INSTRUMENTS:
         ecr = ecr_stack.EcrStack(
             scope,
             f"{instrument}Ecr",
@@ -178,8 +177,6 @@ def build_sds(
         efs_instance=efs_instance,
         env=env,
     )
-
-    # TODO: create batch_starter_lambda
 
     # I-ALiRT IOIS ECR
     ialirt_ecr = ecr_stack.EcrStack(

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -74,8 +74,7 @@ def test_file_catalog_simulation(test_engine):
             data_level="l2",
             descriptor="science",
             start_date=datetime(2024, 1, 1),
-            end_date=datetime(2024, 1, 2),
-            version="v00-01",
+            version="v001",
             extension="cdf",
             ingestion_date=datetime.strptime(
                 "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
@@ -87,8 +86,7 @@ def test_file_catalog_simulation(test_engine):
             data_level="l0",
             descriptor="sci",
             start_date=datetime(2024, 1, 1),
-            end_date=datetime(2024, 1, 2),
-            version="v00-01",
+            version="v001",
             extension="pkts",
             ingestion_date=datetime.strptime(
                 "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
@@ -100,8 +98,7 @@ def test_file_catalog_simulation(test_engine):
             data_level="l0",
             descriptor="raw",
             start_date=datetime(2024, 1, 1),
-            end_date=datetime(2024, 1, 2),
-            version="v00-01",
+            version="v001",
             extension="pkts",
             ingestion_date=datetime.strptime(
                 "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
@@ -113,8 +110,7 @@ def test_file_catalog_simulation(test_engine):
             data_level="l1a",
             descriptor="sci",
             start_date=datetime(2024, 1, 1),
-            end_date=datetime(2024, 1, 2),
-            version="v00-01",
+            version="v001",
             extension="pkts",
             ingestion_date=datetime.strptime(
                 "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
@@ -176,7 +172,7 @@ def test_query_instrument(test_file_catalog_simulation):
     upstream_dependency = {
         "instrument": "ultra45",
         "data_level": "l2",
-        "version": "v00-01",
+        "version": "v001",
     }
 
     "Tests query_instrument function."
@@ -184,20 +180,18 @@ def test_query_instrument(test_file_catalog_simulation):
         test_file_catalog_simulation,
         upstream_dependency,
         "20240101",
-        "20240102",
-        "v00-01",
+        "v001",
     )
 
     assert record.instrument == "ultra45"
     assert record.data_level == "l2"
-    assert record.version == "v00-01"
+    assert record.version == "v001"
     assert record.start_date == datetime(2024, 1, 1)
-    assert record.end_date == datetime(2024, 1, 2)
 
 
 def test_query_downstream_dependencies(test_file_catalog_simulation):
-    """Tests ``query_downstream_dependencies`` function."""
-    filename = "imap_hit_l1a_sci_20240101_20240102_v00-01.cdf"
+    "Tests query_downstream_dependencies function."
+    filename = "imap_hit_l1a_sci_20240101_v001.cdf"
     file_params = ScienceFilePath.extract_filename_components(filename)
     complete_dependents = query_downstream_dependencies(
         test_file_catalog_simulation, file_params
@@ -207,9 +201,8 @@ def test_query_downstream_dependencies(test_file_catalog_simulation):
         "instrument": "hit",
         "data_level": "l1b",
         "descriptor": "sci",
-        "version": "v00-01",
+        "version": "v001",
         "start_date": "20240101",
-        "end_date": "20240102",
     }
 
     assert complete_dependents[0] == expected_complete_dependent
@@ -221,18 +214,16 @@ def test_query_upstream_dependencies(test_file_catalog_simulation):
         {
             "instrument": "hit",
             "data_level": "l1a",
-            "version": "v00-01",
+            "version": "v001",
             "descriptor": "sci",
             "start_date": "20240101",
-            "end_date": "20240102",
         },
         {
             "instrument": "hit",
             "data_level": "l3",
-            "version": "v00-01",
+            "version": "v001",
             "descriptor": "sci",
             "start_date": "20240101",
-            "end_date": "20240102",
         },
     ]
 
@@ -243,23 +234,22 @@ def test_query_upstream_dependencies(test_file_catalog_simulation):
     assert list(result[0].keys()) == ["command"]
     assert result[0]["command"][1] == "hit"
     assert result[0]["command"][3] == "l1a"
-    assert result[0]["command"][9] == "v00-01"
+    assert result[0]["command"][7] == "v001"
     expected_upstream_dependents = (
         "[{'instrument': 'hit', 'data_level': 'l0', "
         "'descriptor': 'sci', 'start_date': '20240101',"
-        " 'end_date': '20240102', 'version': 'v00-01'}]"
+        " 'version': 'v001'}]"
     )
-    assert result[0]["command"][11] == expected_upstream_dependents
+    assert result[0]["command"][9] == expected_upstream_dependents
 
     # find swe upstream dependencies
     downstream_dependents = [
         {
             "instrument": "swe",
             "data_level": "l1a",
-            "version": "v00-01",
+            "version": "v001",
             "descriptor": "all",
             "start_date": "20240101",
-            "end_date": "20240102",
         }
     ]
 
@@ -270,22 +260,21 @@ def test_query_upstream_dependencies(test_file_catalog_simulation):
     assert len(result) == 1
     assert result[0]["command"][1] == "swe"
     assert result[0]["command"][3] == "l1a"
-    assert result[0]["command"][9] == "v00-01"
+    assert result[0]["command"][7] == "v001"
     expected_upstream_dependents = (
         "[{'instrument': 'swe', 'data_level': 'l0', "
         "'descriptor': 'raw', 'start_date': '20240101',"
-        " 'end_date': '20240102', 'version': 'v00-01'}]"
+        " 'version': 'v001'}]"
     )
-    assert result[0]["command"][11] == expected_upstream_dependents
+    assert result[0]["command"][9] == expected_upstream_dependents
 
     downstream_dependents = [
         {
             "instrument": "swe",
             "data_level": "l1b",
-            "version": "v00-01",
+            "version": "v001",
             "descriptor": "sci",
             "start_date": "20240101",
-            "end_date": "20240102",
         }
     ]
 
@@ -296,13 +285,13 @@ def test_query_upstream_dependencies(test_file_catalog_simulation):
     assert len(result) == 1
     assert result[0]["command"][1] == "swe"
     assert result[0]["command"][3] == "l1b"
-    assert result[0]["command"][9] == "v00-01"
+    assert result[0]["command"][7] == "v001"
     expected_upstream_dependents = (
         "[{'instrument': 'swe', 'data_level': 'l1a', "
         "'descriptor': 'sci', 'start_date': '20240101',"
-        " 'end_date': '20240102', 'version': 'v00-01'}]"
+        " 'version': 'v001'}]"
     )
-    assert result[0]["command"][11] == expected_upstream_dependents
+    assert result[0]["command"][9] == expected_upstream_dependents
 
 
 def test_prepare_data():
@@ -312,18 +301,16 @@ def test_prepare_data():
             "instrument": "hit",
             "data_level": "l0",
             "start_date": "20240101",
-            "end_date": "20240102",
-            "version": "v00-01",
+            "version": "v001",
         }
     ]
 
-    filename = "imap_hit_l1a_sci_20240101_20240102_v00-01.cdf"
+    filename = "imap_hit_l1a_sci_20240101_v001.cdf"
     file_params = ScienceFilePath.extract_filename_components(filename)
     prepared_data = prepare_data(
         instrument=file_params["instrument"],
         data_level=file_params["data_level"],
         start_date=file_params["start_date"],
-        end_date=file_params["end_date"],
         version=file_params["version"],
         upstream_dependencies=upstream_dependencies,
     )
@@ -335,10 +322,8 @@ def test_prepare_data():
         "l1a",
         "--start-date",
         "20240101",
-        "--end-date",
-        "20240102",
         "--version",
-        "v00-01",
+        "v001",
         "--dependency",
         f"{upstream_dependencies}",
         "--upload-to-sdc",
@@ -348,9 +333,7 @@ def test_prepare_data():
 
 def test_lambda_handler(test_file_catalog_simulation, batch_client, sts_client):
     """Tests ``lambda_handler`` function."""
-    event = {
-        "detail": {"object": {"key": "imap_hit_l1a_sci_20240101_20240102_v00-01.cdf"}}
-    }
+    event = {"detail": {"object": {"key": "imap_hit_l1a_sci_20240101_v001.cdf"}}}
     context = {"context": "sample_context"}
 
     lambda_handler(event, context)
@@ -365,10 +348,8 @@ def test_send_lambda_put_event(events_client):
         "l1a",
         "--start-date",
         "20231212",
-        "--end-date",
-        "20231212",
         "--version",
-        "v00-01",
+        "v001",
         "--dependency",
         """[
             {
@@ -376,7 +357,6 @@ def test_send_lambda_put_event(events_client):
                 'data_level': 'l0',
                 'descriptor': 'lveng-hk',
                 'start_date': '20231212',
-                'end_date': '20231212',
                 'version': 'v01-00',
             },
             {
@@ -384,8 +364,7 @@ def test_send_lambda_put_event(events_client):
                 'data_level': 'l0',
                 'descriptor': 'lveng-hk',
                 'start_date': '20231212',
-                'end_date': '20231212',
-                'version': 'v00-01',
+                'version': 'v001',
             }]""",
         "--upload-to-sdc",
     ]

--- a/tests/lambda_endpoints/test_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_indexer_lambda.py
@@ -27,12 +27,12 @@ def write_to_s3(s3_client):
     # write file to s3
     s3_client.put_object(
         Bucket="test-data-bucket",
-        Key=("imap/swapi/l1/2023/01/imap_swapi_l1_sci-1m_20230724_20230724_v02-01.cdf"),
+        Key=("imap/swapi/l1/2023/01/imap_swapi_l1_sci-1m_20230724_v001.cdf"),
         Body=b"test",
     )
     s3_client.put_object(
         Bucket="test-data-bucket",
-        Key=("imap/hit/l0/2024/01/imap_hit_l0_sci-test_20240101_20240104_v02-01.pkts"),
+        Key=("imap/hit/l0/2024/01/imap_hit_l0_sci-test_20240101_v001.pkts"),
         Body=b"test",
     )
     return s3_client
@@ -49,8 +49,7 @@ def test_batch_job_event(test_engine, write_to_s3, events_client, set_env):
             "instrument": "swapi",
             "data_level": "l1",
             "start_date": "20230724",
-            "end_date": "20230724",
-            "version": "v02-01",
+            "version": "v001",
             "status": "INPROGRESS",
             "dependency": {"codice": "s3-filepath", "mag": "s3-filepath"},
         },
@@ -93,18 +92,15 @@ def test_batch_job_event(test_engine, write_to_s3, events_client, set_env):
                     "l1",
                     "--start-date",
                     "20230724",
-                    "--end-date",
-                    "20230724",
                     "--version",
-                    "v02-01",
+                    "v001",
                     "--dependency",
                     """[
                         {
                             'instrument': 'swapi',
                             'level': 'l0',
                             'start_date': 20230724,
-                            'end_date': 20230724,
-                            'version': 'v02-01'
+                            'version': 'v001'
                         }
                     ]""",
                     "--use-remote",
@@ -171,8 +167,7 @@ def test_custom_lambda_event(test_engine):
             "instrument": "swapi",
             "data_level": "l1",
             "start_date": "20230724",
-            "end_date": "20230724",
-            "version": "v02-01",
+            "version": "v001",
             "status": "INPROGRESS",
             "dependency": {"codice": "s3-filepath", "mag": "s3-filepath"},
         },
@@ -188,7 +183,7 @@ def test_custom_lambda_event(test_engine):
         assert len(result) == 1
         assert result[0].instrument == "swapi"
         assert result[0].data_level == "l1"
-        assert result[0].version == "v02-01"
+        assert result[0].version == "v001"
         assert result[0].status == models.Status.INPROGRESS
 
 
@@ -204,8 +199,7 @@ def test_s3_event(test_engine, events_client, write_to_s3):
             "bucket": {"name": "sds-data-123456789012"},
             "object": {
                 "key": (
-                    "imap/hit/l0/2024/01/"
-                    "imap_hit_l0_sci-test_20240101_20240104_v02-01.pkts"
+                    "imap/hit/l0/2024/01/" "imap_hit_l0_sci-test_20240101_v001.pkts"
                 ),
                 "reason": "PutObject",
             },
@@ -221,7 +215,7 @@ def test_s3_event(test_engine, events_client, write_to_s3):
         assert len(result) == 1
         assert (
             result[0].file_path
-            == "imap/hit/l0/2024/01/imap_hit_l0_sci-test_20240101_20240104_v02-01.pkts"
+            == "imap/hit/l0/2024/01/imap_hit_l0_sci-test_20240101_v001.pkts"
         )
         assert result[0].data_level == "l0"
         assert result[0].instrument == "hit"
@@ -229,7 +223,7 @@ def test_s3_event(test_engine, events_client, write_to_s3):
 
     # Test for bad filename input
     event["detail"]["object"]["key"] = (
-        "imap/hit/l0/2024/01/" "imap_hit_l0_sci-test_20240101_20240104_v02-01.cdf"
+        "imap/hit/l0/2024/01/" "imap_hit_l0_sci-test_20240101_v001.cdf"
     )
 
     expected_msg = (
@@ -253,7 +247,7 @@ def test_unknown_event(test_engine):
 
 def test_send_lambda_put_event(events_client):
     """Test the ``send_event_from_indexer`` function."""
-    filename = "imap_swapi_l1_sci-1m_20230724_20230724_v02-01.cdf"
+    filename = "imap_swapi_l1_sci-1m_20230724_v001.cdf"
 
     result = send_event_from_indexer(filename)
     assert result["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/lambda_endpoints/test_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_indexer_lambda.py
@@ -27,7 +27,7 @@ def write_to_s3(s3_client):
     # write file to s3
     s3_client.put_object(
         Bucket="test-data-bucket",
-        Key=("imap/swapi/l1/2023/01/imap_swapi_l1_sci-1m_20230724_v001.cdf"),
+        Key=("imap/swapi/l1/2023/01/imap_swapi_l1_sci-1min_20230724_v001.cdf"),
         Body=b"test",
     )
     s3_client.put_object(
@@ -247,7 +247,7 @@ def test_unknown_event(test_engine):
 
 def test_send_lambda_put_event(events_client):
     """Test the ``send_event_from_indexer`` function."""
-    filename = "imap_swapi_l1_sci-1m_20230724_v001.cdf"
+    filename = "imap_swapi_l1_sci-1min_20230724_v001.cdf"
 
     result = send_event_from_indexer(filename)
     assert result["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/lambda_endpoints/test_query_api.py
+++ b/tests/lambda_endpoints/test_query_api.py
@@ -12,7 +12,7 @@ from sds_data_manager.lambda_code.SDSCode.database import models
 @pytest.fixture()
 def setup_test_data(test_engine):
     """Return a database engine to test with."""
-    filepath = "test/file/path/imap_hit_l0_raw_20251107_20251108_v02-01.pkts"
+    filepath = "test/file/path/imap_hit_l0_raw_20251107_v001.pkts"
 
     metadata_params = {
         "file_path": filepath,
@@ -20,8 +20,7 @@ def setup_test_data(test_engine):
         "data_level": "l0",
         "descriptor": "raw",
         "start_date": datetime.datetime.strptime("20251107", "%Y%m%d"),
-        "end_date": datetime.datetime.strptime("20251108", "%Y%m%d"),
-        "version": "v02-01",
+        "version": "v001",
         "extension": "pkts",
         "ingestion_date": datetime.datetime.strptime(
             "2025-11-07 10:13:12+00:00", "%Y-%m-%d %H:%M:%S%z"
@@ -43,13 +42,13 @@ def expected_response():
     expected_response = json.dumps(
         [
             {
-                "file_path": "test/file/path/imap_hit_l0_raw_20251107_20251108_v02-01.pkts",  # noqa: E501
+                "file_path": "test/file/path/imap_hit_l0_raw_20251107_v001.pkts",
                 "instrument": "hit",
                 "data_level": "l0",
                 "descriptor": "raw",
                 "start_date": "20251107",
-                "end_date": "20251108",
-                "version": "v02-01",
+                "repointing": None,
+                "version": "v001",
                 "extension": "pkts",
                 "ingestion_date": "2025-11-07 10:13:12",
             }
@@ -156,7 +155,8 @@ def test_invalid_query(setup_test_data, test_engine):
         "size is not a valid query parameter. "
         + "Valid query parameters are: "
         + "['file_path', 'instrument', 'data_level', 'descriptor', "
-        "'start_date', 'end_date', 'version', 'extension', 'ingestion_date']"
+        "'start_date', 'repointing', 'version', 'extension', 'ingestion_date', "
+        + "'end_date']"
     )
     returned_query = query_api.lambda_handler(event=event, context={})
 


### PR DESCRIPTION
# Change Summary
Changes to these lambda to use new filename convention. Main changes was removing end_data and captured one TODO:
1. Batch starter Lambda
2. Indexer Lambda
3. Query API Lambda

Other major updates:
1. Update imap-data-access update
2. Database update
3. Replace instrument_list to use valid instrument list from imap-data-access in stackbuilder.py
4. Commented out ECR push permission because it was causing error with limits

## Testing
Update tests for above changes
