### PR TITLE
I-ALiRT: Add a way to delete stack despite using autoscaling

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -270,6 +270,8 @@ class IalirtProcessing(Construct):
             self,
             f"AsgCapacityProvider{processing_name}",
             auto_scaling_group=auto_scaling_group,
+            enable_managed_termination_protection=False,
+            enable_managed_scaling=False,
         )
 
         self.ecs_cluster.add_asg_capacity_provider(capacity_provider)


### PR DESCRIPTION
# Change Summary

## Overview
Previously you had to manually go in and delete the autoscaling groups before you destroyed the Stack. This allows the stack to be destroyed without that manual process.

## Updated Files
- ialirt_processing_construct
   - update the AsgCapacityProvider so that (1) the ECS can terminate ASG even if EC2 is running tasks and (2) avoid potential issues with automated scaling during cdk destroy.


## Testing
This now destroys the stack: cdk destroy --context account_name="lcs" IalirtStack
