### PR TITLE
MNT: Sort query return results when returning from the API

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/query_api.py
@@ -89,6 +89,11 @@ def lambda_handler(event, context):
         else:
             query = query.where(getattr(models.FileCatalog, param) == value)
 
+    # We want to order the query returns by the filename
+    # This will implicitly sort by: instrument, data level, descriptor, start_date, ...
+    # Default for the table is by the ascending id so by insertion order
+    query = query.order_by(models.FileCatalog.file_path)
+
     engine = db.get_engine()
     with Session(engine) as session:
         search_results = session.execute(query).all()


### PR DESCRIPTION
# Change Summary

## Overview

This adds a sort to our query responses from the database table. We are currently sorting by "id" is all, so it depends on when files got inserted. The filename is a good key to sort by and includes the logical ordering I think we want.