### PR TITLE
I-ALiRT: update to readthedocs

### DIFF
--- a/docs/source/cdk/cdk-deployment.rst
+++ b/docs/source/cdk/cdk-deployment.rst
@@ -1,3 +1,5 @@
+.. _cdk-deployment:
+
 CDK Deployment
 ==============
 Deploy

--- a/docs/source/cdk/ialirt-setup.rst
+++ b/docs/source/cdk/ialirt-setup.rst
@@ -19,6 +19,8 @@ For development we will keep the major changes at 0.
 
 Nexus Repo
 ~~~~~~~~~
+We will have a versioned image and latest image in the Nexus repo. The versioned image will be tagged with the version number (e.g., 1.0) and the latest image will be the same as the most recent version. The reason that we do this is to ease the ability to switch out images in ECS.
+
 #. Check that you are not already logged in by running::
 
     cat ~/.docker/config.json
@@ -36,11 +38,17 @@ Nexus Repo
 #. Tag with the Nexus registry URL::
 
     docker tag ialirt:X.Y docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
+    docker tag ialirt:X.Y docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest
 
 #. Push the image::
 
     docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
+    docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest
 #. Images may be viewed on the Nexus website: https://artifacts.pdmz.lasp.colorado.edu
+#. To verify that the latest image and the most recent version image are the same, run the following and compare the image IDs::
+
+    docker inspect --format='{{.Id}}' docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
+    docker inspect --format='{{.Id}}' docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest
 
 CDK Deployment
 ~~~~~~~~~~~~~
@@ -50,5 +58,5 @@ ECS Recognition of a New Image
 ~~~~~~~~~~~~~
 To have ECS recognize a new image the cdk must be redeployed::
 
-    aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment
+    aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment --deployment-configuration maximumPercent=200,minimumHealthyPercent=0
 

--- a/docs/source/cdk/ialirt-setup.rst
+++ b/docs/source/cdk/ialirt-setup.rst
@@ -44,4 +44,7 @@ Nexus Repo
 
 ECS Recognition of a New Image
 ~~~~~~~~~~~~~
-To have ECS recognize a new image the cdk must be redeployed.
+#. To have ECS recognize a new image the cdk must be redeployed::
+
+    aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment --image lasp-registry.colorado.edu/ialirt/ialirt:<highest-version>
+

--- a/docs/source/cdk/ialirt-setup.rst
+++ b/docs/source/cdk/ialirt-setup.rst
@@ -42,9 +42,13 @@ Nexus Repo
     docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
 #. Images may be viewed on the Nexus website: https://artifacts.pdmz.lasp.colorado.edu
 
+CDK Deployment
+~~~~~~~~~~~~~
+:ref:`cdk-deployment`
+
 ECS Recognition of a New Image
 ~~~~~~~~~~~~~
-#. To have ECS recognize a new image the cdk must be redeployed::
+To have ECS recognize a new image the cdk must be redeployed::
 
-    aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment --image lasp-registry.colorado.edu/ialirt/ialirt:<highest-version>
+    aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment
 

--- a/docs/source/cdk/ialirt-setup.rst
+++ b/docs/source/cdk/ialirt-setup.rst
@@ -1,0 +1,47 @@
+I-ALiRT Setup
+=============
+
+Secrets Manager
+~~~~~~~~~
+
+Ensure you have a secret in AWS Secrets Manager with a username and password for the Nexus repo. The secret should be named `nexus-repo` and can be created using the following command::
+
+    aws secretsmanager create-secret --name nexus-repo --description "Credentials for Nexus Docker registry" --secret-string '{"username":"your-username", "password":"your-password"}'
+
+Image Versioning
+~~~~~~~~~
+We will rely on semantic versioning for the images MAJOR.MINOR (e.g., 1.0).
+
+- MAJOR: Major changes.
+- MINOR: Minor changes.
+
+For development we will keep the major changes at 0.
+
+Nexus Repo
+~~~~~~~~~
+#. Check that you are not already logged in by running::
+
+    cat ~/.docker/config.json
+
+#. Ensure that the Nexus registry URL is not in the list of logged in registries.
+#. Run the following command to login (you will be prompted for your WebIAM username and password)::
+
+    docker login docker-registry.pdmz.lasp.colorado.edu
+#.  Your `~/.docker/config.json` file should now contain a reference to the registry url.
+#.  Determine the appropriate version for your image based on the semantic versioning scheme (MAJOR.MINOR).
+#. Build the image and tag it with the Nexus registry URL::
+
+    docker build -t ialirt:X.Y --rm . --no-cache
+
+#. Tag with the Nexus registry URL::
+
+    docker tag ialirt:X.Y docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
+
+#. Push the image::
+
+    docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
+#. Images may be viewed on the Nexus website: https://artifacts.pdmz.lasp.colorado.edu
+
+ECS Recognition of a New Image
+~~~~~~~~~~~~~
+To have ECS recognize a new image the cdk must be redeployed.

--- a/docs/source/cdk/ialirt-setup.rst
+++ b/docs/source/cdk/ialirt-setup.rst
@@ -37,18 +37,18 @@ We will have a versioned image and latest image in the Nexus repo. The versioned
 
 #. Tag with the Nexus registry URL::
 
-    docker tag ialirt:X.Y docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
-    docker tag ialirt:X.Y docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest
+    docker tag ialirt:X.Y docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt-<primary or secondary>:X.Y
+    docker tag ialirt:X.Y docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt-<primary or secondary>:latest
 
 #. Push the image::
 
-    docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
-    docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest
+    docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt-<primary or secondary>:X.Y
+    docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt-<primary or secondary>:latest
 #. Images may be viewed on the Nexus website: https://artifacts.pdmz.lasp.colorado.edu
 #. To verify that the latest image and the most recent version image are the same, run the following and compare the image IDs::
 
-    docker inspect --format='{{.Id}}' docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y
-    docker inspect --format='{{.Id}}' docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest
+    docker inspect --format='{{.Id}}' docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt-<primary or secondary>:X.Y
+    docker inspect --format='{{.Id}}' docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt-<primary or secondary>:latest
 
 CDK Deployment
 ~~~~~~~~~~~~~

--- a/docs/source/cdk/index.rst
+++ b/docs/source/cdk/index.rst
@@ -8,3 +8,4 @@ CDK Development
     cdk-deployment-personal-aws
     backup-deploy
     s3-replication
+    ialirt-setup

--- a/tests/test-data/ialirt_ec2/Dockerfile
+++ b/tests/test-data/ialirt_ec2/Dockerfile
@@ -1,19 +1,3 @@
-# This code is used to Dockerize test_app.py. The workflow is as follows:
-# 1. Check that you are not already logged in by running `cat ~/.docker/config.json` and ensuring that neither
-# Nexus registry URL is in the list of logged in registries.
-# 2. Run `docker login docker-registry.pdmz.lasp.colorado.edu` (you will be prompted for your WebIAM username and password).
-# Your `~/.docker/config.json` file should now contain a reference to the registry url.
-# 3. `docker build -t my-image-primary:dev --rm . --no-cache`
-# 4. `docker tag my-image-primary:dev docker-registry.pdmz.lasp.colorado.edu/ialirt/my-image-primary:dev`
-# 5. `docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/my-image-primary:dev`
-
-# To run and test locally:
-# 1. `docker build -t my-image-<primary or secondary> --rm .`
-# 2. `docker run -it --privileged -e AWS_PROFILE=<profile> -v /dev/macfuse0:/dev/macfuse0
-# -v ~/.aws:/root/.aws -p <port>:<port> my-image-<primary or secondary>`
-# 3. http://localhost:<port> to see the "Hello World." message.
-# http://localhost:<port>/list to see the list of files in the mounted S3 bucket.
-
 FROM python:3.10
 COPY . /app
 


### PR DESCRIPTION
# Change Summary

## Overview
This is documentation for how to use secrets manager, nexus, versioning, and having the ecs recognize the new image.

## New Files
- ialirt-setup.rst
   - how to use secrets manager, nexus, versioning, and having the ecs recognize the new image.

## Updated Files
- index.rst
   - added ialirt-setup.rst

## Note
ialirt_processing_construct.py will need to be updated in the next pr to have the ability to retrieve the most recent version.