### PR TITLE
I-ALiRT: Switch out ECR for Nexus

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -218,6 +218,7 @@ class IalirtProcessing(Construct):
                 ),
             },
             repository_credentials=ecs.RepositoryCredentials.from_secrets_manager(nexus_secret),
+            # 
             # Ensure the ECS task is running in privileged mode,
             # which allows the container to use FUSE.
             privileged=True,

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -201,7 +201,7 @@ class IalirtProcessing(Construct):
         container = task_definition.add_container(
             f"IalirtContainer{processing_name}",
             image=ecs.ContainerImage.from_registry(
-                f"lasp-registry.colorado.edu/ialirt/my-image-{processing_name.lower()}:dev",
+                f"lasp-registry.colorado.edu/ialirt/ialirt-{processing_name.lower()}:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -7,7 +7,7 @@ https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/networking-inbou
 https://aws.amazon.com/elasticloadbalancing/features/#Product_comparisons
 """
 
-from aws_cdk import CfnOutput
+from aws_cdk import CfnOutput, RemovalPolicy
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
@@ -256,6 +256,8 @@ class IalirtProcessing(Construct):
             vpc=self.vpc,
             desired_capacity=1,
         )
+
+        auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
 
         # integrates ECS with EC2 Auto Scaling Groups
         # to manage the scaling and provisioning of the underlying

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -10,6 +10,8 @@ https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_r
 https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html#task-execution-private-auth
 https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth-container-instances.html
 https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-repositorycredentials.html
+https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ecs/ContainerImage.html
+https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ecs/Ec2TaskDefinition.html
 """
 
 from aws_cdk import CfnOutput
@@ -206,7 +208,7 @@ class IalirtProcessing(Construct):
             f"IalirtContainer{processing_name}",
             image=ecs.ContainerImage.from_registry(
                 f"docker-registry.pdmz.lasp.colorado.edu/ialirt/my-image-{processing_name.lower()}:dev",
-                credentials=nexus_secret.secret_arn  # Correctly pass the secret object
+                credentials=nexus_secret  # Correctly pass the secret object
             ),
             memory_limit_mib=512,
             cpu=256,

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -230,7 +230,9 @@ class IalirtProcessing(Construct):
             task_definition=task_definition,
             security_groups=[self.ecs_security_group],
             desired_count=1,
-            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
+            ),
         )
 
     def add_autoscaling(self, processing_name):

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -258,47 +258,40 @@ def build_sds(
         efs_construct=efs_instance,
     )
 
-    # TODO: Add I-ALiRT Stack to the deployment
-    #       We are skipping this deployment for now because it is currently
-    #       dependent on SDC Stack resources and requires a manual intervention
-    #       to deploy. We can add this stack back in to deployments after we
-    #       fix those updates.
-    if False:
-        ialirt_stack = Stack(scope, "IalirtStack", env=env)
-        # I-ALiRT IOIS ECR
-        ialirt_ecr = ecr_construct.EcrConstruct(
+    ialirt_stack = Stack(scope, "IalirtStack", env=env)
+    # # I-ALiRT IOIS ECR
+    # ialirt_ecr = ecr_construct.EcrConstruct(
+    #     scope=ialirt_stack,
+    #     construct_id="IalirtEcr",
+    #     instrument_name="IalirtEcr",
+    # )
+
+    # I-ALiRT IOIS S3 bucket
+    ialirt_bucket = ialirt_bucket_construct.IAlirtBucketConstruct(
+        scope=ialirt_stack, construct_id="IAlirtBucket", env=env
+    )
+
+    # All traffic to I-ALiRT is directed to listed container ports
+    ialirt_ports = {"Primary": [8080, 8081], "Secondary": [80]}
+    container_ports = {"Primary": 8080, "Secondary": 80}
+
+    for primary_or_secondary in ialirt_ports:
+        ialirt_processing_construct.IalirtProcessing(
             scope=ialirt_stack,
-            construct_id="IalirtEcr",
-            instrument_name="IalirtEcr",
-        )
-
-        # I-ALiRT IOIS S3 bucket
-        ialirt_bucket = ialirt_bucket_construct.IAlirtBucketConstruct(
-            scope=ialirt_stack, construct_id="IAlirtBucket", env=env
-        )
-
-        # All traffic to I-ALiRT is directed to listed container ports
-        ialirt_ports = {"Primary": [8080, 8081], "Secondary": [80]}
-        container_ports = {"Primary": 8080, "Secondary": 80}
-
-        for primary_or_secondary in ialirt_ports:
-            ialirt_processing_construct.IalirtProcessing(
-                scope=ialirt_stack,
-                construct_id=f"IalirtProcessing{primary_or_secondary}",
-                vpc=networking.vpc,
-                repo=ialirt_ecr.container_repo,
-                processing_name=primary_or_secondary,
-                ialirt_ports=ialirt_ports[primary_or_secondary],
-                container_port=container_ports[primary_or_secondary],
-                ialirt_bucket=ialirt_bucket.ialirt_bucket,
-            )
-
-        # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
-        ialirt_ingest_lambda_construct.IalirtIngestLambda(
-            scope=ialirt_stack,
-            construct_id="IalirtIngestLambda",
+            construct_id=f"IalirtProcessing{primary_or_secondary}",
+            vpc=networking.vpc,
+            processing_name=primary_or_secondary,
+            ialirt_ports=ialirt_ports[primary_or_secondary],
+            container_port=container_ports[primary_or_secondary],
             ialirt_bucket=ialirt_bucket.ialirt_bucket,
         )
+
+    # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
+    ialirt_ingest_lambda_construct.IalirtIngestLambda(
+        scope=ialirt_stack,
+        construct_id="IalirtIngestLambda",
+        ialirt_bucket=ialirt_bucket.ialirt_bucket,
+    )
 
 
 def build_backup(scope: App, env: Environment, source_account: str):

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -15,7 +15,6 @@ from sds_data_manager.constructs import (
     backup_bucket_construct,
     data_bucket_construct,
     database_construct,
-    ecr_construct,
     efs_construct,
     ialirt_bucket_construct,
     ialirt_ingest_lambda_construct,
@@ -259,12 +258,6 @@ def build_sds(
     )
 
     ialirt_stack = Stack(scope, "IalirtStack", env=env)
-    # # I-ALiRT IOIS ECR
-    # ialirt_ecr = ecr_construct.EcrConstruct(
-    #     scope=ialirt_stack,
-    #     construct_id="IalirtEcr",
-    #     instrument_name="IalirtEcr",
-    # )
 
     # I-ALiRT IOIS S3 bucket
     ialirt_bucket = ialirt_bucket_construct.IAlirtBucketConstruct(
@@ -274,6 +267,7 @@ def build_sds(
     # All traffic to I-ALiRT is directed to listed container ports
     ialirt_ports = {"Primary": [8080, 8081], "Secondary": [80]}
     container_ports = {"Primary": 8080, "Secondary": 80}
+    ialirt_secret_name = "nexus-credentials"  # noqa
 
     for primary_or_secondary in ialirt_ports:
         ialirt_processing_construct.IalirtProcessing(
@@ -284,6 +278,7 @@ def build_sds(
             ialirt_ports=ialirt_ports[primary_or_secondary],
             container_port=container_ports[primary_or_secondary],
             ialirt_bucket=ialirt_bucket.ialirt_bucket,
+            secret_name=ialirt_secret_name,
         )
 
     # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)

--- a/tests/test-data/ialirt_ec2/Dockerfile
+++ b/tests/test-data/ialirt_ec2/Dockerfile
@@ -1,9 +1,11 @@
 # This code is used to Dockerize test_app.py. The workflow is as follows:
-# 1. Login to the ECR with `aws ecr get-login-password --region <region> | docker login
-# --username AWS --password-stdin <ecr uri>`
-# 2. Build the image with `docker build -t my-image-<primary or secondary> --rm .`
-# 3. docker tag my-image-<primary or secondary> <ecr uri>:latest-<primary or secondary>
-# 4. docker push <ecr uri>:latest-<primary or secondary>
+# 1. Check that you are not already logged in by running `cat ~/.docker/config.json` and ensuring that neither
+# Nexus registry URL is in the list of logged in registries.
+# 2. Run `docker login docker-registry.pdmz.lasp.colorado.edu` (you will be prompted for your WebIAM username and password).
+# Your `~/.docker/config.json` file should now contain a reference to the registry url.
+# 3. `docker build -t my-image-primary:dev --rm . --no-cache`
+# 4. `docker tag my-image-primary:dev docker-registry.pdmz.lasp.colorado.edu/ialirt/my-image-primary:dev`
+# 5. `docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/my-image-primary:dev`
 
 # To run and test locally:
 # 1. `docker build -t my-image-<primary or secondary> --rm .`


### PR DESCRIPTION
# Change Summary

## Overview
Previously I had to do multiple steps to deploy I-ALiRT: first deploy the ecr, push an image to it, and then deploy the rest. Moving to Nexus allows automatic deployment.

## Updated Files
- stackbuilder.py
   - removed ecr
   - made it possible to deploy
- imap_processing_construct.py
   - added execution role (required to pull image externally)
   - added secrets manager
   - added registry information
- Dockerfile
   - changes in instructions. I intend to move these to documentation in the next PR.

## Testing
Deployed the code and it is running as expected. You can see the test output here:
http://Ialirt-Ialir-lCP8FNz5Z4cA-c2402c3467d21908.elb.us-west-2.amazonaws.com:8080
http://Ialirt-Ialir-lCP8FNz5Z4cA-c2402c3467d21908.elb.us-west-2.amazonaws.com:8081
http://Ialirt-Ialir-GYMaPhNOtW8K-d31884774242ee71.elb.us-west-2.amazonaws.com:80