### PR TITLE
ENH: Add a DB synchronizer for our file database

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/database/synchronizer.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/synchronizer.py
@@ -1,0 +1,105 @@
+"""Synchronize database with S3 bucket.
+
+This script compares the contents of an S3 bucket with a database table and
+updates the database with any missing files or removes entries for deleted
+files.
+"""
+
+import logging
+import os
+from datetime import datetime
+
+import boto3
+import imap_data_access
+from sqlalchemy import delete, select
+
+from . import database as db
+from . import models
+
+logger = logging.getLogger(__name__)
+
+
+def lambda_handler(event, context):
+    """Entry point to the database synchronizer lambda.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process
+    context : LambdaContext
+        This object provides methods and properties that provide
+        information about the invocation, function,
+        and runtime environment.
+
+    """
+    logger.info("Synchronizing database with S3 bucket")
+
+    # S3 and database configuration
+    client = boto3.client("s3")
+    bucket = os.getenv("S3_BUCKET")
+    # Paginate through S3 objects (needed because we likely have more than 1000 items)
+    # TODO: Do we want to limit the scope of these query comparisons?
+    #       We may run into performance issues if we have a large number of files.
+    #       Could put an outer loop over instrument + level if needed.
+    paginator = client.get_paginator("list_objects_v2")
+    prefix = "imap/"
+    s3_files_dict = {}
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        if "Contents" in page:
+            s3_files_dict.update(
+                {obj["Key"]: obj["LastModified"] for obj in page["Contents"]}
+            )
+
+    s3_files = set(s3_files_dict.keys())
+
+    # Fetch database entries
+    with db.Session() as session:
+        with session.begin():
+            query = select(models.FileCatalog.file_path)
+            search_results = session.execute(query).all()
+
+        # result is a one-element tuple, so we need to extract the filepath
+        db_files = set([result[0] for result in search_results])
+
+        # Find discrepancies
+        s3_only_files = set(s3_files) - db_files
+        db_only_files = db_files - set(s3_files)
+
+        if len(s3_files) == 0 and len(db_files) == 0:
+            logger.info("No conflicting files found")
+            return
+
+        logger.info("Conflicting files found, syncing up the DB to match s3")
+        logger.info(
+            "S3 only files to be added [%d]: %s", len(s3_only_files), s3_only_files
+        )
+        logger.info(
+            "DB only files to be removed [%d]: %s", len(db_only_files), db_only_files
+        )
+
+        # Update database with missing S3 files
+        records_to_add = []
+        for filename in s3_only_files:
+            file_params = imap_data_access.ScienceFilePath.extract_filename_components(
+                filename.split("/")[-1]
+            )
+
+            # delete mission key from metadata params
+            file_params.pop("mission")
+            file_params["start_date"] = datetime.strptime(
+                file_params.pop("start_date"), "%Y%m%d"
+            )
+
+            file_params["file_path"] = filename
+            file_params["ingestion_date"] = s3_files_dict[filename]
+            records_to_add.append(models.FileCatalog(**file_params))
+        session.add_all(records_to_add)
+
+        # Remove database entries for files that were deleted from s3
+        delete_statement = delete(models.FileCatalog).where(
+            models.FileCatalog.file_path.in_(db_only_files)
+        )
+
+        session.execute(delete_statement)
+        session.commit()

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -169,6 +169,12 @@ def build_sds(
         code=lambda_code,
         layers=[db_lambda_layer],
     )
+    rds_construct.add_synchronizer(
+        code=lambda_code,
+        layers=[db_lambda_layer],
+        bucket_name=data_bucket.data_bucket.bucket_name,
+        vpc=networking.vpc,
+    )
 
     indexer_lambda_construct.IndexerLambda(
         scope=sdc_stack,

--- a/tests/lambda_endpoints/test_synchronizer.py
+++ b/tests/lambda_endpoints/test_synchronizer.py
@@ -1,0 +1,71 @@
+"""Testing the database synchronizer."""
+
+import datetime
+
+from sds_data_manager.lambda_code.SDSCode.database import models, synchronizer
+
+
+def cleanup_bucket(s3_client):
+    """Remove all objects from the test bucket."""
+    items = s3_client.list_objects_v2(Bucket="test-data-bucket")
+    for item in items["Contents"]:
+        s3_client.delete_object(Bucket="test-data-bucket", Key=item["Key"])
+
+
+def test_synchronizer_extra_s3(session, s3_client):
+    """An s3 file not in the database already, gets added as expected."""
+    cleanup_bucket(s3_client)
+
+    filepath = "imap/hit/l0/2025/11/imap_hit_l0_raw_20251107_v001.pkts"
+    s3_client.put_object(Bucket="test-data-bucket", Key=filepath, Body=b"")
+
+    with session.begin():
+        nfiles = session.query(models.FileCatalog).count()
+    assert nfiles == 0
+
+    synchronizer.lambda_handler(event={}, context={})
+
+    with session.begin():
+        files = session.query(models.FileCatalog).all()
+    assert len(files) == 1
+
+    item = files[0]
+    assert item.file_path == filepath
+    assert item.instrument == "hit"
+    assert item.data_level == "l0"
+    assert item.descriptor == "raw"
+    assert item.start_date == datetime.datetime(2025, 11, 7)
+    assert item.version == "v001"
+    assert item.extension == "pkts"
+
+
+def test_synchronizer_extra_db(session, s3_client):
+    """A database entry gets removed if it isn't in s3."""
+    cleanup_bucket(s3_client)
+    filepath = "imap/hit/l0/2025/11/imap_hit_l0_raw_20251107_v001.pkts"
+    metadata_params = {
+        "file_path": filepath,
+        "instrument": "hit",
+        "data_level": "l0",
+        "descriptor": "raw",
+        "start_date": datetime.datetime.strptime("20251107", "%Y%m%d"),
+        "version": "v001",
+        "extension": "pkts",
+        "ingestion_date": datetime.datetime.strptime(
+            "2025-11-07 10:13:12+00:00", "%Y-%m-%d %H:%M:%S%z"
+        ),
+    }
+
+    # # Add data to the file catalog and return the session
+    with session.begin():
+        session.add(models.FileCatalog(**metadata_params))
+
+    with session.begin():
+        nfiles = session.query(models.FileCatalog).count()
+    assert nfiles == 1
+
+    synchronizer.lambda_handler(event={}, context={})
+
+    with session.begin():
+        nfiles = session.query(models.FileCatalog).count()
+    assert nfiles == 0


### PR DESCRIPTION
# Change Summary

## Overview

This will keep s3 and our DB in sync with s3 being the source of truth. Iterate through all items in s3 to get the keys, then do a scan of the File Table to get all items in that table and compare the two sets of items against one another. Then iterate through adding / removing entries from the database table as necessary.

## Notes

* s3 is the source of truth, so the database is the only thing getting updated
* Do we want to run this on a schedule (currently daily), or just have the lambda there for when we need it?

closes https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/254