### PR TITLE
Added way to trigger create schema lambda automatically when dependency config is updated

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/create_schema.py
+++ b/sds_data_manager/lambda_code/SDSCode/create_schema.py
@@ -7,6 +7,7 @@ https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.custom_resources/README.ht
 import logging
 
 from SDSCode.database import database as db
+from SDSCode.database import models
 from SDSCode.database.models import Base
 from SDSCode.dependency_config import all_dependents
 
@@ -17,18 +18,48 @@ logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
     """Entry point to the create schema lambda."""
-    logger.info("Creating RDS tables")
-    logger.info(event)
+    logger.info(f"Event: {event}")
 
-    # NOTE: If we run this when trying to delete the stack, it fails because
-    #       the RDS isn't available, so skip it here.
-    if event.get("RequestType") != "Create":
-        logger.info("Skipping schema creation, only handling Create requests")
+    if event.get("RequestType") == "Delete":
+        logger.info(
+            "Skipping schema modification, only handling Create or Update requests"
+        )
         return
 
-    # Create tables
-    Base.metadata.create_all(db.get_engine())
-
     with db.Session() as session:
-        session.add_all(all_dependents)
-        session.commit()
+        if event.get("RequestType") == "Create":
+            logger.info("Creating RDS tables")
+            # Create tables
+            Base.metadata.create_all(db.get_engine())
+            session.add_all(all_dependents)
+
+        elif event.get("RequestType") == "Update":
+            for dependent in all_dependents:
+                existing_record = (
+                    session.query(models.PreProcessingDependency)
+                    .filter(
+                        models.PreProcessingDependency.primary_instrument
+                        == dependent.primary_instrument,
+                        models.PreProcessingDependency.primary_data_level
+                        == dependent.primary_data_level,
+                        models.PreProcessingDependency.primary_descriptor
+                        == dependent.primary_descriptor,
+                        models.PreProcessingDependency.dependent_instrument
+                        == dependent.dependent_instrument,
+                        models.PreProcessingDependency.dependent_data_level
+                        == dependent.dependent_data_level,
+                        models.PreProcessingDependency.dependent_descriptor
+                        == dependent.dependent_descriptor,
+                        models.PreProcessingDependency.relationship
+                        == dependent.relationship,
+                        models.PreProcessingDependency.direction == dependent.direction,
+                    )
+                    .first()
+                )
+                if existing_record is None:
+                    session.add(dependent)
+                    logger.info(
+                        f"Adding new record with {dependent} to the Dependency table."
+                    )
+
+    session.commit()

--- a/sds_data_manager/lambda_code/SDSCode/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/dependency_config.csv
@@ -115,8 +115,8 @@ swapi, l2, sci, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 # <---- SWE Dependencies ---->
 
 swe, l0, raw, swe, l1a, sci, HARD, DOWNSTREAM
-
 swe, l1a, sci, swe, l1b, sci, HARD, DOWNSTREAM
+swe, l1b, sci, swe, l2, sci, HARD, DOWNSTREAM
 
 # <---- ULTRA Dependencies ---->
 


### PR DESCRIPTION
# Change Summary

## Overview
Added way to trigger create schema lambda and also added checks from adding duplicate records.

## New Dependencies
When we update the dependency config, we also need to update the `last_dependency_update": "09/26/2024"` in database_construct.py

## Updated Files
- sds_data_manager/constructs/database_construct.py
   - Updates to trigger create schema lambda automatically at CDK deploy
- sds_data_manager/lambda_code/SDSCode/create_schema.py
   - checks to avoid adding duplicate record to dependency table
- sds_data_manager/lambda_code/SDSCode/dependency_config.csv
   - Added SWE L2 to the config

## Testing
Tested that this changes works in AWS
