### PR TITLE
Remove and update SPICE files ingestion and how it's written to EFS

### DIFF
--- a/sds_data_manager/constructs/efs_construct.py
+++ b/sds_data_manager/constructs/efs_construct.py
@@ -174,7 +174,7 @@ class EFSWriteLambda(Construct):
         )
 
         # This access point is used by other resources to read from EFS
-        lambda_mount_path = "/mnt/spice"
+        spice_mount_path = "/mnt/spice"
 
         self.efs_spice_ingest_lambda = aws_lambda.Function(
             self,
@@ -191,12 +191,12 @@ class EFSWriteLambda(Construct):
             vpc=vpc,
             # Mount EFS access point to /mnt/data within the lambda
             filesystem=aws_lambda.FileSystem.from_efs_access_point(
-                efs_construct.spice_access_point, lambda_mount_path
+                efs_construct.spice_access_point, spice_mount_path
             ),
             timeout=Duration.minutes(1),
             architecture=aws_lambda.Architecture.ARM_64,
             environment={
-                "EFS_MOUNT_PATH": lambda_mount_path,
+                "EFS_SPICE_MOUNT_PATH": spice_mount_path,
             },
         )
 


### PR DESCRIPTION
# Change Summary
close #387 

## Overview
Removed old symlink implementation. Updated SPICE ingest lambda to write and keep same folder structure defined in imap-data-access. To answer question about how to get kernels that covers input times or latest kernel, this will be addressed in https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/690

## Updated Files
- sds_data_manager/constructs/efs_construct.py
   - minor name updates
- sds_data_manager/lambda_code/efs_lambda/lambda_function.py
   - code that updates write EFS lamda

