### PR TITLE
I-ALiRT: Add Outbound Test

### DIFF
--- a/tests/test-data/ialirt_ec2/Dockerfile
+++ b/tests/test-data/ialirt_ec2/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app
 WORKDIR /app
 
 # Install Flask
-RUN pip install flask
+RUN pip install flask requests
 
 # Non-interactive frontend for apt-get
 ARG DEBIAN_FRONTEND=noninteractive

--- a/tests/test-data/ialirt_ec2/test_app.py
+++ b/tests/test-data/ialirt_ec2/test_app.py
@@ -9,6 +9,7 @@ defined ports, allowing external access for testing.
 import multiprocessing
 import os
 
+import requests
 from flask import Flask
 
 
@@ -28,6 +29,18 @@ def create_app(port):
         """List files in the mounted S3 bucket."""
         files = os.listdir("/mnt/s3/packets")
         return "<br>".join(files)
+
+    @app.route("/test")
+    def outbound_test():
+        """Test outbound connectivity by making an HTTP request."""
+        try:
+            response = requests.get("https://api.ipify.org?format=json", timeout=5)
+            return (
+                f"Port {port}: Outbound request successful! "
+                f"Public IP: {response.json()['ip']}"
+            )
+        except requests.RequestException as e:
+            return f"Port {port}: Outbound request failed! Error: {e!s}", 500
 
     app.run(host="0.0.0.0", port=port)
 


### PR DESCRIPTION
# Change Summary

## Overview
We had a needed to make certain that data from the OpsSW container allows outbound traffic. 

OpsSW also needed an IP address to use so that they can permit traffic into the Bluenet. They are transferring data from their container to the Bluenet using rsync. 

This test can now be used to verify the Elastic IP (EIP) associated with the NAT Gateway that is handling outbound traffic from ECS tasks as well as test that outbound traffic is permitted.

## Updated Files
- Dockerfile
   - install requests
- test_app.py
   - added outbound test

## Testing
Compared address in Elastic IPs to output of the DNS name/test

Saw output:
Port 1234: Outbound request successful! Public IP: <IP address not shown for confidentiality>