### PR TITLE
MNT: Pass around database session rather than creating new ones

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/create_schema.py
+++ b/sds_data_manager/lambda_code/SDSCode/create_schema.py
@@ -7,7 +7,6 @@ import requests
 from SDSCode.database import database as db
 from SDSCode.database.models import Base
 from SDSCode.dependency_config import all_dependents
-from sqlalchemy.orm import Session
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -58,10 +57,9 @@ def lambda_handler(event, context):
     logger.info(event)
     try:
         # Create tables
-        engine = db.get_engine()
-        Base.metadata.create_all(engine)
+        Base.metadata.create_all(db.get_engine())
 
-        with Session(engine) as session:
+        with db.Session() as session:
             session.add_all(all_dependents)
             session.commit()
         send_response(event, context, "SUCCESS")

--- a/sds_data_manager/lambda_code/SDSCode/database/database.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/database.py
@@ -2,9 +2,11 @@
 
 import json
 import os
+from contextlib import contextmanager
 
 import boto3
 from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 
 def get_engine():
@@ -23,3 +25,15 @@ def get_engine():
     db_uri = f'postgresql://{db_config["username"]}:{db_config["password"]}@{db_config["host"]}:{db_config["port"]}/{db_config["dbname"]}'
 
     return create_engine(db_uri)
+
+
+@contextmanager
+class Session:
+    """Create session from engine.
+
+    Setting it up this way allows us to more easily mock this behavior in tests.
+    """
+
+    def __call__(self):
+        """Make a session from the engine."""
+        yield sessionmaker(get_engine())()

--- a/sds_data_manager/lambda_code/SDSCode/database_handler.py
+++ b/sds_data_manager/lambda_code/SDSCode/database_handler.py
@@ -3,9 +3,7 @@
 import logging
 
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 
-from .database import database as db
 from .database import models
 
 # Logger setup
@@ -13,11 +11,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def update_status_table(status_params):
+def update_status_table(session, status_params):
     """Update status tracking table.
 
     Parameters
     ----------
+    session : sqlalchemy.orm.session.Session
+        Database session.
     status_params : dict
         Data information
 
@@ -29,58 +29,55 @@ def update_status_table(status_params):
     version = status_params["version"]
 
     try:
-        with Session(db.get_engine()) as session:
-            # Had to query this way because the select statement
-            # returns a RowProxy object when it executes it,
-            # not the actual StatusTracking model instance,
-            # which is why it can't update table row directly.
-            result = (
-                session.query(models.StatusTracking)
-                .filter(models.StatusTracking.instrument == instrument)
-                .filter(models.StatusTracking.data_level == data_level)
-                .filter(models.StatusTracking.descriptor == descriptor)
-                .filter(models.StatusTracking.start_date == start_date)
-                .filter(models.StatusTracking.version == version)
-                .first()
-            )
+        # Had to query this way because the select statement
+        # returns a RowProxy object when it executes it,
+        # not the actual StatusTracking model instance,
+        # which is why it can't update table row directly.
+        result = (
+            session.query(models.StatusTracking)
+            .filter(models.StatusTracking.instrument == instrument)
+            .filter(models.StatusTracking.data_level == data_level)
+            .filter(models.StatusTracking.descriptor == descriptor)
+            .filter(models.StatusTracking.start_date == start_date)
+            .filter(models.StatusTracking.version == version)
+            .first()
+        )
 
-            if result is None:
-                logger.info(
-                    "No existing record found, creating"
-                    f" new record for {instrument}, {data_level},"
-                    f"{descriptor}, {start_date}, {version}"
-                )
-                session.add(models.StatusTracking(**status_params))
-                session.commit()
-            else:
-                logger.info(
-                    f"Updating existing record, {result.__dict__}, with batch info"
-                )
-                result.status = status_params["status"]
-                result.job_definition = status_params["job_definition"]
-                result.job_log_stream_id = status_params["job_log_stream_id"]
-                result.container_image = status_params["container_image"]
-                result.container_command = status_params["container_command"]
-                session.commit()
+        if result is None:
+            logger.info(
+                "No existing record found, creating"
+                f" new record for {instrument}, {data_level},"
+                f"{descriptor}, {start_date}, {version}"
+            )
+            session.add(models.StatusTracking(**status_params))
+            session.commit()
+        else:
+            logger.info(f"Updating existing record, {result.__dict__}, with batch info")
+            result.status = status_params["status"]
+            result.job_definition = status_params["job_definition"]
+            result.job_log_stream_id = status_params["job_log_stream_id"]
+            result.container_image = status_params["container_image"]
+            result.container_command = status_params["container_command"]
+            session.commit()
 
     except IntegrityError as e:
         logger.error(str(e))
 
 
-def update_file_catalog_table(metadata_params):
+def update_file_catalog_table(session, metadata_params):
     """Update file catalog table.
 
     Parameters
     ----------
+    session : sqlalchemy.orm.session.Session
+        Database session.
     metadata_params : dict
         Data information
 
     """
     try:
-        # Add data to the file catalog
-        with Session(db.get_engine()) as session:
-            # Add data to the file catalog table
-            session.add(models.FileCatalog(**metadata_params))
-            session.commit()
+        # Add data to the file catalog table
+        session.add(models.FileCatalog(**metadata_params))
+        session.commit()
     except IntegrityError as e:
         logger.error(str(e))

--- a/sds_data_manager/lambda_code/SDSCode/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/query_api.py
@@ -5,7 +5,6 @@ import json
 import logging
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 from .database import database as db
 from .database import models
@@ -94,8 +93,7 @@ def lambda_handler(event, context):
     # Default for the table is by the ascending id so by insertion order
     query = query.order_by(models.FileCatalog.file_path)
 
-    engine = db.get_engine()
-    with Session(engine) as session:
+    with db.Session() as session:
         search_results = session.execute(query).all()
 
     # Convert the search results (list of tuples) to a list of dicts


### PR DESCRIPTION
# Change Summary

## Overview

We can refactor the database session handling to always begin with the lambda handler and then pass the session into all of the querying functions. This speeds up the database access by keeping the same connection alive for all queries rather than requesting a new one each time. This also makes the tests easier to mock and inject our test sessions by patching the module-level session factory.

## Testing

Rather than using a fixture to populate the databases, I switched it over to explicitly call the function from within the test so that we are only populating what needs to be populated and isolating the tests. I think this makes it more explicit what is happening, but I could be convinced to leave the setup/populate functions as a fixture if people prefer that style.