### PR TITLE
Db refactor

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -8,7 +8,6 @@ from enum import Enum
 
 from sqlalchemy import (
     Boolean,
-    CheckConstraint,
     Column,
     DateTime,
     Identity,
@@ -108,10 +107,10 @@ class UniversalSpinTable(Base):
     repointing_number = Column(Integer, nullable=False)
 
 
-class StatusTracking(Base):
-    """Status tracking table."""
+class ProcessingJob(Base):
+    """Track all processing jobs."""
 
-    __tablename__ = "status_tracking"
+    __tablename__ = "processing_job_table"
 
     id = Column(Integer, Identity(start=1, increment=1), primary_key=True)
     status = Column(STATUSES, nullable=False)
@@ -142,11 +141,6 @@ class StatusTracking(Base):
             "version",
             unique=True,
             postgresql_where=and_(status.in_(["INPROGRESS", "SUCCEEDED"])),
-        ),
-        # Optional: Check constraint to ensure valid status values
-        CheckConstraint(
-            status.in_(["INPROGRESS", "SUCCEEDED", "FAILED"]),
-            name="check_status_values",
         ),
     )
 

--- a/sds_data_manager/lambda_code/SDSCode/database_handler.py
+++ b/sds_data_manager/lambda_code/SDSCode/database_handler.py
@@ -11,59 +11,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def update_status_table(session, status_params):
-    """Update status tracking table.
-
-    Parameters
-    ----------
-    session : sqlalchemy.orm.session.Session
-        Database session.
-    status_params : dict
-        Data information
-
-    """
-    instrument = status_params["instrument"]
-    data_level = status_params["data_level"]
-    descriptor = status_params["descriptor"]
-    start_date = status_params["start_date"]
-    version = status_params["version"]
-
-    try:
-        # Had to query this way because the select statement
-        # returns a RowProxy object when it executes it,
-        # not the actual StatusTracking model instance,
-        # which is why it can't update table row directly.
-        result = (
-            session.query(models.StatusTracking)
-            .filter(models.StatusTracking.instrument == instrument)
-            .filter(models.StatusTracking.data_level == data_level)
-            .filter(models.StatusTracking.descriptor == descriptor)
-            .filter(models.StatusTracking.start_date == start_date)
-            .filter(models.StatusTracking.version == version)
-            .first()
-        )
-
-        if result is None:
-            logger.info(
-                "No existing record found, creating"
-                f" new record for {instrument}, {data_level},"
-                f"{descriptor}, {start_date}, {version}"
-            )
-            session.add(models.StatusTracking(**status_params))
-            session.commit()
-        else:
-            logger.info(f"Updating existing record, {result.__dict__}, with batch info")
-            result.status = status_params["status"]
-            result.job_definition = status_params["job_definition"]
-            result.job_log_stream_id = status_params["job_log_stream_id"]
-            result.container_image = status_params["container_image"]
-            result.container_command = status_params["container_command"]
-            session.commit()
-
-    except IntegrityError as e:
-        logger.error(str(e))
-
-
 def update_file_catalog_table(session, metadata_params):
     """Update file catalog table.
 

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import boto3
 import pytest
-from moto import mock_batch, mock_events, mock_s3
+from moto import mock_events, mock_s3
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -37,13 +37,6 @@ def science_file():
 def spice_file():
     """Path to a valid spice file."""
     return "imap/spice/ck/test_v000.bc"
-
-
-@pytest.fixture()
-def batch_client():
-    """Yield a batch client."""
-    with mock_batch():
-        yield boto3.client("batch", region_name="us-west-2")
 
 
 @pytest.fixture(autouse=True, scope="module")


### PR DESCRIPTION
# Change Summary

## Overview

This is a major refactor of the batch job submission and updating. I have renamed the table to "Processing Job Table" and removed all references to "status tracking".

I find this logic more serial and easier to follow, but please let me know if you find this harder to follow or anything isn't clear. I tried to avoid the upstream/downstream terminologies when used together and instead switched to "potential jobs" for the downstream case. So we iterate through potential jobs. For each potential job we look "upstream" to see if the required files are available. If any are missing, abort. If all are available, try to submit the record. The record submission will fail if it isn't unique, so we just abort and log that there was already a record for that case.

I also added the unique ID from the table to the job-name so that we can directly get the proper record to update in the database. Before we were just getting the first, so not guaranteed to hit the right job to update if we had multiple failures or attempts.

This builds upon #308 with the final two commits here being relevant for review. Refactoring the batch starter and the indexer functions.