### PR TITLE
Automate development Docker processing deployments

### DIFF
--- a/.github/workflows/deploy_dev_containers.yml
+++ b/.github/workflows/deploy_dev_containers.yml
@@ -1,0 +1,51 @@
+name: (dev) Docker image build and publish
+on:
+  workflow_dispatch:
+    inputs:
+      instrument_name:
+        description: 'Instrument name'
+        required: true
+        type: string
+      git_url:
+        description: 'IMAP Processing Git URL to build from'
+        required: true
+        type: string
+        default: 'https://github.com/IMAP-Science-Operations-Center/imap_processing.git@dev'
+
+# concurrency required to avoid lock contention during ECR provisioning
+concurrency: ci-${{ github.repository }}-${{ inputs.instrument_name }}-dev-docker-pipeline
+
+jobs:
+  deploy_containers:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # https://github.com/aws-actions/configure-aws-credentials
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::449431850278:role/GitHubDeploy
+          aws-region: us-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+         mask-password: "true" # see: https://github.com/aws-actions/amazon-ecr-login#docker-credentials
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.instrument_name}}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $REGISTRY/$REPOSITORY-repo:$IMAGE_TAG \
+            --build-arg GIT_URL=${{ inputs.git_url }} \
+            -f dockerfiles/Dockerfile.dev .
+          docker push $REGISTRY/$REPOSITORY-repo:$IMAGE_TAG

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,0 +1,15 @@
+# Dockerfile that installs imap_processing and its dependencies
+FROM public.ecr.aws/docker/library/python:3.12-slim
+
+# Install the imap_processing package from a specified git location
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y git
+
+ARG GIT_URL=https://github.com/IMAP-Science-Operations-Center/imap_processing.git@dev
+RUN pip install git+${GIT_URL}
+
+WORKDIR /app/data
+ENV IMAP_DATA_DIR /app/data
+
+# Define the entrypoint of the container
+ENTRYPOINT ["imap_cli"]


### PR DESCRIPTION
# Change Summary

## Overview

Now we should be able to point to any git url from forks or the development branch by default. Hopefully making it easier to deploy dev work as well as production.