### PR TITLE
Update HIT dependencies for L1B and L2

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/dependency_config.csv
@@ -60,9 +60,11 @@ hi, l1b, 45sensor-de, hi, l1c, 45sensor-pset, HARD, DOWNSTREAM
 # <---- HIT Dependencies ---->
 
 hit, l0, raw, hit, l1a, all, HARD, DOWNSTREAM
-
-hit, l1a, sci, hit, l1b, sci, HARD, DOWNSTREAM
-hit, l1a, hk, hit, l1b, hk, HARD, DOWNSTREAM
+hit, l0, raw, hit, l1b, hk, HARD, DOWNSTREAM
+hit, l1a, count-rates, hit, l1b, all, HARD, DOWNSTREAM
+hit, l1b, standard-rates, hit, l2, standard-fluxes, HARD, DOWNSTREAM
+hit, l1b, summed-rates, hit, l2, summed-fluxes, HARD, DOWNSTREAM
+hit, l1b, sectored-rates, hit, l2, sectored-fluxes, HARD, DOWNSTREAM
 
 # <---- IDEX Dependencies ---->
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -43,7 +43,7 @@ def _populate_file_catalog(session):
             file_path="/path/to/file2",
             instrument="hit",
             data_level="l0",
-            descriptor="sci",
+            descriptor="raw",
             start_date=datetime(2024, 1, 1),
             version="v001",
             extension="pkts",
@@ -154,14 +154,14 @@ def test_get_file(session):
 
 def test_get_downstream_dependencies(session):
     "Tests get_downstream_dependencies function."
-    filename = "imap_hit_l1a_sci_20240101_v001.cdf"
+    filename = "imap_hit_l1a_count-rates_20240101_v001.cdf"
     file_params = ScienceFilePath.extract_filename_components(filename)
 
     complete_dependents = get_downstream_dependencies(session, file_params)
     expected_complete_dependent = {
         "instrument": "hit",
         "data_level": "l1b",
-        "descriptor": "sci",
+        "descriptor": "all",
         "version": "v001",
         "start_date": "20240101",
     }


### PR DESCRIPTION
Updated HIT dependencies for L1B and L2 data products

## Updated Files
- dependency_config.csv
   - updated HIT dependencies
- test_batch_starter.py
   - update HIT parameters

