### PR TITLE
I-ALiRT: Combine tools NLB and ECS Cluster

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -86,7 +86,7 @@ class IalirtProcessing(Construct):
         )
 
         # Only allow traffic from the NLB security group
-        for port in self.ports:
+        for port in self.primary_ports + self.secondary_ports:
             self.ecs_security_group.add_ingress_rule(
                 peer=ec2.Peer.security_group_id(
                     self.load_balancer_security_group.security_group_id
@@ -108,7 +108,7 @@ class IalirtProcessing(Construct):
         # Allow inbound and outbound traffic from a specific port and IP.
         # IPs: LASP IP, BlueNet (tlm relay)
         ip_ranges = ["128.138.131.0/24", "198.118.1.14/32"]
-        for port in self.ports:
+        for port in self.primary_ports + self.secondary_ports:
             for ip_range in ip_ranges:
                 self.load_balancer_security_group.add_ingress_rule(
                     # TODO: allow IP addresses from partners
@@ -189,7 +189,7 @@ class IalirtProcessing(Construct):
         # Network Load Balancers (NLB).
         primary_task_definition = ecs.Ec2TaskDefinition(
             self,
-            f"IalirtTaskDef",
+            f"IalirtTaskDefPrimary",
             network_mode=ecs.NetworkMode.AWS_VPC,
             task_role=task_role,
             execution_role=execution_role,
@@ -197,7 +197,7 @@ class IalirtProcessing(Construct):
 
         secondary_task_definition = ecs.Ec2TaskDefinition(
             self,
-            f"IalirtTaskDef",
+            f"IalirtTaskDefSecondary",
             network_mode=ecs.NetworkMode.AWS_VPC,
             task_role=task_role,
             execution_role=execution_role,
@@ -380,38 +380,38 @@ class IalirtProcessing(Construct):
                 ),
             )
 
-            # Create a listener for each port specified
-            for port in self.secondary_ports:
-                listener = self.load_balancer.add_listener(
-                    f"ListenerSecondary{port}",
-                    port=port,
-                    protocol=elbv2.Protocol.TCP,
-                )
-
-                # Register the ECS service as a target for the listener
-                listener.add_targets(
-                    f"TargetSecondary{port}",
-                    port=port,
-                    # Specifies the container and port to route traffic to.
-                    targets=[
-                        self.secondary_ecs_service.load_balancer_target(
-                            container_name=f"IalirtContainerSecondary",
-                            container_port=port,
-                        )
-                    ],
-                    # Configures health checks for the target group
-                    # to ensure traffic is routed only to healthy ECS tasks.
-                    health_check=elbv2.HealthCheck(
-                        enabled=True,
-                        port=str(port),
-                        protocol=elbv2.Protocol.TCP,
-                    ),
-                )
-
-            # This simply prints the DNS name of the
-            # load balancer in the terminal.
-            CfnOutput(
-                self,
-                f"LoadBalancerDNS{port}",
-                value=f"http://{self.load_balancer.load_balancer_dns_name}:{port}",
+        # Create a listener for each port specified
+        for port in self.secondary_ports:
+            listener = self.load_balancer.add_listener(
+                f"ListenerSecondary{port}",
+                port=port,
+                protocol=elbv2.Protocol.TCP,
             )
+
+            # Register the ECS service as a target for the listener
+            listener.add_targets(
+                f"TargetSecondary{port}",
+                port=port,
+                # Specifies the container and port to route traffic to.
+                targets=[
+                    self.secondary_ecs_service.load_balancer_target(
+                        container_name=f"IalirtContainerSecondary",
+                        container_port=port,
+                     )
+                ],
+                # Configures health checks for the target group
+                # to ensure traffic is routed only to healthy ECS tasks.
+                health_check=elbv2.HealthCheck(
+                    enabled=True,
+                    port=str(port),
+                    protocol=elbv2.Protocol.TCP,
+                ),
+            )
+
+        # This simply prints the DNS name of the
+        # load balancer in the terminal.
+        CfnOutput(
+            self,
+            f"LoadBalancerDNS",
+            value=f"http://{self.load_balancer.load_balancer_dns_name}",
+        )

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -26,8 +26,8 @@ class IalirtProcessing(Construct):
         scope: Construct,
         construct_id: str,
         vpc: ec2.Vpc,
-        processing_name: str,
-        ports: list[int],
+        primary_ports: list[int],
+        secondary_ports: list[int],
         ialirt_bucket: s3.Bucket,
         secret_name: str,
         **kwargs,
@@ -42,9 +42,9 @@ class IalirtProcessing(Construct):
             A unique string identifier for this construct.
         vpc : ec2.Vpc
             VPC into which to put the resources that require networking.
-        processing_name : str
-            Name of the processing stack.
-        ports : list[int]
+        primary_ports : list[int]
+            List of ports to listen on for incoming traffic and used by container.
+        secondary_ports : list[int]
             List of ports to listen on for incoming traffic and used by container.
         ialirt_bucket: s3.Bucket
             S3 bucket
@@ -56,29 +56,30 @@ class IalirtProcessing(Construct):
         """
         super().__init__(scope, construct_id, **kwargs)
 
-        self.ports = ports
+        self.primary_ports = primary_ports
+        self.secondary_ports = secondary_ports
         self.vpc = vpc
         self.s3_bucket_name = ialirt_bucket.bucket_name
         self.secret_name = secret_name
 
         # Add a security group in which network load balancer will reside
-        self.create_load_balancer_security_group(processing_name)
+        self.create_load_balancer_security_group()
 
         # Create security group in which containers will reside
-        self.create_ecs_security_group(processing_name)
+        self.create_ecs_security_group()
 
         # Add an ecs service and cluster for each container
-        self.add_compute_resources(processing_name)
+        self.add_compute_resources()
         # Add load balancer for each container
-        self.add_load_balancer(processing_name)
+        self.add_load_balancer()
         # Add autoscaling for each container
-        self.add_autoscaling(processing_name)
+        self.add_autoscaling()
 
-    def create_ecs_security_group(self, processing_name):
+    def create_ecs_security_group(self):
         """Create and return a security group for containers."""
         self.ecs_security_group = ec2.SecurityGroup(
             self,
-            f"IalirtEcsSecurityGroup{processing_name}",
+            f"IalirtEcsSecurityGroup",
             vpc=self.vpc,
             description="Security group for Ialirt",
             allow_all_outbound=True,
@@ -94,12 +95,12 @@ class IalirtProcessing(Construct):
                 description=f"Allow inbound traffic from the NLB on TCP port {port}",
             )
 
-    def create_load_balancer_security_group(self, processing_name):
+    def create_load_balancer_security_group(self):
         """Create and return a security group for load balancers."""
         # Create a security group for the NLB
         self.load_balancer_security_group = ec2.SecurityGroup(
             self,
-            f"NLBSecurityGroup{processing_name}",
+            f"NLBSecurityGroup",
             vpc=self.vpc,
             description="Security group for the Ialirt NLB",
         )
@@ -123,22 +124,22 @@ class IalirtProcessing(Construct):
                     description=f"Allow outbound traffic on TCP port {port}",
                 )
 
-    def add_compute_resources(self, processing_name):
+    def add_compute_resources(self):
         """Add ECS compute resources for a container."""
         # ECS Cluster manages EC2 instances on which containers are deployed.
         self.ecs_cluster = ecs.Cluster(
-            self, f"IalirtCluster{processing_name}", vpc=self.vpc
+            self, f"IalirtCluster", vpc=self.vpc
         )
 
         # Retrieve the secret from Secrets Manager.
         nexus_secret = secretsmanager.Secret.from_secret_name_v2(
-            self, f"NexusCredentials{processing_name}", secret_name=self.secret_name
+            self, f"NexusCredentials", secret_name=self.secret_name
         )
 
         # Add IAM role and policy for S3 access
         task_role = iam.Role(
             self,
-            f"IalirtTaskRole{processing_name}",
+            f"IalirtTaskRole",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
         )
 
@@ -162,7 +163,7 @@ class IalirtProcessing(Construct):
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html
         execution_role = iam.Role(
             self,
-            f"IalirtTaskExecutionRole{processing_name}",
+            f"IalirtTaskExecutionRole",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name(
@@ -188,7 +189,7 @@ class IalirtProcessing(Construct):
         # Network Load Balancers (NLB).
         task_definition = ecs.Ec2TaskDefinition(
             self,
-            f"IalirtTaskDef{processing_name}",
+            f"IalirtTaskDef",
             network_mode=ecs.NetworkMode.AWS_VPC,
             task_role=task_role,
             execution_role=execution_role,
@@ -196,10 +197,10 @@ class IalirtProcessing(Construct):
 
         # Adds a container to the ECS task definition
         # Logging is configured to use AWS CloudWatch Logs.
-        container = task_definition.add_container(
-            f"IalirtContainer{processing_name}",
+        primary_container = task_definition.add_container(
+            f"IalirtContainerPrimary",
             image=ecs.ContainerImage.from_registry(
-                f"lasp-registry.colorado.edu/ialirt/ialirt-{processing_name.lower()}:latest",
+                f"lasp-registry.colorado.edu/ialirt/ialirt-primary:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:
@@ -207,7 +208,25 @@ class IalirtProcessing(Construct):
             # aws-cdk-lib.aws_ecs.TaskDefinition.html#cpu
             memory_limit_mib=1024,
             cpu=512,
-            logging=ecs.LogDrivers.aws_logs(stream_prefix=f"Ialirt{processing_name}"),
+            logging=ecs.LogDrivers.aws_logs(stream_prefix=f"Ialirtprimary"),
+            environment={"S3_BUCKET": self.s3_bucket_name},
+            # Ensure the ECS task is running in privileged mode,
+            # which allows the container to use FUSE.
+            privileged=True,
+        )
+
+        secondary_container = task_definition.add_container(
+            f"IalirtContainerSecondary",
+            image=ecs.ContainerImage.from_registry(
+                f"lasp-registry.colorado.edu/ialirt/ialirt-secondary:latest",
+                credentials=nexus_secret,
+            ),
+            # Allowable values:
+            # https://docs.aws.amazon.com/cdk/api/v2/docs/
+            # aws-cdk-lib.aws_ecs.TaskDefinition.html#cpu
+            memory_limit_mib=1024,
+            cpu=512,
+            logging=ecs.LogDrivers.aws_logs(stream_prefix=f"Ialirtsecondary"),
             environment={"S3_BUCKET": self.s3_bucket_name},
             # Ensure the ECS task is running in privileged mode,
             # which allows the container to use FUSE.
@@ -217,20 +236,28 @@ class IalirtProcessing(Construct):
         # Map ports to container
         # NLB needs to know which port on the EC2 instances
         # it should forward the traffic to
-        for port in self.ports:
+        for port in self.primary_ports:
             port_mapping = ecs.PortMapping(
                 container_port=port,
                 host_port=port,
                 protocol=ecs.Protocol.TCP,
             )
-            container.add_port_mappings(port_mapping)
+            primary_container.add_port_mappings(port_mapping)
+
+        for port in self.secondary_ports:
+            port_mapping = ecs.PortMapping(
+                container_port=port,
+                host_port=port,
+                protocol=ecs.Protocol.TCP,
+            )
+            secondary_container.add_port_mappings(port_mapping)
 
         # ECS Service is a configuration that
         # ensures application can run and maintain
         # instances of a task definition.
-        self.ecs_service = ecs.Ec2Service(
+        self.primary_ecs_service = ecs.Ec2Service(
             self,
-            f"IalirtService{processing_name}",
+            f"IalirtServicePrimary",
             cluster=self.ecs_cluster,
             task_definition=task_definition,
             security_groups=[self.ecs_security_group],
@@ -240,20 +267,34 @@ class IalirtProcessing(Construct):
             ),
         )
 
-    def add_autoscaling(self, processing_name):
+        self.secondary_ecs_service = ecs.Ec2Service(
+            self,
+            f"IalirtServiceSecondary",
+            cluster=self.ecs_cluster,
+            task_definition=task_definition,
+            security_groups=[self.ecs_security_group],
+            desired_count=1,
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
+            ),
+        )
+
+    def add_autoscaling(self):
         """Add autoscaling resources."""
         # This auto-scaling group is used to manage the
         # number of instances in the ECS cluster. If an instance
         # becomes unhealthy, the auto-scaling group will replace it.
+
+        # TODO
         auto_scaling_group = autoscaling.AutoScalingGroup(
             self,
-            f"AutoScalingGroup{processing_name}",
+            f"AutoScalingGroup",
             instance_type=ec2.InstanceType.of(
                 ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL
             ),
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             vpc=self.vpc,
-            desired_capacity=1,
+            desired_capacity=2,
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
@@ -270,7 +311,7 @@ class IalirtProcessing(Construct):
         # EC2 instances based on the requirements of ECS tasks
         capacity_provider = ecs.AsgCapacityProvider(
             self,
-            f"AsgCapacityProvider{processing_name}",
+            f"AsgCapacityProvider",
             auto_scaling_group=auto_scaling_group,
             enable_managed_termination_protection=False,
             enable_managed_scaling=False,
@@ -281,18 +322,22 @@ class IalirtProcessing(Construct):
         # Allow inbound traffic from the Network Load Balancer
         # to the security groups associated with the EC2 instances
         # within the Auto Scaling Group.
-        for port in self.ports:
+        for port in self.primary_ports:
+            auto_scaling_group.connections.allow_from(
+                self.load_balancer, ec2.Port.tcp(port)
+            )
+        for port in self.secondary_ports:
             auto_scaling_group.connections.allow_from(
                 self.load_balancer, ec2.Port.tcp(port)
             )
 
-    def add_load_balancer(self, processing_name):
+    def add_load_balancer(self):
         """Add a load balancer for a container."""
         # Create the Network Load Balancer and
         # place it in a public subnet.
         self.load_balancer = elbv2.NetworkLoadBalancer(
             self,
-            f"IalirtNLB{processing_name}",
+            f"IalirtNLB",
             vpc=self.vpc,
             security_groups=[self.load_balancer_security_group],
             internet_facing=True,
@@ -300,21 +345,21 @@ class IalirtProcessing(Construct):
         )
 
         # Create a listener for each port specified
-        for port in self.ports:
+        for port in self.primary_ports:
             listener = self.load_balancer.add_listener(
-                f"Listener{processing_name}{port}",
+                f"ListenerPrimary{port}",
                 port=port,
                 protocol=elbv2.Protocol.TCP,
             )
 
             # Register the ECS service as a target for the listener
             listener.add_targets(
-                f"Target{processing_name}{port}",
+                f"TargetPrimary{port}",
                 port=port,
                 # Specifies the container and port to route traffic to.
                 targets=[
                     self.ecs_service.load_balancer_target(
-                        container_name=f"IalirtContainer{processing_name}",
+                        container_name=f"IalirtContainerPrimary",
                         container_port=port,
                     )
                 ],
@@ -327,10 +372,66 @@ class IalirtProcessing(Construct):
                 ),
             )
 
+            # Create a listener for each port specified
+            for port in self.primary_ports:
+                listener = self.load_balancer.add_listener(
+                    f"ListenerPrimary{port}",
+                    port=port,
+                    protocol=elbv2.Protocol.TCP,
+                )
+
+                # Register the ECS service as a target for the listener
+                listener.add_targets(
+                    f"TargetPrimary{port}",
+                    port=port,
+                    # Specifies the container and port to route traffic to.
+                    targets=[
+                        self.ecs_service.load_balancer_target(
+                            container_name=f"IalirtContainerPrimary",
+                            container_port=port,
+                        )
+                    ],
+                    # Configures health checks for the target group
+                    # to ensure traffic is routed only to healthy ECS tasks.
+                    health_check=elbv2.HealthCheck(
+                        enabled=True,
+                        port=str(port),
+                        protocol=elbv2.Protocol.TCP,
+                    ),
+                )
+
+            # Create a listener for each port specified
+            for port in self.secondary_ports:
+                listener = self.load_balancer.add_listener(
+                    f"ListenerSecondary{port}",
+                    port=port,
+                    protocol=elbv2.Protocol.TCP,
+                )
+
+                # Register the ECS service as a target for the listener
+                listener.add_targets(
+                    f"TargetSecondary{port}",
+                    port=port,
+                    # Specifies the container and port to route traffic to.
+                    targets=[
+                        self.ecs_service.load_balancer_target(
+                            container_name=f"IalirtContainerSecondary",
+                            container_port=port,
+                        )
+                    ],
+                    # Configures health checks for the target group
+                    # to ensure traffic is routed only to healthy ECS tasks.
+                    health_check=elbv2.HealthCheck(
+                        enabled=True,
+                        port=str(port),
+                        protocol=elbv2.Protocol.TCP,
+                    ),
+                )
+
             # This simply prints the DNS name of the
             # load balancer in the terminal.
             CfnOutput(
                 self,
-                f"LoadBalancerDNS{processing_name}{port}",
+                f"LoadBalancerDNS{port}",
                 value=f"http://{self.load_balancer.load_balancer_dns_name}:{port}",
             )

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -79,7 +79,7 @@ class IalirtProcessing(Construct):
         """Create and return a security group for containers."""
         self.ecs_security_group = ec2.SecurityGroup(
             self,
-            f"IalirtEcsSecurityGroup",
+            "IalirtEcsSecurityGroup",
             vpc=self.vpc,
             description="Security group for Ialirt",
             allow_all_outbound=True,
@@ -100,7 +100,7 @@ class IalirtProcessing(Construct):
         # Create a security group for the NLB
         self.load_balancer_security_group = ec2.SecurityGroup(
             self,
-            f"NLBSecurityGroup",
+            "NLBSecurityGroup",
             vpc=self.vpc,
             description="Security group for the Ialirt NLB",
         )
@@ -127,19 +127,17 @@ class IalirtProcessing(Construct):
     def add_compute_resources(self):
         """Add ECS compute resources for a container."""
         # ECS Cluster manages EC2 instances on which containers are deployed.
-        self.ecs_cluster = ecs.Cluster(
-            self, f"IalirtCluster", vpc=self.vpc
-        )
+        self.ecs_cluster = ecs.Cluster(self, "IalirtCluster", vpc=self.vpc)
 
         # Retrieve the secret from Secrets Manager.
         nexus_secret = secretsmanager.Secret.from_secret_name_v2(
-            self, f"NexusCredentials", secret_name=self.secret_name
+            self, "NexusCredentials", secret_name=self.secret_name
         )
 
         # Add IAM role and policy for S3 access
         task_role = iam.Role(
             self,
-            f"IalirtTaskRole",
+            "IalirtTaskRole",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
         )
 
@@ -163,7 +161,7 @@ class IalirtProcessing(Construct):
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html
         execution_role = iam.Role(
             self,
-            f"IalirtTaskExecutionRole",
+            "IalirtTaskExecutionRole",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name(
@@ -189,7 +187,7 @@ class IalirtProcessing(Construct):
         # Network Load Balancers (NLB).
         primary_task_definition = ecs.Ec2TaskDefinition(
             self,
-            f"IalirtTaskDefPrimary",
+            "IalirtTaskDefPrimary",
             network_mode=ecs.NetworkMode.AWS_VPC,
             task_role=task_role,
             execution_role=execution_role,
@@ -197,7 +195,7 @@ class IalirtProcessing(Construct):
 
         secondary_task_definition = ecs.Ec2TaskDefinition(
             self,
-            f"IalirtTaskDefSecondary",
+            "IalirtTaskDefSecondary",
             network_mode=ecs.NetworkMode.AWS_VPC,
             task_role=task_role,
             execution_role=execution_role,
@@ -206,17 +204,17 @@ class IalirtProcessing(Construct):
         # Adds a container to the ECS task definition
         # Logging is configured to use AWS CloudWatch Logs.
         primary_container = primary_task_definition.add_container(
-            f"IalirtContainerPrimary",
+            "IalirtContainerPrimary",
             image=ecs.ContainerImage.from_registry(
-                f"lasp-registry.colorado.edu/ialirt/ialirt-primary:latest",
+                "lasp-registry.colorado.edu/ialirt/ialirt-primary:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:
             # https://docs.aws.amazon.com/cdk/api/v2/docs/
             # aws-cdk-lib.aws_ecs.TaskDefinition.html#cpu
-            memory_limit_mib=1024,
-            cpu=512,
-            logging=ecs.LogDrivers.aws_logs(stream_prefix=f"Ialirtprimary"),
+            memory_limit_mib=512,
+            cpu=256,
+            logging=ecs.LogDrivers.aws_logs(stream_prefix="Ialirtprimary"),
             environment={"S3_BUCKET": self.s3_bucket_name},
             # Ensure the ECS task is running in privileged mode,
             # which allows the container to use FUSE.
@@ -224,17 +222,17 @@ class IalirtProcessing(Construct):
         )
 
         secondary_container = secondary_task_definition.add_container(
-            f"IalirtContainerSecondary",
+            "IalirtContainerSecondary",
             image=ecs.ContainerImage.from_registry(
-                f"lasp-registry.colorado.edu/ialirt/ialirt-secondary:latest",
+                "lasp-registry.colorado.edu/ialirt/ialirt-secondary:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:
             # https://docs.aws.amazon.com/cdk/api/v2/docs/
             # aws-cdk-lib.aws_ecs.TaskDefinition.html#cpu
-            memory_limit_mib=1024,
-            cpu=512,
-            logging=ecs.LogDrivers.aws_logs(stream_prefix=f"Ialirtsecondary"),
+            memory_limit_mib=512,
+            cpu=256,
+            logging=ecs.LogDrivers.aws_logs(stream_prefix="Ialirtsecondary"),
             environment={"S3_BUCKET": self.s3_bucket_name},
             # Ensure the ECS task is running in privileged mode,
             # which allows the container to use FUSE.
@@ -265,7 +263,7 @@ class IalirtProcessing(Construct):
         # instances of a task definition.
         self.primary_ecs_service = ecs.Ec2Service(
             self,
-            f"IalirtServicePrimary",
+            "IalirtServicePrimary",
             cluster=self.ecs_cluster,
             task_definition=primary_task_definition,
             security_groups=[self.ecs_security_group],
@@ -277,7 +275,7 @@ class IalirtProcessing(Construct):
 
         self.secondary_ecs_service = ecs.Ec2Service(
             self,
-            f"IalirtServiceSecondary",
+            "IalirtServiceSecondary",
             cluster=self.ecs_cluster,
             task_definition=secondary_task_definition,
             security_groups=[self.ecs_security_group],
@@ -294,9 +292,9 @@ class IalirtProcessing(Construct):
         # becomes unhealthy, the auto-scaling group will replace it.
         auto_scaling_group = autoscaling.AutoScalingGroup(
             self,
-            f"AutoScalingGroup",
+            "AutoScalingGroup",
             instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL
+                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.LARGE
             ),
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             vpc=self.vpc,
@@ -317,7 +315,7 @@ class IalirtProcessing(Construct):
         # EC2 instances based on the requirements of ECS tasks
         capacity_provider = ecs.AsgCapacityProvider(
             self,
-            f"AsgCapacityProvider",
+            "AsgCapacityProvider",
             auto_scaling_group=auto_scaling_group,
             enable_managed_termination_protection=False,
             enable_managed_scaling=False,
@@ -339,7 +337,7 @@ class IalirtProcessing(Construct):
         # place it in a public subnet.
         self.load_balancer = elbv2.NetworkLoadBalancer(
             self,
-            f"IalirtNLB",
+            "IalirtNLB",
             vpc=self.vpc,
             security_groups=[self.load_balancer_security_group],
             internet_facing=True,
@@ -361,7 +359,7 @@ class IalirtProcessing(Construct):
                 # Specifies the container and port to route traffic to.
                 targets=[
                     self.primary_ecs_service.load_balancer_target(
-                        container_name=f"IalirtContainerPrimary",
+                        container_name="IalirtContainerPrimary",
                         container_port=port,
                     )
                 ],
@@ -389,9 +387,9 @@ class IalirtProcessing(Construct):
                 # Specifies the container and port to route traffic to.
                 targets=[
                     self.secondary_ecs_service.load_balancer_target(
-                        container_name=f"IalirtContainerSecondary",
+                        container_name="IalirtContainerSecondary",
                         container_port=port,
-                     )
+                    )
                 ],
                 # Configures health checks for the target group
                 # to ensure traffic is routed only to healthy ECS tasks.
@@ -406,6 +404,6 @@ class IalirtProcessing(Construct):
         # load balancer in the terminal.
         CfnOutput(
             self,
-            f"LoadBalancerDNS",
+            "LoadBalancerDNS",
             value=f"http://{self.load_balancer.load_balancer_dns_name}",
         )

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -292,8 +292,6 @@ class IalirtProcessing(Construct):
         # This auto-scaling group is used to manage the
         # number of instances in the ECS cluster. If an instance
         # becomes unhealthy, the auto-scaling group will replace it.
-
-        # TODO
         auto_scaling_group = autoscaling.AutoScalingGroup(
             self,
             f"AutoScalingGroup",
@@ -330,11 +328,7 @@ class IalirtProcessing(Construct):
         # Allow inbound traffic from the Network Load Balancer
         # to the security groups associated with the EC2 instances
         # within the Auto Scaling Group.
-        for port in self.primary_ports:
-            auto_scaling_group.connections.allow_from(
-                self.load_balancer, ec2.Port.tcp(port)
-            )
-        for port in self.secondary_ports:
+        for port in self.primary_ports + self.secondary_ports:
             auto_scaling_group.connections.allow_from(
                 self.load_balancer, ec2.Port.tcp(port)
             )

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -187,7 +187,15 @@ class IalirtProcessing(Construct):
         # Specifies the networking mode as AWS_VPC.
         # ECS tasks in AWS_VPC mode can be registered with
         # Network Load Balancers (NLB).
-        task_definition = ecs.Ec2TaskDefinition(
+        primary_task_definition = ecs.Ec2TaskDefinition(
+            self,
+            f"IalirtTaskDef",
+            network_mode=ecs.NetworkMode.AWS_VPC,
+            task_role=task_role,
+            execution_role=execution_role,
+        )
+
+        secondary_task_definition = ecs.Ec2TaskDefinition(
             self,
             f"IalirtTaskDef",
             network_mode=ecs.NetworkMode.AWS_VPC,
@@ -197,7 +205,7 @@ class IalirtProcessing(Construct):
 
         # Adds a container to the ECS task definition
         # Logging is configured to use AWS CloudWatch Logs.
-        primary_container = task_definition.add_container(
+        primary_container = primary_task_definition.add_container(
             f"IalirtContainerPrimary",
             image=ecs.ContainerImage.from_registry(
                 f"lasp-registry.colorado.edu/ialirt/ialirt-primary:latest",
@@ -215,7 +223,7 @@ class IalirtProcessing(Construct):
             privileged=True,
         )
 
-        secondary_container = task_definition.add_container(
+        secondary_container = secondary_task_definition.add_container(
             f"IalirtContainerSecondary",
             image=ecs.ContainerImage.from_registry(
                 f"lasp-registry.colorado.edu/ialirt/ialirt-secondary:latest",
@@ -259,7 +267,7 @@ class IalirtProcessing(Construct):
             self,
             f"IalirtServicePrimary",
             cluster=self.ecs_cluster,
-            task_definition=task_definition,
+            task_definition=primary_task_definition,
             security_groups=[self.ecs_security_group],
             desired_count=1,
             vpc_subnets=ec2.SubnetSelection(
@@ -271,7 +279,7 @@ class IalirtProcessing(Construct):
             self,
             f"IalirtServiceSecondary",
             cluster=self.ecs_cluster,
-            task_definition=task_definition,
+            task_definition=secondary_task_definition,
             security_groups=[self.ecs_security_group],
             desired_count=1,
             vpc_subnets=ec2.SubnetSelection(
@@ -358,7 +366,7 @@ class IalirtProcessing(Construct):
                 port=port,
                 # Specifies the container and port to route traffic to.
                 targets=[
-                    self.ecs_service.load_balancer_target(
+                    self.primary_ecs_service.load_balancer_target(
                         container_name=f"IalirtContainerPrimary",
                         container_port=port,
                     )
@@ -371,34 +379,6 @@ class IalirtProcessing(Construct):
                     protocol=elbv2.Protocol.TCP,
                 ),
             )
-
-            # Create a listener for each port specified
-            for port in self.primary_ports:
-                listener = self.load_balancer.add_listener(
-                    f"ListenerPrimary{port}",
-                    port=port,
-                    protocol=elbv2.Protocol.TCP,
-                )
-
-                # Register the ECS service as a target for the listener
-                listener.add_targets(
-                    f"TargetPrimary{port}",
-                    port=port,
-                    # Specifies the container and port to route traffic to.
-                    targets=[
-                        self.ecs_service.load_balancer_target(
-                            container_name=f"IalirtContainerPrimary",
-                            container_port=port,
-                        )
-                    ],
-                    # Configures health checks for the target group
-                    # to ensure traffic is routed only to healthy ECS tasks.
-                    health_check=elbv2.HealthCheck(
-                        enabled=True,
-                        port=str(port),
-                        protocol=elbv2.Protocol.TCP,
-                    ),
-                )
 
             # Create a listener for each port specified
             for port in self.secondary_ports:
@@ -414,7 +394,7 @@ class IalirtProcessing(Construct):
                     port=port,
                     # Specifies the container and port to route traffic to.
                     targets=[
-                        self.ecs_service.load_balancer_target(
+                        self.secondary_ecs_service.load_balancer_target(
                             container_name=f"IalirtContainerSecondary",
                             container_port=port,
                         )

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -307,16 +307,15 @@ def build_sds(
     ports = {"Primary": [1234, 1235], "Secondary": [1236]}
     ialirt_secret_name = "nexus-credentials"  # noqa
 
-    for primary_or_secondary in ports:
-        ialirt_processing_construct.IalirtProcessing(
-            scope=ialirt_stack,
-            construct_id=f"IalirtProcessing{primary_or_secondary}",
-            vpc=networking.vpc,
-            processing_name=primary_or_secondary,
-            ports=ports[primary_or_secondary],
-            ialirt_bucket=ialirt_bucket.ialirt_bucket,
-            secret_name=ialirt_secret_name,
-        )
+    ialirt_processing_construct.IalirtProcessing(
+        scope=ialirt_stack,
+        construct_id="IalirtProcessing",
+        vpc=networking.vpc,
+        primary_ports=ports["Primary"],
+        secondary_ports=ports["Secondary"],
+        ialirt_bucket=ialirt_bucket.ialirt_bucket,
+        secret_name=ialirt_secret_name,
+    )
 
     # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
     ialirt_ingest_lambda_construct.IalirtIngestLambda(


### PR DESCRIPTION
# Change Summary

## Overview
We had redundant resources for packet ingest (NLB, ECS Cluster, Security Groups, ASG). Previously we did this so we would have completely redundant constructs (previously they were stacks) that could be deployed separately while maintain functionality. This was important because ECS does not automatically update when a new image is pushed. However, the following command can be used to update the Service.

aws ecs update-service
--cluster IalirtCluster
--service IalirtServicePrimary
--force-new-deployment
--deployment-configuration maximumPercent=200,minimumHealthyPercent=100 > /dev/null

Example:
aws ecs update-service --cluster IalirtStack-IalirtProcessingIalirtCluster239B5309-KRdDdZpnvLuN --service IalirtStack-IalirtProcessingIalirtServicePrimaryService78BD5E27-nJxaEvhNxhtD --force-new-deployment --deployment-configuration maximumPercent=200,minimumHealthyPercent=100 > /dev/null

This PR removes the redundant tools while maintaining the same functionality as it did previously.

## Updated Files
- stackbuilder.py
   - Removes for loop to create the two redundant  systems
- ialirt_processing_construct.py
   - Remove redundant security groups (ECS security group and Load Balancer security group)
   - Switched to a single Network Load Balancer and ECS Cluster
   - Switched to a single Autoscaling Group
   - Increased size of EC2 instance being used

## Testing
- Confirmed that the code deployed and had same functionality as previously
- Changed test container in Nexus and then implemented the example command shown above. Verified that the task restarted seamlessly by visiting:

http://ialirt-ialir-9tlmgrxkquge-848bbb993d4f9ede.elb.us-west-2.amazonaws.com:1234

and seeing: "Hello from Port 1234 - update!" in my browser window