### PR TITLE
I-ALiRT: Domain Name Update

### DIFF
--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -4,8 +4,10 @@ Sets up api gateway, creates routes, and creates methods that are linked to the
 lambda function.
 
 An example of the format of the url: https://api.prod.imap-mission.com/query
-https://ialirtapi.prod.imap-mission.com/ialirt-log-query
+https://ialirt.prod.imap-mission.com/ialirt-log-query
 """
+
+from typing import Optional
 
 from aws_cdk import Duration, aws_sns
 from aws_cdk import aws_apigateway as apigw
@@ -27,9 +29,9 @@ class ApiGateway(Construct):
         self,
         scope: Construct,
         construct_id: str,
-        domain_construct: DomainConstruct = None,
-        certificate: acm.Certificate = None,
-        ialirt_prefix: str = "",
+        domain_construct: Optional[DomainConstruct] = None,
+        certificate: Optional[acm.Certificate] = None,
+        ialirt_prefix: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Construct the API Gateway Construct.
@@ -42,7 +44,7 @@ class ApiGateway(Construct):
             A unique string identifier for this construct.
         domain_construct : DomainConstruct, Optional
             Custom domain, hosted zone
-        certificate : Certificate
+        certificate : Certificate, Optional
             SSL certificate for the custom domain (in the same region)
         ialirt_prefix : str
             Prefix for ialirt domain, Optional
@@ -51,7 +53,13 @@ class ApiGateway(Construct):
 
         """
         super().__init__(scope, construct_id, **kwargs)
-        self.prefix = ialirt_prefix
+
+        if ialirt_prefix is not None:
+            self.prefix = ialirt_prefix
+            self.lowercase_prefix = f"{ialirt_prefix.lower()}"
+        else:
+            self.prefix = ""
+            self.lowercase_prefix = "api"
 
         # Create a single API Gateway
         self.api = apigw.RestApi(
@@ -67,7 +75,7 @@ class ApiGateway(Construct):
             custom_domain = apigw.DomainName(
                 self,
                 f"{self.prefix}RestAPI-DomainName",
-                domain_name=f"{self.prefix.lower()}api.{domain_construct.domain_name}",
+                domain_name=f"{self.lowercase_prefix}.{domain_construct.domain_name}",
                 certificate=certificate,
                 endpoint_type=apigw.EndpointType.REGIONAL,
             )
@@ -85,7 +93,7 @@ class ApiGateway(Construct):
                 self,
                 f"{self.prefix}RestAPI-AliasRecord",
                 zone=domain_construct.hosted_zone,
-                record_name=f"{self.prefix.lower()}api.{domain_construct.domain_name}",
+                record_name=f"{self.lowercase_prefix}.{domain_construct.domain_name}",
                 target=route53.RecordTarget.from_alias(
                     targets.ApiGatewayDomain(custom_domain)
                 ),
@@ -117,8 +125,8 @@ class ApiGateway(Construct):
         # Define the alarm
         cloudwatch_alarm = cloudwatch.Alarm(
             self,
-            f"{self.prefix.lower()}apigw-cw-alarm",
-            alarm_name=f"{self.prefix.lower()}apigw-cw-alarm",
+            f"{self.lowercase_prefix}gw-cw-alarm",
+            alarm_name=f"{self.lowercase_prefix}gw-cw-alarm",
             alarm_description="API Gateway latency is high",
             actions_enabled=True,
             metric=metric,

--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -4,6 +4,7 @@ Sets up api gateway, creates routes, and creates methods that are linked to the
 lambda function.
 
 An example of the format of the url: https://api.prod.imap-mission.com/query
+https://ialirtapi.prod.imap-mission.com/ialirt-log-query
 """
 
 from aws_cdk import Duration, aws_sns
@@ -28,6 +29,7 @@ class ApiGateway(Construct):
         construct_id: str,
         domain_construct: DomainConstruct = None,
         certificate: acm.Certificate = None,
+        ialirt_prefix: str = "",
         **kwargs,
     ) -> None:
         """Construct the API Gateway Construct.
@@ -42,17 +44,20 @@ class ApiGateway(Construct):
             Custom domain, hosted zone
         certificate : Certificate
             SSL certificate for the custom domain (in the same region)
+        ialirt_prefix : str
+            Prefix for ialirt domain, Optional
         kwargs : dict
             Keyword arguments
 
         """
         super().__init__(scope, construct_id, **kwargs)
+        self.prefix = ialirt_prefix
 
         # Create a single API Gateway
         self.api = apigw.RestApi(
             self,
-            "RestApi",
-            rest_api_name="RestApi",
+            f"{self.prefix}RestApi",
+            rest_api_name=f"{self.prefix}RestApi",
             description="API Gateway for lambda function endpoints.",
             endpoint_types=[apigw.EndpointType.REGIONAL],
         )
@@ -61,8 +66,8 @@ class ApiGateway(Construct):
         if domain_construct is not None:
             custom_domain = apigw.DomainName(
                 self,
-                "RestAPI-DomainName",
-                domain_name=f"api.{domain_construct.domain_name}",
+                f"{self.prefix}RestAPI-DomainName",
+                domain_name=f"{self.prefix.lower()}api.{domain_construct.domain_name}",
                 certificate=certificate,
                 endpoint_type=apigw.EndpointType.REGIONAL,
             )
@@ -70,7 +75,7 @@ class ApiGateway(Construct):
             # Route domain to api gateway
             apigw.BasePathMapping(
                 self,
-                "RestAPI-BasePathMapping",
+                f"{self.prefix}RestAPI-BasePathMapping",
                 domain_name=custom_domain,
                 rest_api=self.api,
             )
@@ -78,9 +83,9 @@ class ApiGateway(Construct):
             # Add record to Route53
             route53.ARecord(
                 self,
-                "RestAPI-AliasRecord",
+                f"{self.prefix}RestAPI-AliasRecord",
                 zone=domain_construct.hosted_zone,
-                record_name=f"api.{domain_construct.domain_name}",
+                record_name=f"{self.prefix.lower()}api.{domain_construct.domain_name}",
                 target=route53.RecordTarget.from_alias(
                     targets.ApiGatewayDomain(custom_domain)
                 ),
@@ -112,8 +117,8 @@ class ApiGateway(Construct):
         # Define the alarm
         cloudwatch_alarm = cloudwatch.Alarm(
             self,
-            "apigw-cw-alarm",
-            alarm_name="apigw-cw-alarm",
+            f"{self.prefix.lower()}apigw-cw-alarm",
+            alarm_name=f"{self.prefix.lower()}apigw-cw-alarm",
             alarm_description="API Gateway latency is high",
             actions_enabled=True,
             metric=metric,

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -281,7 +281,7 @@ def build_sds(
         construct_id="IAlirtApiGateway",
         domain_construct=domain,
         certificate=root_certificate,
-        ialirt_prefix="Ialirt",
+        ialirt_prefix="IAlirt",
     )
     ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
 

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -281,6 +281,7 @@ def build_sds(
         construct_id="IAlirtApiGateway",
         domain_construct=domain,
         certificate=root_certificate,
+        ialirt_prefix="Ialirt",
     )
     ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
 


### PR DESCRIPTION
# Change Summary

## Overview
I-ALiRT requires an API for querying and downloading logs. I was hoping to simply use the same domain name. However, when I was deploying I had the error:

**api.dev.imap-mission.com already exists in stack arn:aws:cloudformation:us-west-2:449431850278:stack/SDCStack/3699d440-7217-11ef-9abe-06fae9ea8027**

This small change just allows me to create a new domain for ialirt.

## Updated Files
- stackbuilder.py
   - Updated to allow "Ialirt" string to be passed to api_gateway_construct.ApiGateway
- api_gateway_construct.py
   - Allows prefix to be added for I-ALiRT.

## Testing
Deployed both SDC and I-ALiRT Stacks.
