### PR TITLE
FIX: Add region to the s3 presigned urls

### DIFF
--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -54,8 +54,6 @@ class SdsApiManager(Construct):
             Keyword arguments
         """
         super().__init__(scope, construct_id, **kwargs)
-        # Get the current region
-        region = env.region
 
         s3_write_policy = iam.PolicyStatement(
             effect=iam.Effect.ALLOW,
@@ -88,6 +86,7 @@ class SdsApiManager(Construct):
             environment={
                 "S3_BUCKET": data_bucket.bucket_name,
                 "SECRET_NAME": db_secret_name,
+                "REGION": env.region,
             },
             layers=layers,
             architecture=lambda_.Architecture.ARM_64,
@@ -117,7 +116,7 @@ class SdsApiManager(Construct):
             vpc=vpc,
             security_groups=[rds_security_group],
             environment={
-                "REGION": region,
+                "REGION": env.region,
                 "SECRET_NAME": db_secret_name,
             },
             layers=layers,
@@ -141,6 +140,7 @@ class SdsApiManager(Construct):
             timeout=cdk.Duration.minutes(1),
             environment={
                 "S3_BUCKET": data_bucket.bucket_name,
+                "REGION": env.region,
             },
             layers=layers,
             architecture=lambda_.Architecture.ARM_64,

--- a/tests/lambda_endpoints/test_download_api.py
+++ b/tests/lambda_endpoints/test_download_api.py
@@ -14,6 +14,7 @@ def test_object_exists(spice_file):
     response = download_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 302
     assert "Location" in response["headers"]
+    assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in response["headers"]["Location"]
     assert "download_url" in response["body"]
 
 


### PR DESCRIPTION
# Change Summary

When initially deploying the bucket and then trying to upload a file, I was getting 307 redirects which can apparently happen if the region isn't specified in the initial PUT request. This happens because the default presigned URL returns a global s3 endpoint rather than a region specific one.

This updates the code to use s3v4 signature for our presined URLs, which contain the region information in them. We also connect boto3 to the region our bucket is in for this purpose.

NOTE: We may be able to update `imap-data-access` to catch the 307 redirects and do that for the users, but the reason it fails is because the HTTP spec says you should not redirect a PUT to 307 for a user automatically, and the Python standard library therefore doesn't follow that redirect.

To me, this seemed like a good approach to try for now to return region-specific URLs to the users.