### PR TITLE
I-ALiRT: Added IP range for BlueNet (tlm relay)

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -104,22 +104,24 @@ class IalirtProcessing(Construct):
             description="Security group for the Ialirt NLB",
         )
 
-        # Allow inbound and outbound traffic from a specific port and
-        # LASP IP address range.
+        # Allow inbound and outbound traffic from a specific port and IP.
+        # IPs: LASP IP, BlueNet (tlm relay)
+        ip_ranges = ["128.138.131.0/24", "198.118.1.14/32"]
         for port in self.ports:
-            self.load_balancer_security_group.add_ingress_rule(
-                # TODO: allow IP addresses from partners
-                peer=ec2.Peer.ipv4("128.138.131.0/24"),
-                connection=ec2.Port.tcp(port),
-                description=f"Allow inbound traffic on TCP port {port}",
-            )
+            for ip_range in ip_ranges:
+                self.load_balancer_security_group.add_ingress_rule(
+                    # TODO: allow IP addresses from partners
+                    peer=ec2.Peer.ipv4(ip_range),
+                    connection=ec2.Port.tcp(port),
+                    description=f"Allow inbound traffic on TCP port {port}",
+                )
 
-            # Allow outbound traffic.
-            self.load_balancer_security_group.add_egress_rule(
-                peer=ec2.Peer.ipv4("128.138.131.0/24"),
-                connection=ec2.Port.tcp(port),
-                description=f"Allow outbound traffic on TCP port {port}",
-            )
+                # Allow outbound traffic.
+                self.load_balancer_security_group.add_egress_rule(
+                    peer=ec2.Peer.ipv4(ip_range),
+                    connection=ec2.Port.tcp(port),
+                    description=f"Allow outbound traffic on TCP port {port}",
+                )
 
     def add_compute_resources(self, processing_name):
         """Add ECS compute resources for a container."""


### PR DESCRIPTION
# Change Summary

## Overview
There is a way for data streams to enter the container running in ECS and that is to open it up to a specific IP range. OpsSW needs to connect to the ECS via tlm relay (the Blue Net). Previously, I only had an IP range for LASP. Now we also have it for tlm relay.

## Updated Files
- ialirt_processing_construct.py
   - Added a IP range that allows traffic from tlm relay to the container running in ECS.
