### PR TITLE
I-ALiRT: Added Download API

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -61,7 +61,7 @@ class IalirtApiManager(Construct):
         query_api_lambda = lambda_.Function(
             self,
             id="IAlirtCodeQueryAPILambda",
-            function_name="query-api-handler",
+            function_name="ialirt-query-api-handler",
             code=code,
             handler="IAlirtCode.ialirt_query_api.lambda_handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
@@ -83,4 +83,30 @@ class IalirtApiManager(Construct):
             route="ialirt-log-query",
             http_method="GET",
             lambda_function=query_api_lambda,
+        )
+
+        # download API lambda
+        download_api = lambda_.Function(
+            self,
+            id="IAlirtCodeDownloadAPILambda",
+            function_name="ialirt-download-api-handler",
+            code=code,
+            handler="SDSCode.api_lambdas.download_api.lambda_handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            timeout=cdk.Duration.minutes(1),
+            environment={
+                "S3_BUCKET": data_bucket.bucket_name,
+                "REGION": env.region,
+            },
+            layers=layers,
+            architecture=lambda_.Architecture.ARM_64,
+        )
+
+        download_api.add_to_role_policy(s3_read_policy)
+
+        api.add_route(
+            route="ialirt-log-download",
+            http_method="GET",
+            lambda_function=download_api,
+            use_path_params=True,
         )


### PR DESCRIPTION
# Change Summary

## Overview
I am reusing the SDS download api for I-ALiRT so OpsSW can download their logs.

## Updated Files
- ialirt_api_manager_construct
   - Added capability to download files from ialirt s3 bucket.

## Testing
Gateway/APIs/RestApi/Stages
Invoke URL

And then in Postman:
https://yj7oheruq3.execute-api.us-west-2.amazonaws.com/prod/ialirt-log-download/logs/flight_iois_1.log.2024-045T16-54-46_123456.txt

This displayed the contents of flight_iois_1.log.2024-045T16-54-46_123456.txt.