### PR TITLE
ENH: Add a stack for website deployments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,4 +109,6 @@ lint.ignore = ["D104", "D203", "D213", "D300", "D413", "S101", "S104", "PLR0913"
 # TODO: Too many statements, this could be refactored to separate
 #       it into a few smaller pieces
 "sds_data_manager/utils/stackbuilder.py" = ["PLR0915"]
+# subprocess calls within these modules are expected
+"tests/lambda_endpoints/conftest.py" = ["S"]
 "tests/infrastructure/test_website_cloudfront_function.py" = ["S"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,6 @@ lint.ignore = ["D104", "D203", "D213", "D300", "D413", "S101", "S104", "PLR0913"
 
 [tool.ruff.lint.per-file-ignores]
 # TODO: Too many statements, this could be refactored to separate
-#       the single stack out into a few smaller pieces
-"sds_data_manager/stacks/sds_data_manager_construct.py" = ["PLR0915"]
-"tests/lambda_endpoints/conftest.py" = ["S"]
+#       it into a few smaller pieces
+"sds_data_manager/utils/stackbuilder.py" = ["PLR0915"]
+"tests/infrastructure/test_website_cloudfront_function.py" = ["S"]

--- a/sds_data_manager/cloudfront_functions/package.json
+++ b/sds_data_manager/cloudfront_functions/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/sds_data_manager/cloudfront_functions/test_uri_routes.js
+++ b/sds_data_manager/cloudfront_functions/test_uri_routes.js
@@ -1,0 +1,49 @@
+import { handler } from './update_uri_routes.js';
+
+// set up a basic event we can manipulate for CloudFront
+const event = {
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-request"
+    },
+    "viewer": {
+        "ip": "198.51.1.1"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/example.png",
+        "headers": {
+            "host": {"value": "example.org"}
+        }
+    }
+}
+
+const testUris = [
+    // basic page
+    ["/", "/live/index.html"],
+    // routes within the site
+    ["/about", "/live/index.html"],
+    ["/about?123", "/live/index.html"],
+    ["/about/about2", "/live/index.html"],
+    // assets within the site
+    ["/image.png", "/live/image.png"],
+    ["/assets/image.png", "/live/assets/image.png"],
+    // PR routes
+    ["/feature/IMAP-123/DEMO", "/live/feature/IMAP-123/DEMO/index.html"],
+    ["/feature/IMAP-123/DEMO/", "/live/feature/IMAP-123/DEMO/index.html"],
+    ["/feature/IMAP-123/DEMO/about", "/live/feature/IMAP-123/DEMO/index.html"],
+    ["/feature/IMAP-123/DEMO/about/about2", "/live/feature/IMAP-123/DEMO/index.html"],
+    ["/feature/IMAP-123/DEMO/about?123", "/live/feature/IMAP-123/DEMO/index.html"],
+    // PR assets
+    ["/feature/IMAP-123/DEMO/image.png", "/live/feature/IMAP-123/DEMO/image.png"],
+    ["/feature/IMAP-123/DEMO/assets/image.png", "/live/feature/IMAP-123/DEMO/assets/image.png"],
+]
+
+testUris.map(testUri => {
+    event.request.uri = testUri[0]
+    const value = handler(event).uri
+    if (value !== testUri[1]) {
+        console.error("[Input, Output, Expected]", [testUri[0], value, testUri[1]]);
+        process.exit(1);
+    }
+})

--- a/sds_data_manager/cloudfront_functions/update_uri_routes.js
+++ b/sds_data_manager/cloudfront_functions/update_uri_routes.js
@@ -1,0 +1,44 @@
+/*
+This Cloudfront function sits between the browser/viewer requests and Cloudfront routing/behaviors
+It updates incoming URI requests to the appropriate Angular/React SPA route
+*/
+
+function handler(event) {
+    var request = event.request;
+    // strip off the initial slash
+    var remainingPath = request.uri.substr(1);
+
+    // We always want to point to our "live" app location which is a subdirectory
+    // "live/" in the s3 bucket
+   var pageLocation = '/live/';
+
+    // We want to see if there is a DEMO label indicating a PR branch
+    // if so, then we add that piece after the /live/ portion of the path
+    // NOTE: We need DEMO to be the end of the branch name so we have something
+    //       to key off of indicating what the base location of our app should be
+    var demoIndex = remainingPath.indexOf('DEMO');
+    if (demoIndex >= 0) {
+        // `feature/imap-123/DEMO/index.html`
+        // We don't know whether there is a "/" in the name or not, so just
+        // split before it and add it manually
+        // i.e. we could get a user requesting DEMO or DEMO/route1
+        // but we want the slash in both cases for later referencing
+        pageLocation += remainingPath.substr(0, demoIndex + 4) + '/';
+        // but we want to strip off that slash from the remainingPath if it is present
+        // remainingPath becomes emptry string or route1 in the examples above
+        remainingPath = remainingPath.substr(demoIndex + 5);
+    }
+
+    // If it is an object (has a period indicating file extension) then we
+    // want the path to that object. Otherwise, we got a path route from
+    // the app and want to redirect to the SPA index.html and let the browser
+    // take care of the routing
+    if (remainingPath.includes('.')) {
+        // Case for all other project based files included in path
+        request.uri = pageLocation + remainingPath;
+    } else {
+        // Case for everything else, just redirect to index.html
+        request.uri = pageLocation + 'index.html';
+    }
+    return request
+}

--- a/sds_data_manager/constructs/website_hosting.py
+++ b/sds_data_manager/constructs/website_hosting.py
@@ -1,0 +1,175 @@
+"""All resources to  put together a public facing website."""
+
+from pathlib import Path
+
+import aws_cdk as cdk
+from aws_cdk import (
+    Duration,
+)
+from aws_cdk import (
+    aws_cloudfront as cloudfront,
+)
+from aws_cdk import (
+    aws_cloudfront_origins as origins,
+)
+from aws_cdk import (
+    aws_iam as iam,
+)
+from aws_cdk import (
+    aws_route53 as route53,
+)
+from aws_cdk import (
+    aws_route53_targets as targets,
+)
+from aws_cdk import (
+    aws_s3 as s3,
+)
+from constructs import Construct
+
+from sds_data_manager.constructs.route53_hosted_zone import DomainConstruct
+
+
+class Website(Construct):
+    """Website hosting resources.
+
+    It takes ~5 minutes to redeploy this stack for any cloudfront updates.
+
+    In order to provide https access to the S3 content, Cloudfront is
+    required to provide the SSL termination from the browser request.
+
+    This should be deployed in us-east-1 for the CloudFront SSL certs.
+
+    Resources:
+    - S3 Bucket for website hosting
+    - CloudFront distribution to serve the S3 content
+    - Route53 DNS record to point to the CloudFront distribution
+    - IAM group and policy for automated frontend deployments
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        domain: DomainConstruct,
+        **kwargs,
+    ) -> None:
+        """Create the website hosting stack.
+
+        Parameters
+        ----------
+        scope : Construct
+            Parent construct.
+        construct_id : str
+            A unique string identifier for this construct.
+        domain : DomainConstruct
+            The domain construct containing hosted zone and certificate.
+        kwargs : dict
+            Extra keyword arguments
+        """
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Create an s3 bucket for our website hosting
+        s3_bucket = s3.Bucket(
+            self,
+            "website-bucket",
+            bucket_name=f"imap-website-{domain.domain_name}",
+            public_read_access=False,
+            removal_policy=cdk.RemovalPolicy.DESTROY,
+        )
+
+        # Create the Cloudfront Function used to change the uri
+        code_path = str(
+            Path(__file__).parent.parent / "cloudfront_functions/update_uri_routes.js"
+        )
+        cf_function = cloudfront.Function(
+            self,
+            "website-CF-Function",
+            code=cloudfront.FunctionCode.from_file(file_path=code_path),
+            function_name="WebsiteURIRouteRequestUpdate",
+        )
+
+        # Setup CF dist to serve the data over https
+        self.distribution = cloudfront.Distribution(
+            self,
+            "cloudfront_distribution",
+            default_behavior=cloudfront.BehaviorOptions(
+                # origin_path restricts CloudFront access to frontend/ S3 data
+                origin=origins.S3Origin(s3_bucket, origin_path="frontend/"),
+                viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+                # We want to disable caching so updates to the S3 bucket are reflected
+                cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
+                # Function to help update URI to Angular/SPA routes
+                function_associations=[
+                    cloudfront.FunctionAssociation(
+                        function=cf_function,
+                        event_type=cloudfront.FunctionEventType.VIEWER_REQUEST,
+                    )
+                ],
+            ),
+            domain_names=[domain.domain_name],
+            # Lowest price limits to US/CANADA/EU
+            price_class=cloudfront.PriceClass.PRICE_CLASS_100,
+            certificate=domain.certificate,
+            default_root_object="/live/index.html",
+            comment="CF dist to serve IMAP S3 frontend content",
+            error_responses=[
+                # Web Team frontend apps uses SPA, so redirects are required
+                cloudfront.ErrorResponse(
+                    http_status=403,
+                    response_http_status=200,
+                    response_page_path="/live/index.html",
+                    ttl=Duration.seconds(10),
+                ),
+            ],
+        )
+
+        # DNS record for CF -> S3 bucket access
+        # May need to wait 5-10 minutes after this record is created
+        # to propogate through all domain servers
+        self.route53_domain_name = route53.ARecord(
+            self,
+            "CFAliasRecord",
+            zone=domain.hosted_zone,
+            # Route53 records automatically/always append the subdomain to new records.
+            # We explicitiy pass in the S3 prefix, as extracting the prefix from the
+            # bucket name within the CFT is not as simple as a python replace() method
+            # record_name=s3_bucket_name_prefix,
+            target=route53.RecordTarget.from_alias(
+                targets.CloudFrontTarget(self.distribution)
+            ),
+        )
+
+        frontend_group = iam.Group(self, "FrontendGroup", group_name="FrontendGroup")
+
+        frontend_iam_policy = iam.Policy(
+            self,
+            "FrontendCICDPolicy",
+            policy_name="frontend-automated-deploy",
+            statements=[
+                iam.PolicyStatement(
+                    # Permission to list all S3 buckets
+                    effect=iam.Effect.ALLOW,
+                    actions=["s3:GetBucketLocation", "s3:ListAllMyBuckets"],
+                    resources=[
+                        "arn:aws:s3:::*",
+                    ],
+                ),
+                iam.PolicyStatement(
+                    # Permission to do anything to objects inside this specific bucket
+                    effect=iam.Effect.ALLOW,
+                    actions=[
+                        "s3:*",
+                    ],
+                    resources=[
+                        f"{s3_bucket.bucket_arn}",
+                        f"{s3_bucket.bucket_arn}/*",
+                    ],
+                ),
+            ],
+        )
+        frontend_iam_policy.attach_to_group(frontend_group)
+        # Optionally, create a user and add the user to the group
+        frontend_user = iam.User(
+            self, "FrontendAutomatedUser", user_name="FrontendAutomatedUser"
+        )
+        frontend_group.add_user(frontend_user)

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -28,6 +28,7 @@ from sds_data_manager.constructs import (
     route53_hosted_zone,
     sds_api_manager_construct,
     sqs_construct,
+    website_hosting,
 )
 
 
@@ -76,6 +77,12 @@ def build_sds(
             domain_name,
             create_new_hosted_zone=True,
         )
+
+    # Make the website stack only if we have a domain name
+    # This needs to be deployed in us-east-1 for the CloudFront SSL certs
+    if domain is not None:
+        website_stack = Stack(scope, "WebsiteStack", env=us_east_env)
+        website_hosting.Website(website_stack, "WebsiteConstruct", domain=domain)
 
     sdc_stack = Stack(scope, "SDCStack", cross_region_references=True, env=env)
 

--- a/tests/infrastructure/test_website.py
+++ b/tests/infrastructure/test_website.py
@@ -1,0 +1,62 @@
+"""Test the website hosting resources."""
+
+from aws_cdk.assertions import Template
+
+from sds_data_manager.constructs.route53_hosted_zone import DomainConstruct
+from sds_data_manager.constructs.website_hosting import Website
+
+
+def test_website_resources(stack):
+    """Test the website hosting resources."""
+    domain = DomainConstruct(
+        stack, "DomainConstruct", domain_name="test.com", create_new_hosted_zone=True
+    )
+    Website(
+        stack,
+        "WebsiteStack",
+        domain=domain,
+    )
+
+    # Prepare the stack for assertions.
+    template = Template.from_stack(stack)
+
+    template.resource_count_is("AWS::CloudFront::Function", 1)
+
+    template.resource_count_is("AWS::CloudFront::Distribution", 1)
+    template.has_resource_properties(
+        "AWS::CloudFront::Distribution",
+        props={
+            "DistributionConfig": {
+                "CustomErrorResponses": [
+                    {
+                        "ErrorCachingMinTTL": 10,
+                        "ErrorCode": 403,
+                        "ResponseCode": 200,
+                        "ResponsePagePath": "/live/index.html",
+                    },
+                ],
+                "DefaultRootObject": "/live/index.html",
+                "Enabled": True,
+                "HttpVersion": "http2",
+                "IPV6Enabled": True,
+                "PriceClass": "PriceClass_100",
+                "Origins": [
+                    {
+                        "OriginPath": "/frontend",
+                    }
+                ],
+                # This Cache policy ID maps to caching disabled and is a static AWS ID
+                # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+                "DefaultCacheBehavior": {
+                    "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+                },
+            },
+        },
+    )
+
+    # Make sure we have an A record set for this too
+    template.resource_count_is("AWS::Route53::RecordSet", 1)
+    template.has_resource_properties(
+        "AWS::Route53::RecordSet",
+        props={"Name": f"{domain.domain_name}.", "Type": "A"},
+    )

--- a/tests/infrastructure/test_website_cloudfront_function.py
+++ b/tests/infrastructure/test_website_cloudfront_function.py
@@ -1,0 +1,45 @@
+"""Cloudfront function for URL routing."""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+def test_cloudfront_function():
+    """Testing the CF Function routing.
+
+    The actual test is defined in the test_uri_routes.js file. We run it as
+    a subprocess through pytest so we can get that report here easily. We know
+    that to install the cdk node must be installed, so we can run `node file.js`
+    within the test suite as well.
+    """
+    test_dir = (
+        Path(__file__).parent.parent.parent / "sds_data_manager/cloudfront_functions"
+    )
+
+    # Copy everything over to a new temporary directory that gets
+    # cleaned up automatically for us. We need to do this because
+    # CloudFront doesn't allow us to "export" the function, so we
+    # monkeypatch the export statement in here for testing purposes.
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmpdirpath = Path(tmpdirname)
+        for orig_file in test_dir.glob("*"):
+            with open(orig_file) as fin, open(tmpdirpath / orig_file.name, "w") as fout:
+                for line in fin:
+                    if line.startswith("function"):
+                        # prepend export
+                        line = "export " + line  # noqa
+                    fout.write(line)
+
+        test_file = tmpdirpath / "test_uri_routes.js"
+        try:
+            subprocess.run(
+                ["node", str(test_file.resolve())],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as err:
+            pytest.fail(f"CloudFront routes don't align\n{err.stderr}")


### PR DESCRIPTION
# Change Summary

This adds all of the resources required for a frontend website as a separate stack. It relies on the hosted_zone stack to get the root hosted_zone and certificate. It creates an s3 bucket to host the website and corresponding IAM user, group, and policy.

This pulls in the content from SWx TREC's CDK CloudFront Stack.

## Testing

There is some routing logic that goes on via CloudFront Functions, that is tested in a subprocess and has a separate javascript test associated with it.