### PR TITLE
Automate Docker processing deployments

### DIFF
--- a/.github/workflows/deploy_containers.yml
+++ b/.github/workflows/deploy_containers.yml
@@ -1,0 +1,44 @@
+name: Docker image build and publish
+on:
+  workflow_dispatch:
+    inputs:
+      instrument_name:
+        description: 'Instrument name'
+        required: true
+        type: string
+
+# concurrency required to avoid lock contention during ECR provisioning
+concurrency: ci-${{ github.repository }}-${{ inputs.instrument_name }}-docker-pipeline
+
+jobs:
+  deploy_containers:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # https://github.com/aws-actions/configure-aws-credentials
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::449431850278:role/GitHubDeploy
+          aws-region: us-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+         mask-password: "true" # see: https://github.com/aws-actions/amazon-ecr-login#docker-credentials
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.instrument_name}}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $REGISTRY/$REPOSITORY-repo:$IMAGE_TAG -f dockerfiles/Dockerfile.prod .
+          docker push $REGISTRY/$REPOSITORY-repo:$IMAGE_TAG

--- a/dockerfiles/Dockerfile.prod
+++ b/dockerfiles/Dockerfile.prod
@@ -1,0 +1,12 @@
+# Dockerfile that installs imap_processing and its dependencies
+FROM public.ecr.aws/docker/library/python:3.12-slim
+
+# Install the imap_processing package
+# --pre will get pre-released versions as well
+RUN pip install --pre imap_processing
+
+WORKDIR /app/data
+ENV IMAP_DATA_DIR /app/data
+
+# Define the entrypoint of the container
+ENTRYPOINT ["imap_cli"]


### PR DESCRIPTION
# Change Summary

## Overview

This will automate the build and push of dockerfiles up to our ECR repositories. The idea is that it is a semi-manual procedure where we will go to "dispatch workflow" and put in our instrument name we want to deploy.

🤞 With the automated credentials, we have to sort of wait and see I think. I tried adding a branch directly to this upstream repo and that wasn't enough. I think we need to merge it into "dev" so that it is vetted before being approved as a workflow.