### PR TITLE
Instructions for SSH for OpsSW/IT

### DIFF
--- a/docs/source/cdk/ialirt-ssh-access.rst
+++ b/docs/source/cdk/ialirt-ssh-access.rst
@@ -1,0 +1,66 @@
+I-ALiRT IT SSH Access
+==================
+
+Create IAM Role for IT
+~~~~~~~~~
+SDC will have already created key-pairs and associated them with the EC2 instances. Note each keypair is required to be restricted::
+
+    chmod 600 <keypair-name.pem>
+
+SDC will create the IAM user, attach the AmazonSSMFullAccess Policy, and securely provide access keys for the user::
+
+    aws iam create-user --user-name <user>
+    aws iam attach-user-policy --user-name <user> --policy-arn arn:aws:iam::aws:policy/AmazonSSMFullAccess
+    aws iam create-access-key --user-name <user>
+
+IT should then follow the directions in Section "Existing User" on this page:
+:ref:`aws-setup`
+
+Setting Up IT SSH Key Pair
+~~~~~~~~~
+
+IT will generate a SSH key pair on their machine::
+
+    ssh-keygen -t rsa -b 2048 -f ~/.ssh/ialirt_key
+
+This command will create two files: a private key (rsa_name) and a public key (rsa_name.pub). IT will keep the private key secure and send the SDC the public key. The SDC will start a Services Systems Manager (SSM) session::
+
+    aws ssm start-session --target <EC2 instance ID> --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"host":["127.0.0.1"],"portNumber":["22"]}'
+
+This command will result in a port being opened (as printed in the terminal). The SDC will use their .pem file to SSH into the EC2 instance::
+
+    ssh -i <keypair-name.pem> -p <port> ec2-user@127.0.0.1
+
+Once logged in change directories::
+
+    cd ~/.ssh
+
+And paste the public key at the end of the authorized_keys file. Ensure the .ssh directory and authorized_keys file have the correct permissions::
+
+    vi authorized_keys
+
+- Press i to enter insert mode.
+- Use the arrow keys to navigate to the end of the file
+- Press Enter to create a new line below the existing key.
+- Copy the new public key to your clipboard and paste it into the file.
+- Press Esc. Type :wq and press Enter.
+Ensure the .ssh directory and authorized_keys file have the correct permissions::
+
+    chmod 700 ~/.ssh
+    chmod 600 ~/.ssh/authorized_keys
+
+IT should now be able to connect to the EC2 instance using their private key::
+
+    aws ssm start-session --target <EC2 instance ID> --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"host":["127.0.0.1"],"portNumber":["22"]}’
+    ssh -i <rsa_name> -p <port> ec2-user@127.0.0.1
+
+Now any command required to connect to rsync can be performed.
+To exit the ssh session, type exit and press Enter.
+To exit the SSM session::
+
+    aws ssm describe-sessions --state Active
+
+Note the session id then::
+
+    aws ssm terminate-session --session-id <session-id>
+

--- a/docs/source/cdk/index.rst
+++ b/docs/source/cdk/index.rst
@@ -9,3 +9,4 @@ CDK Development
     backup-deploy
     s3-replication
     ialirt-setup
+    ialirt-ssh-access

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -252,6 +252,7 @@ class IalirtProcessing(Construct):
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             vpc=self.vpc,
             desired_capacity=1,
+            key_name=f"keypair-{processing_name.lower()}",
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)


### PR DESCRIPTION
# Change Summary

## Overview
OpsSW needs to use rsync to retrieve raw record files being created in their container running in an ECS task on an EC2 instance. Each EC2 instance is located in a security group and private subnet. They can only be accessed by the Network Load Balancer. This is best practice for production. So I had to consider a few options for how OpsSW can access their raw record files.

**1. Make the private subnet -> public subnet and then allow traffic from a specific LASP IP range and port.**

**Advantages**
* Simplest solution. Requires almost no changes.
* Direct SSH access without additional configuration steps.
* Familiar process: Uses standard, well-understood SSH mechanisms.

**Disadvantages**
* Compromises security: Exposing the subnet as public increases the attack surface and goes against production best practices. (this was the deciding factor)

**2. Use Services Systems Manager (SSM) to create a session that would allow ssh access.**

**Advantages**
* Enhanced security: No public IP exposure; access is tunneled through private SSM sessions.
* For Long-Lived Sessions: SSM is better as it supports up to 12 hours for a single session, with a more flexible idle timeout.
* Free
* Simple implementation
* Can be monitored using CloudTrail or CloudWatch

**Disadvantages**
* Requires an IAM user or role: OpsSW or IT needs an AWS IAM user or role with appropriate permissions (e.g., AmazonSSMFullAccess).
* Timeout after 24 hours (non-idle); 20 min (idle)

**3. Use EC2 Instance Connect Endpoint (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-with-ec2-instance-connect-endpoint.html)**

**Advantages**
* Enhanced security: Keeps instances in private subnets without requiring a public IP.
* Only incurs charges for the endpoint's network usage.
* Can be monitored using CloudWatch/CloudTrail
* No .pem File Required

**Disadvantages**
* Requires AWS IAM permissions for users who need SSH access.
* Requires creating an interface endpoint in the VPC, which adds some complexity to the infrastructure setup (changes in cdk code)
* For Quick Temporary Access: EC2 Instance Connect is simpler for short-term access, but the 1-hour TCP connection limit and 60-second key validity require repeated setup for longer tasks.

Based on the advantages/disadvantages list I selected Option 2. I will need to make certain that the SSM timeout is acceptable with OpsSW/IT. **UPDATE**: Melissa Mantey thinks the timeout will not be an issue for rsync. I think we will move forward with the plan as described in this ticket unless any other objections/issues arise.

## New Files
- ialirt-ssh-access.rst
   - readthedocs description of using SSM

## Updated Files
- ialirt_processing_construct.py
   - associated keypair to EC2
- index.rst
   - update for readthedocs

## Testing
After deploying the code I went through the steps and verified they all work.
