### PR TITLE
Update imap-data-access version

### DIFF
--- a/lambda_layer/python/requirements.txt
+++ b/lambda_layer/python/requirements.txt
@@ -154,8 +154,8 @@ greenlet==3.0.3 ; python_version >= "3.9" and python_version < "4" and (platform
 idna==3.6 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
-imap-data-access==0.10.1 ; python_version >= "3.9" and python_version < "4" \
-    --hash=sha256:54a65d2a220fe82bba08290c4d8fa5cb3aa58ff587230d2f4b2f544ef1bb0f67
+imap-data-access==0.11.0 ; python_version >= "3.9" and python_version < "4" \
+    --hash=sha256:f778876415633223069160e8ff764d33aaa9cbdbc803a5ba0ab99bba59d240e9
 psycopg2-binary==2.9.9 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:03ef7df18daf2c4c07e2695e8cfd5ee7f748a1d54d802330985a78d2a5a6dca9 \
     --hash=sha256:0a602ea5aff39bb9fac6308e9c9d82b9a35c2bf288e184a816002c9fae930b77 \

--- a/poetry.lock
+++ b/poetry.lock
@@ -735,12 +735,12 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.10.1"
+version = "0.11.0"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap_data_access-0.10.1.tar.gz", hash = "sha256:54a65d2a220fe82bba08290c4d8fa5cb3aa58ff587230d2f4b2f544ef1bb0f67"},
+    {file = "imap_data_access-0.11.0.tar.gz", hash = "sha256:f778876415633223069160e8ff764d33aaa9cbdbc803a5ba0ab99bba59d240e9"},
 ]
 
 [package.extras]
@@ -1967,4 +1967,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "fc232f6df87dd13d389f444e9a14aa0195326bb141b9da103598f7ecf246c6a1"
+content-hash = "32873894ce450f1ce2ccd0ca58b52443f3d3a554552169af5728dd2992d8a2f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ pydata-sphinx-theme = {version="^0.13.3", optional=true}
 aws-cdk-lib = ">=2.141.0,<3.0.0"
 "aws-cdk.aws-lambda-python-alpha" = "^2.141.0a0"
 constructs = ">=10.0.0,<11.0.0"
-imap-data-access = ">=0.10.1"
+imap-data-access = ">=0.11.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "==0.2.1"


### PR DESCRIPTION
# Change Summary
closes #385 

## Overview
To enable spin and repoint upload, I only had to make updates to `imap-data-access`. Rest was taken care of by current upload API lambda.

## Updated Files
- lambda_layer/python/requirements.txt
- poetry.lock
- pyproject.toml


