### PR TITLE
Fixing unique constraint for dependency table

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/batch_starter.py
@@ -58,13 +58,13 @@ def get_dependencies(
     results = session.execute(query).all()
 
     for result in results:
-        dependencies.append(
-            {
-                "instrument": result.dependent_instrument,
-                "data_level": result.dependent_data_level,
-                "descriptor": result.dependent_descriptor,
-            }
-        )
+        dep = {
+            "instrument": result.dependent_instrument,
+            "data_level": result.dependent_data_level,
+            "descriptor": result.dependent_descriptor,
+        }
+        if dep not in dependencies:
+            dependencies.append(dep)
     return dependencies
 
 

--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -180,6 +180,7 @@ class PreProcessingDependency(Base):
     __tablename__ = "preprocessing_dependency"
     __table_args__ = (
         UniqueConstraint(
+            "id",
             "primary_instrument",
             "primary_data_level",
             "primary_descriptor",

--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -180,7 +180,6 @@ class PreProcessingDependency(Base):
     __tablename__ = "preprocessing_dependency"
     __table_args__ = (
         UniqueConstraint(
-            "id",
             "primary_instrument",
             "primary_data_level",
             "primary_descriptor",

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -238,6 +238,15 @@ def test_pre_processing_dependency(session):
     assert downstream_dependency[0]["descriptor"] == "norm-mago"
 
 
+def test_duplicate_dependencies(session):
+    """Tests the unique constraint in the dependency table."""
+    _populate_dependency_table(session)
+
+    with pytest.raises(IntegrityError):
+        # Duplicate dependencies should raise an error
+        _populate_dependency_table(session)
+
+
 def test_get_file(session):
     """Tests the get_file function."""
     _populate_file_catalog(session)

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -241,10 +241,22 @@ def test_pre_processing_dependency(session):
 def test_duplicate_dependencies(session):
     """Tests the unique constraint in the dependency table."""
     _populate_dependency_table(session)
+    _populate_dependency_table(session)
 
-    with pytest.raises(IntegrityError):
-        # Duplicate dependencies should raise an error
-        _populate_dependency_table(session)
+    upstream_dependency = get_dependencies(
+        session=session,
+        instrument="mag",
+        data_level="l1a",
+        descriptor="all",
+        relationship="HARD",
+        direction="UPSTREAM",
+    )
+
+    assert upstream_dependency[0]["instrument"] == "mag"
+    assert upstream_dependency[0]["data_level"] == "l0"
+    assert upstream_dependency[0]["descriptor"] == "raw"
+
+    assert len(upstream_dependency) == 1
 
 
 def test_get_file(session):


### PR DESCRIPTION
# Change Summary
This adds a check within batch_starter to remove duplicate dependencies returned from sciencefiles/filecatalog before moving along, due to changes in #344 that I didn't want to conflict with.

This fixes part of but not all of #299 and completely fixes #348. The MAG team noticed that processing didn't run because the dependency was incorrect, so I wanted to get this fix in quickly. 

I did also open another issue in imap processing related to this bug: https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/870
