### PR TITLE
Changes to DynamoDB to accomodate query patterns

### DIFF
--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -67,14 +67,16 @@ class IalirtIngestLambda(Construct):
                 name="met",
                 type=ddb.AttributeType.NUMBER,
             ),
-            # Sort key (SK) = Ingest Time (ISO).
-            sort_key=ddb.Attribute(
-                name="ingest_time",
-                type=ddb.AttributeType.STRING,
-            ),
-            # Define the read and write capacity units.
-            # TODO: change to provisioned capacity mode in production.
             billing_mode=ddb.BillingMode.PAY_PER_REQUEST,  # On-Demand capacity mode.
+        )
+
+        # Add a GSI for ingest time.
+        table.add_global_secondary_index(
+            index_name="ingest_time",
+            partition_key=ddb.Attribute(
+                name="ingest_time", type=ddb.AttributeType.STRING
+            ),
+            projection_type=ddb.ProjectionType.ALL
         )
         return table
 

--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -62,21 +62,34 @@ class IalirtIngestLambda(Construct):
             # Restore data to any point in time within the last 35 days.
             # TODO: change to True in production.
             point_in_time_recovery=False,
-            # Partition key (PK) = Mission Elapsed Time (MET).
+            # Partition key (PK) = ingest year (YYYY).
             partition_key=ddb.Attribute(
+                name="ingest_year",
+                type=ddb.AttributeType.NUMBER,
+            ),
+            # Sort key (SK) = Mission Elapsed Time (MET).
+            sort_key=ddb.Attribute(
                 name="met",
                 type=ddb.AttributeType.NUMBER,
             ),
+            # Define the read and write capacity units.
+            # TODO: change to provisioned capacity mode in production.
             billing_mode=ddb.BillingMode.PAY_PER_REQUEST,  # On-Demand capacity mode.
         )
 
         # Add a GSI for ingest time.
         table.add_global_secondary_index(
-            index_name="ingest_time",
+            index_name="ingest_date",
+            # Partition key (PK) = ingest year (YYYY).
             partition_key=ddb.Attribute(
-                name="ingest_time", type=ddb.AttributeType.STRING
+                name="ingest_year", type=ddb.AttributeType.NUMBER
             ),
-            projection_type=ddb.ProjectionType.ALL
+            # Sort key (SK) = Ingest Time (ISO).
+            sort_key=ddb.Attribute(
+                name="ingest_date",
+                type=ddb.AttributeType.STRING,
+            ),
+            projection_type=ddb.ProjectionType.ALL,
         )
         return table
 

--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -64,7 +64,7 @@ class IalirtIngestLambda(Construct):
             point_in_time_recovery=False,
             # Partition key (PK) = ingest year (YYYY).
             partition_key=ddb.Attribute(
-                name="ingest_year",
+                name="apid",
                 type=ddb.AttributeType.NUMBER,
             ),
             # Sort key (SK) = Mission Elapsed Time (MET).
@@ -81,9 +81,7 @@ class IalirtIngestLambda(Construct):
         table.add_global_secondary_index(
             index_name="ingest_date",
             # Partition key (PK) = ingest year (YYYY).
-            partition_key=ddb.Attribute(
-                name="ingest_year", type=ddb.AttributeType.NUMBER
-            ),
+            partition_key=ddb.Attribute(name="apid", type=ddb.AttributeType.NUMBER),
             # Sort key (SK) = Ingest Time (ISO).
             sort_key=ddb.Attribute(
                 name="ingest_date",

--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -79,12 +79,12 @@ class IalirtIngestLambda(Construct):
 
         # Add a GSI for ingest time.
         table.add_global_secondary_index(
-            index_name="ingest_date",
+            index_name="ingest_time",
             # Partition key (PK) = ingest year (YYYY).
             partition_key=ddb.Attribute(name="apid", type=ddb.AttributeType.NUMBER),
             # Sort key (SK) = Ingest Time (ISO).
             sort_key=ddb.Attribute(
-                name="ingest_date",
+                name="ingest_time",
                 type=ddb.AttributeType.STRING,
             ),
             projection_type=ddb.ProjectionType.ALL,

--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -62,7 +62,7 @@ class IalirtIngestLambda(Construct):
             # Restore data to any point in time within the last 35 days.
             # TODO: change to True in production.
             point_in_time_recovery=False,
-            # Partition key (PK) = ingest year (YYYY).
+            # Partition key (PK) = APID.
             partition_key=ddb.Attribute(
                 name="apid",
                 type=ddb.AttributeType.NUMBER,
@@ -80,7 +80,7 @@ class IalirtIngestLambda(Construct):
         # Add a GSI for ingest time.
         table.add_global_secondary_index(
             index_name="ingest_time",
-            # Partition key (PK) = ingest year (YYYY).
+            # Partition key (PK) = APID.
             partition_key=ddb.Attribute(name="apid", type=ddb.AttributeType.NUMBER),
             # Sort key (SK) = Ingest Time (ISO).
             sort_key=ddb.Attribute(

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -39,7 +39,7 @@ def lambda_handler(event, context):
 
     # TODO: item is temporary and will be replaced with actual packet data.
     item = {
-        "ingest_year": 2021,
+        "apid": 478,
         "met": 123,
         "ingest_date": "2021-01-01T00:00:00Z",
         "packet_blob": b"binary_data_string",

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -39,8 +39,9 @@ def lambda_handler(event, context):
 
     # TODO: item is temporary and will be replaced with actual packet data.
     item = {
+        "ingest_year": 2021,
         "met": 123,
-        "ingest_time": "2021-01-01T00:00:00Z",
+        "ingest_date": "2021-01-01T00:00:00Z",
         "packet_blob": b"binary_data_string",
     }
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -41,7 +41,7 @@ def lambda_handler(event, context):
     item = {
         "apid": 478,
         "met": 123,
-        "ingest_date": "2021-01-01T00:00:00Z",
+        "ingest_time": "2021-01-01T00:00:00Z",
         "packet_blob": b"binary_data_string",
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,15 +26,15 @@ def table():
             AttributeDefinitions=[
                 {"AttributeName": "apid", "AttributeType": "N"},
                 {"AttributeName": "met", "AttributeType": "N"},
-                {"AttributeName": "ingest_date", "AttributeType": "S"},
+                {"AttributeName": "ingest_time", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
                 {
-                    "IndexName": "ingest_date",
+                    "IndexName": "ingest_time",
                     "KeySchema": [
                         {"AttributeName": "apid", "KeyType": "HASH"},
                         {
-                            "AttributeName": "ingest_date",
+                            "AttributeName": "ingest_time",
                             "KeyType": "RANGE",
                         },
                     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,12 @@ def table():
             TableName="imap-data-table",
             KeySchema=[
                 # Partition key
-                {"AttributeName": "ingest_year", "KeyType": "HASH"},
+                {"AttributeName": "apid", "KeyType": "HASH"},
                 # Sort key
                 {"AttributeName": "met", "KeyType": "RANGE"},
             ],
             AttributeDefinitions=[
-                {"AttributeName": "ingest_year", "AttributeType": "N"},
+                {"AttributeName": "apid", "AttributeType": "N"},
                 {"AttributeName": "met", "AttributeType": "N"},
                 {"AttributeName": "ingest_date", "AttributeType": "S"},
             ],
@@ -32,7 +32,7 @@ def table():
                 {
                     "IndexName": "ingest_date",
                     "KeySchema": [
-                        {"AttributeName": "ingest_year", "KeyType": "HASH"},
+                        {"AttributeName": "apid", "KeyType": "HASH"},
                         {
                             "AttributeName": "ingest_date",
                             "KeyType": "RANGE",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,22 @@ def table():
             KeySchema=[
                 # Partition key
                 {"AttributeName": "met", "KeyType": "HASH"},
-                # Sort key
-                {"AttributeName": "ingest_time", "KeyType": "RANGE"},
             ],
             AttributeDefinitions=[
                 {"AttributeName": "met", "AttributeType": "N"},
                 {"AttributeName": "ingest_time", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "ingest_time",
+                    "KeySchema": [
+                        {
+                            "AttributeName": "ingest_time",
+                            "KeyType": "HASH"
+                        },
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
             ],
             BillingMode="PAY_PER_REQUEST",
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,19 +19,23 @@ def table():
             TableName="imap-data-table",
             KeySchema=[
                 # Partition key
-                {"AttributeName": "met", "KeyType": "HASH"},
+                {"AttributeName": "ingest_year", "KeyType": "HASH"},
+                # Sort key
+                {"AttributeName": "met", "KeyType": "RANGE"},
             ],
             AttributeDefinitions=[
+                {"AttributeName": "ingest_year", "AttributeType": "N"},
                 {"AttributeName": "met", "AttributeType": "N"},
-                {"AttributeName": "ingest_time", "AttributeType": "S"},
+                {"AttributeName": "ingest_date", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
                 {
-                    "IndexName": "ingest_time",
+                    "IndexName": "ingest_date",
                     "KeySchema": [
+                        {"AttributeName": "ingest_year", "KeyType": "HASH"},
                         {
-                            "AttributeName": "ingest_time",
-                            "KeyType": "HASH"
+                            "AttributeName": "ingest_date",
+                            "KeyType": "RANGE",
                         },
                     ],
                     "Projection": {"ProjectionType": "ALL"},

--- a/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
+++ b/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
@@ -9,13 +9,13 @@ def populate_table(table):
     """Populate DynamoDB table."""
     items = [
         {
+            "ingest_date": 20210101,
             "met": 123,
-            "ingest_time": "2021-01-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
         {
+            "ingest_date": 20210101,
             "met": 124,
-            "ingest_time": "2021-01-01T00:00:01Z",
             "packet_blob": b"binary_data_string",
         },
     ]
@@ -27,8 +27,9 @@ def populate_table(table):
 
 def test_query_by_sct_vtcw(table, populate_table):
     """Test to query irregular packet length."""
-    response = table.query(KeyConditionExpression=Key("met").eq(124))
+    response = table.query(KeyConditionExpression=Key("ingest_date").eq(20210101))
 
     items = response["Items"]
-    assert items[0]["met"] == 124
-    assert items[0]["ingest_time"] == "2021-01-01T00:00:01Z"
+    assert items[0]["ingest_date"] == 20210101
+    assert items[0]["met"] == 123
+    assert items[1]["met"] == 124

--- a/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
+++ b/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
@@ -11,13 +11,13 @@ def populate_table(table):
         {
             "apid": 478,
             "met": 123,
-            "ingest_date": "2021-01-01T00:00:00Z",
+            "ingest_time": "2021-01-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
         {
             "apid": 478,
             "met": 124,
-            "ingest_date": "2021-02-01T00:00:00Z",
+            "ingest_time": "2021-02-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
     ]
@@ -36,10 +36,7 @@ def test_query_by_met(table, populate_table):
     items = response["Items"]
 
     for item in range(len(items)):
-        assert items[item]["apid"] == expected_items[item]["apid"]
-        assert items[item]["met"] == expected_items[item]["met"]
-        assert items[item]["ingest_date"] == expected_items[item]["ingest_date"]
-        assert items[item]["packet_blob"] == expected_items[item]["packet_blob"]
+        assert items[item] == expected_items[item]
 
     response = table.query(
         KeyConditionExpression=Key("apid").eq(478) & Key("met").between(100, 123)
@@ -54,10 +51,10 @@ def test_query_by_date(table, populate_table):
     expected_items = populate_table
 
     response = table.query(
-        IndexName="ingest_date",
+        IndexName="ingest_time",
         KeyConditionExpression=Key("apid").eq(478)
-        & Key("ingest_date").begins_with("2021-01"),
+        & Key("ingest_time").begins_with("2021-01"),
     )
     items = response["Items"]
     assert len(items) == 1
-    assert items[0]["met"] == expected_items[0]["met"]
+    assert items[0] == expected_items[0]

--- a/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
+++ b/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
@@ -9,27 +9,56 @@ def populate_table(table):
     """Populate DynamoDB table."""
     items = [
         {
-            "ingest_date": 20210101,
+            "ingest_year": 2021,
             "met": 123,
+            "ingest_date": "2021-01-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
         {
-            "ingest_date": 20210101,
+            "ingest_year": 2021,
             "met": 124,
+            "ingest_date": "2021-02-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
     ]
     for item in items:
         table.put_item(Item=item)
 
-    return item
+    return items
 
 
-def test_query_by_sct_vtcw(table, populate_table):
-    """Test to query irregular packet length."""
-    response = table.query(KeyConditionExpression=Key("ingest_date").eq(20210101))
+def test_query_by_met(table, populate_table):
+    """Test to query by met."""
+    expected_items = populate_table
+
+    response = table.query(KeyConditionExpression=Key("ingest_year").eq(2021))
 
     items = response["Items"]
-    assert items[0]["ingest_date"] == 20210101
-    assert items[0]["met"] == 123
-    assert items[1]["met"] == 124
+
+    for item in range(len(items)):
+        assert items[item]["ingest_year"] == expected_items[item]["ingest_year"]
+        assert items[item]["met"] == expected_items[item]["met"]
+        assert items[item]["ingest_date"] == expected_items[item]["ingest_date"]
+        assert items[item]["packet_blob"] == expected_items[item]["packet_blob"]
+
+    response = table.query(
+        KeyConditionExpression=Key("ingest_year").eq(2021)
+        & Key("met").between(100, 123)
+    )
+    items = response["Items"]
+    assert len(items) == 1
+    assert items[0]["met"] == expected_items[0]["met"]
+
+
+def test_query_by_date(table, populate_table):
+    """Test to query by date."""
+    expected_items = populate_table
+
+    response = table.query(
+        IndexName="ingest_date",
+        KeyConditionExpression=Key("ingest_year").eq(2021)
+        & Key("ingest_date").begins_with("2021-01"),
+    )
+    items = response["Items"]
+    assert len(items) == 1
+    assert items[0]["met"] == expected_items[0]["met"]

--- a/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
+++ b/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
@@ -9,13 +9,13 @@ def populate_table(table):
     """Populate DynamoDB table."""
     items = [
         {
-            "ingest_year": 2021,
+            "apid": 478,
             "met": 123,
             "ingest_date": "2021-01-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
         {
-            "ingest_year": 2021,
+            "apid": 478,
             "met": 124,
             "ingest_date": "2021-02-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
@@ -31,19 +31,18 @@ def test_query_by_met(table, populate_table):
     """Test to query by met."""
     expected_items = populate_table
 
-    response = table.query(KeyConditionExpression=Key("ingest_year").eq(2021))
+    response = table.query(KeyConditionExpression=Key("apid").eq(478))
 
     items = response["Items"]
 
     for item in range(len(items)):
-        assert items[item]["ingest_year"] == expected_items[item]["ingest_year"]
+        assert items[item]["apid"] == expected_items[item]["apid"]
         assert items[item]["met"] == expected_items[item]["met"]
         assert items[item]["ingest_date"] == expected_items[item]["ingest_date"]
         assert items[item]["packet_blob"] == expected_items[item]["packet_blob"]
 
     response = table.query(
-        KeyConditionExpression=Key("ingest_year").eq(2021)
-        & Key("met").between(100, 123)
+        KeyConditionExpression=Key("apid").eq(478) & Key("met").between(100, 123)
     )
     items = response["Items"]
     assert len(items) == 1
@@ -56,7 +55,7 @@ def test_query_by_date(table, populate_table):
 
     response = table.query(
         IndexName="ingest_date",
-        KeyConditionExpression=Key("ingest_year").eq(2021)
+        KeyConditionExpression=Key("apid").eq(478)
         & Key("ingest_date").begins_with("2021-01"),
     )
     items = response["Items"]

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -1,7 +1,6 @@
 """Test the IAlirt ingest lambda function."""
 
 import pytest
-from boto3.dynamodb.conditions import Key
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import lambda_handler
 
@@ -47,40 +46,3 @@ def test_lambda_handler(table):
     assert item is not None
     assert item["met"] == 123
     assert item["packet_blob"] == b"binary_data_string"
-
-
-def test_query_by_met(table, populate_table):
-    """Test to query by met."""
-    expected_items = populate_table
-
-    response = table.query(KeyConditionExpression=Key("ingest_year").eq(2021))
-
-    items = response["Items"]
-
-    for item in range(len(items)):
-        assert items[item]["ingest_year"] == expected_items[item]["ingest_year"]
-        assert items[item]["met"] == expected_items[item]["met"]
-        assert items[item]["ingest_date"] == expected_items[item]["ingest_date"]
-        assert items[item]["packet_blob"] == expected_items[item]["packet_blob"]
-
-    response = table.query(
-        KeyConditionExpression=Key("ingest_year").eq(2021)
-        & Key("met").between(100, 123)
-    )
-    items = response["Items"]
-    assert len(items) == 1
-    assert items[0]["met"] == expected_items[0]["met"]
-
-
-def test_query_by_date(table, populate_table):
-    """Test to query by date."""
-    expected_items = populate_table
-
-    response = table.query(
-        IndexName="ingest_date",
-        KeyConditionExpression=Key("ingest_year").eq(2021)
-        & Key("ingest_date").begins_with("2021-01"),
-    )
-    items = response["Items"]
-    assert len(items) == 1
-    assert items[0]["met"] == expected_items[0]["met"]

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -10,13 +10,13 @@ def populate_table(table):
     """Populate DynamoDB table."""
     items = [
         {
-            "ingest_year": 2021,
+            "apid": 478,
             "met": 123,
             "ingest_date": "2021-01-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
         {
-            "ingest_year": 2021,
+            "apid": 478,
             "met": 124,
             "ingest_date": "2021-02-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
@@ -37,7 +37,7 @@ def test_lambda_handler(table):
 
     response = table.get_item(
         Key={
-            "ingest_year": 2021,
+            "apid": 478,
             "met": 123,
         }
     )

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -1,7 +1,6 @@
 """Test the IAlirt ingest lambda function."""
 
 import pytest
-import boto3
 from boto3.dynamodb.conditions import Key
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import lambda_handler
@@ -12,20 +11,22 @@ def populate_table(table):
     """Populate DynamoDB table."""
     items = [
         {
+            "ingest_year": 2021,
             "met": 123,
-            "ingest_time": "2021-01-01T00:00:00Z",
+            "ingest_date": "2021-01-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
         {
+            "ingest_year": 2021,
             "met": 124,
-            "ingest_time": "2021-01-01T00:00:01Z",
+            "ingest_date": "2021-02-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
     ]
     for item in items:
         table.put_item(Item=item)
 
-    return item
+    return items
 
 
 def test_lambda_handler(table):
@@ -37,6 +38,7 @@ def test_lambda_handler(table):
 
     response = table.get_item(
         Key={
+            "ingest_year": 2021,
             "met": 123,
         }
     )
@@ -48,53 +50,37 @@ def test_lambda_handler(table):
 
 
 def test_query_by_met(table, populate_table):
-    """Test to query irregular packet length."""
-    response = table.query(KeyConditionExpression=Key("met").eq(124))
+    """Test to query by met."""
+    expected_items = populate_table
+
+    response = table.query(KeyConditionExpression=Key("ingest_year").eq(2021))
 
     items = response["Items"]
-    assert items[0]["met"] == 124
 
-
-def test_batch_get_met_range(table, populate_table):
-    """Test querying a range of met values using BatchGetItem."""
-    met_values = [123, 124]
-    dynamodb = boto3.client("dynamodb")
-
-    response = dynamodb.batch_get_item(
-        RequestItems={
-            table.table_name: {
-                "Keys": [{"met": {"N": str(met)}} for met in met_values]
-            }
-        }
-    )
-
-    items = response.get("Responses", {}).get(table.table_name, [])
-
-    assert int(items[0]["met"]["N"]) == met_values[0]
-    assert int(items[1]["met"]["N"]) == met_values[1]
-    assert items[0]["packet_blob"]["B"] == b"binary_data_string"
-    assert items[1]["packet_blob"]["B"] == b"binary_data_string"
-
-
-def test_query_ingest_time_range(table, populate_table):
-    """Test querying a range of ingest_time values using the GSI."""
+    for item in range(len(items)):
+        assert items[item]["ingest_year"] == expected_items[item]["ingest_year"]
+        assert items[item]["met"] == expected_items[item]["met"]
+        assert items[item]["ingest_date"] == expected_items[item]["ingest_date"]
+        assert items[item]["packet_blob"] == expected_items[item]["packet_blob"]
 
     response = table.query(
-        IndexName="ingest_time",
-        KeyConditionExpression=Key("ingest_time").eq("2021-01-01T00:00:01Z"),
+        KeyConditionExpression=Key("ingest_year").eq(2021)
+        & Key("met").between(100, 123)
     )
-    item = response.get("Items")
+    items = response["Items"]
+    assert len(items) == 1
+    assert items[0]["met"] == expected_items[0]["met"]
+
+
+def test_query_by_date(table, populate_table):
+    """Test to query by date."""
+    expected_items = populate_table
 
     response = table.query(
-        IndexName="ingest_time",
-        KeyConditionExpression=Key("ingest_time").between("2021-01-01T00:00:00Z", "2021-01-01T00:00:02Z")
+        IndexName="ingest_date",
+        KeyConditionExpression=Key("ingest_year").eq(2021)
+        & Key("ingest_date").begins_with("2021-01"),
     )
-
-    items = response.get("Items", [])
-
-    # Assert the data is correct
-    assert items[0]["ingest_time"] == "2021-01-01T00:00:00Z"
-    assert items[1]["ingest_time"] == "2021-01-01T00:00:01Z"
-
-    assert items[0]["packet_blob"] == b"binary_data_string"
-    assert items[1]["packet_blob"] == b"binary_data_string"
+    items = response["Items"]
+    assert len(items) == 1
+    assert items[0]["met"] == expected_items[0]["met"]

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -12,13 +12,13 @@ def populate_table(table):
         {
             "apid": 478,
             "met": 123,
-            "ingest_date": "2021-01-01T00:00:00Z",
+            "ingest_time": "2021-01-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
         {
             "apid": 478,
             "met": 124,
-            "ingest_date": "2021-02-01T00:00:00Z",
+            "ingest_time": "2021-02-01T00:00:00Z",
             "packet_blob": b"binary_data_string",
         },
     ]


### PR DESCRIPTION
# Change Summary

## Overview
The scientists may need to query the ingest db so they can product intermediate data products. Therefore the query patterns have changed.

Before I had the db table setup this way:

partition key: met
sort key: ingest date

But to query the table you have to do this:

``` response = table.query( KeyConditionExpression=dynamodb.conditions.Key('met').eq(partition_key_value) & dynamodb.conditions.Key('ingest_date').between(start_ingest_date, end_ingest_date) ) ```

So you can't query a range because the met and ingest date are 1:1 ratio. There is 1 met/s so just to get a days worth of data a user would need to query the db  86400 times. 

This was all fine if we didn't have to do anything with this table except store the binary blobs, but now it will possibly be used by the instrument teams via an api. They will likely want to query a range of mets and/or ingest dates. 

> Also, the smallest partition that DynamoDB can do is 10 GB. So I couldn't just use a single partition (like apid) because after ~8 years we would run out of space.

Update: Greg suggested reverting to apid. If you run over that, AWS will start combining the partition key and sort key into the hash and create a new partition for you. So it isn't a hard-stop on the 10GB limit.

## Updated Files

- ialirt_ingest_lambda_construct.py
   - Add GSI and update partition key
- ialirt_ingest.py
   - Changed example of what will be ingested using the lambda.

## Testing
test_ialirt_ingest_lambda_construct.py
   - test ialirt_ingest_lambda_construct.py.
test_ialirt_ingest.py
   - test ialirt_ingest.py.
conftest.py
   - Updated test DynamoDB.