### PR TITLE
MNT: Change the dependency database table into a local lookup

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/create_schema.py
+++ b/sds_data_manager/lambda_code/SDSCode/create_schema.py
@@ -8,7 +8,6 @@ import logging
 
 from SDSCode.database import database as db
 from SDSCode.database.models import Base
-from SDSCode.dependency_config import all_dependents
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -28,7 +27,3 @@ def lambda_handler(event, context):
 
     # Create tables
     Base.metadata.create_all(db.get_engine())
-
-    with db.Session() as session:
-        session.add_all(all_dependents)
-        session.commit()

--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -174,51 +174,6 @@ class FileCatalog(Base):
     ingestion_date = Column(DateTime(timezone=True))
 
 
-class PreProcessingDependency(Base):
-    """Preprocessing dependency table."""
-
-    __tablename__ = "preprocessing_dependency"
-    __table_args__ = (
-        UniqueConstraint(
-            "id",
-            "primary_instrument",
-            "primary_data_level",
-            "primary_descriptor",
-            "dependent_instrument",
-            "dependent_data_level",
-            "dependent_descriptor",
-            "relationship",
-            "direction",
-            name="preprocessing_dependency_uc",
-        ),
-    )
-
-    # TODO: improve this table after February demo
-    id = Column(Integer, Identity(start=1, increment=1), primary_key=True)
-    primary_instrument = Column(INSTRUMENTS, nullable=False)
-    primary_data_level = Column(DATA_LEVELS, nullable=False)
-    primary_descriptor = Column(String, nullable=False)
-    dependent_instrument = Column(INSTRUMENTS, nullable=False)
-    dependent_data_level = Column(DATA_LEVELS, nullable=False)
-    dependent_descriptor = Column(String, nullable=False)
-    relationship = Column(DEPENDENCY_RELATIONSHIPS, nullable=False)
-    direction = Column(DEPENDENCY_DIRECTIONS, nullable=False)
-
-    # This can not be used for inter-instrument dependencies.
-    def reverse_direction(self):
-        "PreProcessingDependency instance with reversed direction."
-        return PreProcessingDependency(
-            primary_instrument=self.dependent_instrument,
-            primary_data_level=self.dependent_data_level,
-            primary_descriptor=self.dependent_descriptor,
-            dependent_instrument=self.primary_instrument,
-            dependent_data_level=self.primary_data_level,
-            dependent_descriptor=self.primary_descriptor,
-            relationship=self.relationship,
-            direction="UPSTREAM" if self.direction == "DOWNSTREAM" else "DOWNSTREAM",
-        )
-
-
 class Version(Base):
     """Version table."""
 

--- a/sds_data_manager/lambda_code/SDSCode/dependency_config.py
+++ b/sds_data_manager/lambda_code/SDSCode/dependency_config.py
@@ -1,23 +1,26 @@
-"""Stores the downstream and upstream dependency configuration of some IMAP instruments.
+"""Stores the dependency configuration for IMAP data products.
 
-This is used to populate pre-processing dependency table in the database.
+We can keep track of dependencies by tracking nodes in a graph. Each node
+represents a data product and the edges represent the dependencies between
+them. There is an upstream/downstream relationship between nodes. A node
+can be any data product, from a science file (instrument, data level, descriptor),
+a SPICE file, or an ancillary file.
 
 NOTE: This setup assumes that we get one data file with multiple APIDs data.
+
 This is why we have only one dependency for l0. We expect that we get one
 l0 file, eg. imap_idex_l0_raw_20240529_v001.pkts, which contains all the data of all
 APIDs. That l0 data file will kick off one l1a process for 'all' as l1a will produce
-multiple files with different descriptor(aka different data product per APID). Those
-different descriptor are handled by CDF attrs.
+multiple files with different descriptors (aka different data product per APID). Those
+different descriptors are handled through CDF attrs.
 """
 
 import logging
+from collections import defaultdict
 from pathlib import Path
-
-from .database.models import PreProcessingDependency
 
 logger = logging.getLogger(__name__)
 
-downstream_dependents = []
 header = [
     "primary_instrument",
     "primary_data_level",
@@ -28,6 +31,12 @@ header = [
     "relationship",
     "direction",
 ]
+
+# Accessed like DEPENDENCIES["HARD"]["UPSTREAM"][node]
+DEPENDENCIES = {
+    hard_soft: {up_down: defaultdict(list) for up_down in ["UPSTREAM", "DOWNSTREAM"]}
+    for hard_soft in ["HARD", "SOFT"]
+}
 
 with open(Path(__file__).parent / "dependency_config.csv") as f:
     for line in f:
@@ -41,9 +50,11 @@ with open(Path(__file__).parent / "dependency_config.csv") as f:
             raise ValueError(f"Each dependency must have 8 items\nCurrent line: {line}")
 
         logger.info(contents)
-        dependency = PreProcessingDependency(**{h: c for h, c in zip(header, contents)})
-        downstream_dependents.append(dependency)
-
-upstream_dependents = [dep.reverse_direction() for dep in downstream_dependents]
-
-all_dependents = downstream_dependents + upstream_dependents
+        # Instrument, data level, descriptor
+        parent_node = tuple(contents[:3])
+        child_node = tuple(contents[3:6])
+        hard_soft = contents[6]
+        # Downstream direction
+        DEPENDENCIES[hard_soft]["DOWNSTREAM"][parent_node].append(child_node)
+        # Upstream direction (flip parent/child)
+        DEPENDENCIES[hard_soft]["UPSTREAM"][child_node].append(parent_node)


### PR DESCRIPTION
# Change Summary

## Overview

This changes the `PreProcessingDependency` table into an in-memory "database" that is stored as nested dictionaries of "nodes". This makes it simpler to keep track of (IMO) and makes sure we are always in sync when deploying code changes because they are read into Python objects directly, thus avoiding any duplicates and other synchronization issues for a table that gets deployed/updated. The csv dependency file is still the source of truth and what populates this dictionary lookup.

@maxinelasp I'd like to hear from you especially on this since you've said that we need a database, but I'm still not sure what we need the capabilities of a SQL search for yet, thus the proposal here to try and simplify things.

My vision for this is that this will tell us what the data product mapping is (product A -> product B). Then we can go and query the Science / SPICE / Ancillary file tables for the necessary products and versions to see if those things exist. So this is basically a lookup table mapping of initial items to check. We still use the DB File Tables to query for actual items.