### PR TITLE
Update EventBridge Rule to match new spice path in data bucket

### DIFF
--- a/sds_data_manager/constructs/efs_construct.py
+++ b/sds_data_manager/constructs/efs_construct.py
@@ -214,7 +214,7 @@ class EFSWriteLambda(Construct):
                     "bucket": {"name": [data_bucket.bucket_name]},
                     "object": {
                         "key": [
-                            {"prefix": "imap/spice/imap"},
+                            {"prefix": "spice/imap"},
                             {"suffix": "ah.a"},
                             {"suffix": ".bsp"},
                         ]

--- a/sds_data_manager/constructs/efs_construct.py
+++ b/sds_data_manager/constructs/efs_construct.py
@@ -214,7 +214,7 @@ class EFSWriteLambda(Construct):
                     "bucket": {"name": [data_bucket.bucket_name]},
                     "object": {
                         "key": [
-                            {"prefix": "spice/imap"},
+                            {"prefix": "spice/"},
                             {"suffix": "ah.a"},
                             {"suffix": ".bsp"},
                         ]


### PR DESCRIPTION
# Change Summary

## Overview
Updated Event Bridge rule to trigger on any event in `spice/` directory on s3 data bucket.


## New Dependencies
Update to match this new update on `imap-data-access`

## Updated Files
- sds_data_manager/constructs/efs_construct.py
   - update rule

