### PR TITLE
HIT - Use Raw L0 File as Single L1A Dependency

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/dependency_config.csv
@@ -59,8 +59,7 @@ hi, l1b, 45sensor-de, hi, l1c, 45sensor-pset, HARD, DOWNSTREAM
 
 # <---- HIT Dependencies ---->
 
-hit, l0, sci, hit, l1a, sci, HARD, DOWNSTREAM
-hit, l0, hk, hit, l1a, hk, HARD, DOWNSTREAM
+hit, l0, raw, hit, l1a, all, HARD, DOWNSTREAM
 
 hit, l1a, sci, hit, l1b, sci, HARD, DOWNSTREAM
 hit, l1a, hk, hit, l1b, hk, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview
This PR updates the HIT dependency table to use a single raw ccsds as the depdency for all L1A processing instead of splitting it up by housekeeping and science


Closes #346
