### PR TITLE
MNT: Use direct inheritance for simple resource like LambdaLayer

### DIFF
--- a/sds_data_manager/constructs/lambda_layer_construct.py
+++ b/sds_data_manager/constructs/lambda_layer_construct.py
@@ -2,14 +2,17 @@
 
 import aws_cdk as cdk
 from aws_cdk import aws_lambda as lambda_
-from constructs import Construct
 
 
-class LambdaLayerConstruct(Construct):
-    """Lambda Layer Construct."""
+class IMAPLambdaLayer(lambda_.LayerVersion):
+    """Lambda Layer."""
 
     def __init__(
-        self, scope: Construct, id: str, layer_dependencies_dir: str, **kwargs
+        self,
+        id: str,
+        layer_dependencies_dir: str,
+        runtime=lambda_.Runtime.PYTHON_3_12,
+        **kwargs,
     ) -> None:
         """Create layer.
 
@@ -19,21 +22,19 @@ class LambdaLayerConstruct(Construct):
 
         Parameters
         ----------
-        scope : obj
-            Parent construct
         id : str
             A unique string identifier for this construct
         layer_dependencies_dir : str
             Directory containing the lambda layer requirements.txt file
+        runtime : lambda_.Runtime, optional
+            Lambda runtime, by default lambda_.Runtime.PYTHON_3_12
         kwargs : dict
             Keyword arguments
         """
-        super().__init__(scope, id, **kwargs)
-
         code_bundle = lambda_.Code.from_asset(
             layer_dependencies_dir,
             bundling=cdk.BundlingOptions(
-                image=lambda_.Runtime.PYTHON_3_12.bundling_image,
+                image=runtime.bundling_image,
                 command=[
                     "bash",
                     "-c",
@@ -45,9 +46,6 @@ class LambdaLayerConstruct(Construct):
             ),
         )
 
-        self.layer = lambda_.LayerVersion(
-            self,
-            id=f"{id}-Layer",
-            code=code_bundle,
-            compatible_runtimes=[lambda_.Runtime.PYTHON_3_12],
+        super().__init__(
+            id=f"{id}-Layer", code=code_bundle, compatible_runtimes=[runtime], **kwargs
         )

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -135,11 +135,11 @@ def build_sds(
     lambda_code_directory = Path(__file__).parent.parent / "lambda_code"
 
     lambda_code = lambda_.Code.from_asset(str(lambda_code_directory))
-    db_lambda_layer = lambda_layer_construct.LambdaLayerConstruct(
+    db_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
         scope=sdc_stack,
         id="DatabaseDependencies",
         layer_dependencies_dir=str(layer_code_directory),
-    ).layer
+    )
 
     # Get RDS properties from account_config
     rds_size = account_config.get("rds_size", "SMALL")

--- a/tests/infrastructure/test_lambda_layer_construct.py
+++ b/tests/infrastructure/test_lambda_layer_construct.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from aws_cdk.assertions import Template
 
-from sds_data_manager.constructs.lambda_layer_construct import LambdaLayerConstruct
+from sds_data_manager.constructs.lambda_layer_construct import IMAPLambdaLayer
 
 
 def test_lambda_layer_creation(stack):
@@ -12,7 +12,7 @@ def test_lambda_layer_creation(stack):
     lambda_code_directory = (
         Path(__file__).parent.parent.parent / "lambda_layer/python"
     ).resolve()
-    LambdaLayerConstruct(
+    IMAPLambdaLayer(
         scope=stack,
         id="TestDependencies",
         layer_dependencies_dir=str(lambda_code_directory),


### PR DESCRIPTION
# Change Summary

Rather than subclassing Construct and then calling the `LambdaLayer` Construct within the initializer, we can actually just subclass the `LambdaLayer` directly here and do whatever else we need to (bundling the code through Docker) before initializing the AWS's Construct.