### PR TITLE
I-ALiRT - Reduced to single running container

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -183,7 +183,7 @@ class IalirtProcessing(Construct):
         # Network Load Balancers (NLB).
         task_definition = ecs.Ec2TaskDefinition(
             self,
-            f"IalirtTaskDef",
+            "IalirtTaskDef",
             network_mode=ecs.NetworkMode.AWS_VPC,
             task_role=task_role,
             execution_role=execution_role,
@@ -192,9 +192,9 @@ class IalirtProcessing(Construct):
         # Adds a container to the ECS task definition
         # Logging is configured to use AWS CloudWatch Logs.
         container = task_definition.add_container(
-            f"IalirtContainer",
+            "IalirtContainer",
             image=ecs.ContainerImage.from_registry(
-                f"lasp-registry.colorado.edu/ialirt/ialirt-primary:latest",
+                "lasp-registry.colorado.edu/ialirt/ialirt:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:
@@ -225,7 +225,7 @@ class IalirtProcessing(Construct):
         # instances of a task definition.
         self.ecs_service = ecs.Ec2Service(
             self,
-            f"IalirtService",
+            "IalirtService",
             cluster=self.ecs_cluster,
             task_definition=task_definition,
             security_groups=[self.ecs_security_group],
@@ -309,7 +309,7 @@ class IalirtProcessing(Construct):
                 # Specifies the container and port to route traffic to.
                 targets=[
                     self.ecs_service.load_balancer_target(
-                        container_name=f"IalirtContainer",
+                        container_name="IalirtContainer",
                         container_port=port,
                     )
                 ],

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -26,7 +26,6 @@ class IalirtProcessing(Construct):
         scope: Construct,
         construct_id: str,
         vpc: ec2.Vpc,
-        processing_name: str,
         ports: list[int],
         ialirt_bucket: s3.Bucket,
         secret_name: str,
@@ -42,8 +41,6 @@ class IalirtProcessing(Construct):
             A unique string identifier for this construct.
         vpc : ec2.Vpc
             VPC into which to put the resources that require networking.
-        processing_name : str
-            Name of the processing stack.
         ports : list[int]
             List of ports to listen on for incoming traffic and used by container.
         ialirt_bucket: s3.Bucket
@@ -62,23 +59,23 @@ class IalirtProcessing(Construct):
         self.secret_name = secret_name
 
         # Add a security group in which network load balancer will reside
-        self.create_load_balancer_security_group(processing_name)
+        self.create_load_balancer_security_group()
 
         # Create security group in which containers will reside
-        self.create_ecs_security_group(processing_name)
+        self.create_ecs_security_group()
 
         # Add an ecs service and cluster for each container
-        self.add_compute_resources(processing_name)
+        self.add_compute_resources()
         # Add load balancer for each container
-        self.add_load_balancer(processing_name)
+        self.add_load_balancer()
         # Add autoscaling for each container
-        self.add_autoscaling(processing_name)
+        self.add_autoscaling()
 
-    def create_ecs_security_group(self, processing_name):
+    def create_ecs_security_group(self):
         """Create and return a security group for containers."""
         self.ecs_security_group = ec2.SecurityGroup(
             self,
-            f"IalirtEcsSecurityGroup{processing_name}",
+            "IalirtEcsSecurityGroup",
             vpc=self.vpc,
             description="Security group for Ialirt",
             allow_all_outbound=True,
@@ -94,12 +91,12 @@ class IalirtProcessing(Construct):
                 description=f"Allow inbound traffic from the NLB on TCP port {port}",
             )
 
-    def create_load_balancer_security_group(self, processing_name):
+    def create_load_balancer_security_group(self):
         """Create and return a security group for load balancers."""
         # Create a security group for the NLB
         self.load_balancer_security_group = ec2.SecurityGroup(
             self,
-            f"NLBSecurityGroup{processing_name}",
+            "NLBSecurityGroup",
             vpc=self.vpc,
             description="Security group for the Ialirt NLB",
         )
@@ -123,22 +120,20 @@ class IalirtProcessing(Construct):
                     description=f"Allow outbound traffic on TCP port {port}",
                 )
 
-    def add_compute_resources(self, processing_name):
+    def add_compute_resources(self):
         """Add ECS compute resources for a container."""
         # ECS Cluster manages EC2 instances on which containers are deployed.
-        self.ecs_cluster = ecs.Cluster(
-            self, f"IalirtCluster{processing_name}", vpc=self.vpc
-        )
+        self.ecs_cluster = ecs.Cluster(self, "IalirtCluster", vpc=self.vpc)
 
         # Retrieve the secret from Secrets Manager.
         nexus_secret = secretsmanager.Secret.from_secret_name_v2(
-            self, f"NexusCredentials{processing_name}", secret_name=self.secret_name
+            self, "NexusCredentials", secret_name=self.secret_name
         )
 
         # Add IAM role and policy for S3 access
         task_role = iam.Role(
             self,
-            f"IalirtTaskRole{processing_name}",
+            "IalirtTaskRole",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
         )
 
@@ -162,7 +157,7 @@ class IalirtProcessing(Construct):
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html
         execution_role = iam.Role(
             self,
-            f"IalirtTaskExecutionRole{processing_name}",
+            "IalirtTaskExecutionRole",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name(
@@ -188,7 +183,7 @@ class IalirtProcessing(Construct):
         # Network Load Balancers (NLB).
         task_definition = ecs.Ec2TaskDefinition(
             self,
-            f"IalirtTaskDef{processing_name}",
+            f"IalirtTaskDef",
             network_mode=ecs.NetworkMode.AWS_VPC,
             task_role=task_role,
             execution_role=execution_role,
@@ -197,17 +192,17 @@ class IalirtProcessing(Construct):
         # Adds a container to the ECS task definition
         # Logging is configured to use AWS CloudWatch Logs.
         container = task_definition.add_container(
-            f"IalirtContainer{processing_name}",
+            f"IalirtContainer",
             image=ecs.ContainerImage.from_registry(
-                f"lasp-registry.colorado.edu/ialirt/ialirt-{processing_name.lower()}:latest",
+                f"lasp-registry.colorado.edu/ialirt/ialirt-primary:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:
             # https://docs.aws.amazon.com/cdk/api/v2/docs/
             # aws-cdk-lib.aws_ecs.TaskDefinition.html#cpu
-            memory_limit_mib=1024,
-            cpu=512,
-            logging=ecs.LogDrivers.aws_logs(stream_prefix=f"Ialirt{processing_name}"),
+            memory_limit_mib=512,
+            cpu=256,
+            logging=ecs.LogDrivers.aws_logs(stream_prefix="Ialirtsecondary"),
             environment={"S3_BUCKET": self.s3_bucket_name},
             # Ensure the ECS task is running in privileged mode,
             # which allows the container to use FUSE.
@@ -230,7 +225,7 @@ class IalirtProcessing(Construct):
         # instances of a task definition.
         self.ecs_service = ecs.Ec2Service(
             self,
-            f"IalirtService{processing_name}",
+            f"IalirtService",
             cluster=self.ecs_cluster,
             task_definition=task_definition,
             security_groups=[self.ecs_security_group],
@@ -240,20 +235,20 @@ class IalirtProcessing(Construct):
             ),
         )
 
-    def add_autoscaling(self, processing_name):
+    def add_autoscaling(self):
         """Add autoscaling resources."""
         # This auto-scaling group is used to manage the
         # number of instances in the ECS cluster. If an instance
         # becomes unhealthy, the auto-scaling group will replace it.
         auto_scaling_group = autoscaling.AutoScalingGroup(
             self,
-            f"AutoScalingGroup{processing_name}",
+            "AutoScalingGroup",
             instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL
+                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.LARGE
             ),
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             vpc=self.vpc,
-            desired_capacity=1,
+            desired_capacity=2,
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
@@ -270,7 +265,7 @@ class IalirtProcessing(Construct):
         # EC2 instances based on the requirements of ECS tasks
         capacity_provider = ecs.AsgCapacityProvider(
             self,
-            f"AsgCapacityProvider{processing_name}",
+            "AsgCapacityProvider",
             auto_scaling_group=auto_scaling_group,
             enable_managed_termination_protection=False,
             enable_managed_scaling=False,
@@ -286,13 +281,13 @@ class IalirtProcessing(Construct):
                 self.load_balancer, ec2.Port.tcp(port)
             )
 
-    def add_load_balancer(self, processing_name):
+    def add_load_balancer(self):
         """Add a load balancer for a container."""
         # Create the Network Load Balancer and
         # place it in a public subnet.
         self.load_balancer = elbv2.NetworkLoadBalancer(
             self,
-            f"IalirtNLB{processing_name}",
+            "IalirtNLB",
             vpc=self.vpc,
             security_groups=[self.load_balancer_security_group],
             internet_facing=True,
@@ -302,19 +297,19 @@ class IalirtProcessing(Construct):
         # Create a listener for each port specified
         for port in self.ports:
             listener = self.load_balancer.add_listener(
-                f"Listener{processing_name}{port}",
+                f"Listener{port}",
                 port=port,
                 protocol=elbv2.Protocol.TCP,
             )
 
             # Register the ECS service as a target for the listener
             listener.add_targets(
-                f"Target{processing_name}{port}",
+                f"Target{port}",
                 port=port,
                 # Specifies the container and port to route traffic to.
                 targets=[
                     self.ecs_service.load_balancer_target(
-                        container_name=f"IalirtContainer{processing_name}",
+                        container_name=f"IalirtContainer",
                         container_port=port,
                     )
                 ],
@@ -331,6 +326,6 @@ class IalirtProcessing(Construct):
             # load balancer in the terminal.
             CfnOutput(
                 self,
-                f"LoadBalancerDNS{processing_name}{port}",
+                f"LoadBalancerDNS{port}",
                 value=f"http://{self.load_balancer.load_balancer_dns_name}:{port}",
             )

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -26,8 +26,8 @@ class IalirtProcessing(Construct):
         scope: Construct,
         construct_id: str,
         vpc: ec2.Vpc,
-        primary_ports: list[int],
-        secondary_ports: list[int],
+        processing_name: str,
+        ports: list[int],
         ialirt_bucket: s3.Bucket,
         secret_name: str,
         **kwargs,
@@ -42,9 +42,9 @@ class IalirtProcessing(Construct):
             A unique string identifier for this construct.
         vpc : ec2.Vpc
             VPC into which to put the resources that require networking.
-        primary_ports : list[int]
-            List of ports to listen on for incoming traffic and used by container.
-        secondary_ports : list[int]
+        processing_name : str
+            Name of the processing stack.
+        ports : list[int]
             List of ports to listen on for incoming traffic and used by container.
         ialirt_bucket: s3.Bucket
             S3 bucket
@@ -56,37 +56,36 @@ class IalirtProcessing(Construct):
         """
         super().__init__(scope, construct_id, **kwargs)
 
-        self.primary_ports = primary_ports
-        self.secondary_ports = secondary_ports
+        self.ports = ports
         self.vpc = vpc
         self.s3_bucket_name = ialirt_bucket.bucket_name
         self.secret_name = secret_name
 
         # Add a security group in which network load balancer will reside
-        self.create_load_balancer_security_group()
+        self.create_load_balancer_security_group(processing_name)
 
         # Create security group in which containers will reside
-        self.create_ecs_security_group()
+        self.create_ecs_security_group(processing_name)
 
         # Add an ecs service and cluster for each container
-        self.add_compute_resources()
+        self.add_compute_resources(processing_name)
         # Add load balancer for each container
-        self.add_load_balancer()
+        self.add_load_balancer(processing_name)
         # Add autoscaling for each container
-        self.add_autoscaling()
+        self.add_autoscaling(processing_name)
 
-    def create_ecs_security_group(self):
+    def create_ecs_security_group(self, processing_name):
         """Create and return a security group for containers."""
         self.ecs_security_group = ec2.SecurityGroup(
             self,
-            "IalirtEcsSecurityGroup",
+            f"IalirtEcsSecurityGroup{processing_name}",
             vpc=self.vpc,
             description="Security group for Ialirt",
             allow_all_outbound=True,
         )
 
         # Only allow traffic from the NLB security group
-        for port in self.primary_ports + self.secondary_ports:
+        for port in self.ports:
             self.ecs_security_group.add_ingress_rule(
                 peer=ec2.Peer.security_group_id(
                     self.load_balancer_security_group.security_group_id
@@ -95,12 +94,12 @@ class IalirtProcessing(Construct):
                 description=f"Allow inbound traffic from the NLB on TCP port {port}",
             )
 
-    def create_load_balancer_security_group(self):
+    def create_load_balancer_security_group(self, processing_name):
         """Create and return a security group for load balancers."""
         # Create a security group for the NLB
         self.load_balancer_security_group = ec2.SecurityGroup(
             self,
-            "NLBSecurityGroup",
+            f"NLBSecurityGroup{processing_name}",
             vpc=self.vpc,
             description="Security group for the Ialirt NLB",
         )
@@ -108,7 +107,7 @@ class IalirtProcessing(Construct):
         # Allow inbound and outbound traffic from a specific port and IP.
         # IPs: LASP IP, BlueNet (tlm relay)
         ip_ranges = ["128.138.131.0/24", "198.118.1.14/32"]
-        for port in self.primary_ports + self.secondary_ports:
+        for port in self.ports:
             for ip_range in ip_ranges:
                 self.load_balancer_security_group.add_ingress_rule(
                     # TODO: allow IP addresses from partners
@@ -124,20 +123,22 @@ class IalirtProcessing(Construct):
                     description=f"Allow outbound traffic on TCP port {port}",
                 )
 
-    def add_compute_resources(self):
+    def add_compute_resources(self, processing_name):
         """Add ECS compute resources for a container."""
         # ECS Cluster manages EC2 instances on which containers are deployed.
-        self.ecs_cluster = ecs.Cluster(self, "IalirtCluster", vpc=self.vpc)
+        self.ecs_cluster = ecs.Cluster(
+            self, f"IalirtCluster{processing_name}", vpc=self.vpc
+        )
 
         # Retrieve the secret from Secrets Manager.
         nexus_secret = secretsmanager.Secret.from_secret_name_v2(
-            self, "NexusCredentials", secret_name=self.secret_name
+            self, f"NexusCredentials{processing_name}", secret_name=self.secret_name
         )
 
         # Add IAM role and policy for S3 access
         task_role = iam.Role(
             self,
-            "IalirtTaskRole",
+            f"IalirtTaskRole{processing_name}",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
         )
 
@@ -161,7 +162,7 @@ class IalirtProcessing(Construct):
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html
         execution_role = iam.Role(
             self,
-            "IalirtTaskExecutionRole",
+            f"IalirtTaskExecutionRole{processing_name}",
             assumed_by=iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name(
@@ -185,17 +186,9 @@ class IalirtProcessing(Construct):
         # Specifies the networking mode as AWS_VPC.
         # ECS tasks in AWS_VPC mode can be registered with
         # Network Load Balancers (NLB).
-        primary_task_definition = ecs.Ec2TaskDefinition(
+        task_definition = ecs.Ec2TaskDefinition(
             self,
-            "IalirtTaskDefPrimary",
-            network_mode=ecs.NetworkMode.AWS_VPC,
-            task_role=task_role,
-            execution_role=execution_role,
-        )
-
-        secondary_task_definition = ecs.Ec2TaskDefinition(
-            self,
-            "IalirtTaskDefSecondary",
+            f"IalirtTaskDef{processing_name}",
             network_mode=ecs.NetworkMode.AWS_VPC,
             task_role=task_role,
             execution_role=execution_role,
@@ -203,36 +196,18 @@ class IalirtProcessing(Construct):
 
         # Adds a container to the ECS task definition
         # Logging is configured to use AWS CloudWatch Logs.
-        primary_container = primary_task_definition.add_container(
-            "IalirtContainerPrimary",
+        container = task_definition.add_container(
+            f"IalirtContainer{processing_name}",
             image=ecs.ContainerImage.from_registry(
-                "lasp-registry.colorado.edu/ialirt/ialirt-primary:latest",
+                f"lasp-registry.colorado.edu/ialirt/ialirt-{processing_name.lower()}:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:
             # https://docs.aws.amazon.com/cdk/api/v2/docs/
             # aws-cdk-lib.aws_ecs.TaskDefinition.html#cpu
-            memory_limit_mib=512,
-            cpu=256,
-            logging=ecs.LogDrivers.aws_logs(stream_prefix="Ialirtprimary"),
-            environment={"S3_BUCKET": self.s3_bucket_name},
-            # Ensure the ECS task is running in privileged mode,
-            # which allows the container to use FUSE.
-            privileged=True,
-        )
-
-        secondary_container = secondary_task_definition.add_container(
-            "IalirtContainerSecondary",
-            image=ecs.ContainerImage.from_registry(
-                "lasp-registry.colorado.edu/ialirt/ialirt-secondary:latest",
-                credentials=nexus_secret,
-            ),
-            # Allowable values:
-            # https://docs.aws.amazon.com/cdk/api/v2/docs/
-            # aws-cdk-lib.aws_ecs.TaskDefinition.html#cpu
-            memory_limit_mib=512,
-            cpu=256,
-            logging=ecs.LogDrivers.aws_logs(stream_prefix="Ialirtsecondary"),
+            memory_limit_mib=1024,
+            cpu=512,
+            logging=ecs.LogDrivers.aws_logs(stream_prefix=f"Ialirt{processing_name}"),
             environment={"S3_BUCKET": self.s3_bucket_name},
             # Ensure the ECS task is running in privileged mode,
             # which allows the container to use FUSE.
@@ -242,30 +217,22 @@ class IalirtProcessing(Construct):
         # Map ports to container
         # NLB needs to know which port on the EC2 instances
         # it should forward the traffic to
-        for port in self.primary_ports:
+        for port in self.ports:
             port_mapping = ecs.PortMapping(
                 container_port=port,
                 host_port=port,
                 protocol=ecs.Protocol.TCP,
             )
-            primary_container.add_port_mappings(port_mapping)
-
-        for port in self.secondary_ports:
-            port_mapping = ecs.PortMapping(
-                container_port=port,
-                host_port=port,
-                protocol=ecs.Protocol.TCP,
-            )
-            secondary_container.add_port_mappings(port_mapping)
+            container.add_port_mappings(port_mapping)
 
         # ECS Service is a configuration that
         # ensures application can run and maintain
         # instances of a task definition.
-        self.primary_ecs_service = ecs.Ec2Service(
+        self.ecs_service = ecs.Ec2Service(
             self,
-            "IalirtServicePrimary",
+            f"IalirtService{processing_name}",
             cluster=self.ecs_cluster,
-            task_definition=primary_task_definition,
+            task_definition=task_definition,
             security_groups=[self.ecs_security_group],
             desired_count=1,
             vpc_subnets=ec2.SubnetSelection(
@@ -273,32 +240,20 @@ class IalirtProcessing(Construct):
             ),
         )
 
-        self.secondary_ecs_service = ecs.Ec2Service(
-            self,
-            "IalirtServiceSecondary",
-            cluster=self.ecs_cluster,
-            task_definition=secondary_task_definition,
-            security_groups=[self.ecs_security_group],
-            desired_count=1,
-            vpc_subnets=ec2.SubnetSelection(
-                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
-            ),
-        )
-
-    def add_autoscaling(self):
+    def add_autoscaling(self, processing_name):
         """Add autoscaling resources."""
         # This auto-scaling group is used to manage the
         # number of instances in the ECS cluster. If an instance
         # becomes unhealthy, the auto-scaling group will replace it.
         auto_scaling_group = autoscaling.AutoScalingGroup(
             self,
-            "AutoScalingGroup",
+            f"AutoScalingGroup{processing_name}",
             instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.LARGE
+                ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL
             ),
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             vpc=self.vpc,
-            desired_capacity=2,
+            desired_capacity=1,
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
@@ -315,7 +270,7 @@ class IalirtProcessing(Construct):
         # EC2 instances based on the requirements of ECS tasks
         capacity_provider = ecs.AsgCapacityProvider(
             self,
-            "AsgCapacityProvider",
+            f"AsgCapacityProvider{processing_name}",
             auto_scaling_group=auto_scaling_group,
             enable_managed_termination_protection=False,
             enable_managed_scaling=False,
@@ -326,18 +281,18 @@ class IalirtProcessing(Construct):
         # Allow inbound traffic from the Network Load Balancer
         # to the security groups associated with the EC2 instances
         # within the Auto Scaling Group.
-        for port in self.primary_ports + self.secondary_ports:
+        for port in self.ports:
             auto_scaling_group.connections.allow_from(
                 self.load_balancer, ec2.Port.tcp(port)
             )
 
-    def add_load_balancer(self):
+    def add_load_balancer(self, processing_name):
         """Add a load balancer for a container."""
         # Create the Network Load Balancer and
         # place it in a public subnet.
         self.load_balancer = elbv2.NetworkLoadBalancer(
             self,
-            "IalirtNLB",
+            f"IalirtNLB{processing_name}",
             vpc=self.vpc,
             security_groups=[self.load_balancer_security_group],
             internet_facing=True,
@@ -345,21 +300,21 @@ class IalirtProcessing(Construct):
         )
 
         # Create a listener for each port specified
-        for port in self.primary_ports:
+        for port in self.ports:
             listener = self.load_balancer.add_listener(
-                f"ListenerPrimary{port}",
+                f"Listener{processing_name}{port}",
                 port=port,
                 protocol=elbv2.Protocol.TCP,
             )
 
             # Register the ECS service as a target for the listener
             listener.add_targets(
-                f"TargetPrimary{port}",
+                f"Target{processing_name}{port}",
                 port=port,
                 # Specifies the container and port to route traffic to.
                 targets=[
-                    self.primary_ecs_service.load_balancer_target(
-                        container_name="IalirtContainerPrimary",
+                    self.ecs_service.load_balancer_target(
+                        container_name=f"IalirtContainer{processing_name}",
                         container_port=port,
                     )
                 ],
@@ -372,38 +327,10 @@ class IalirtProcessing(Construct):
                 ),
             )
 
-        # Create a listener for each port specified
-        for port in self.secondary_ports:
-            listener = self.load_balancer.add_listener(
-                f"ListenerSecondary{port}",
-                port=port,
-                protocol=elbv2.Protocol.TCP,
+            # This simply prints the DNS name of the
+            # load balancer in the terminal.
+            CfnOutput(
+                self,
+                f"LoadBalancerDNS{processing_name}{port}",
+                value=f"http://{self.load_balancer.load_balancer_dns_name}:{port}",
             )
-
-            # Register the ECS service as a target for the listener
-            listener.add_targets(
-                f"TargetSecondary{port}",
-                port=port,
-                # Specifies the container and port to route traffic to.
-                targets=[
-                    self.secondary_ecs_service.load_balancer_target(
-                        container_name="IalirtContainerSecondary",
-                        container_port=port,
-                    )
-                ],
-                # Configures health checks for the target group
-                # to ensure traffic is routed only to healthy ECS tasks.
-                health_check=elbv2.HealthCheck(
-                    enabled=True,
-                    port=str(port),
-                    protocol=elbv2.Protocol.TCP,
-                ),
-            )
-
-        # This simply prints the DNS name of the
-        # load balancer in the terminal.
-        CfnOutput(
-            self,
-            "LoadBalancerDNS",
-            value=f"http://{self.load_balancer.load_balancer_dns_name}",
-        )

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -302,19 +302,17 @@ def build_sds(
     # )
 
     # All traffic to I-ALiRT is directed to listed container ports
-    ports = {"Primary": [1234, 1235]}  # , "Secondary": [1236]}
+    ialirt_ports = [1234, 1235]
     ialirt_secret_name = "nexus-credentials"  # noqa
 
-    for primary_or_secondary in ports:
-        ialirt_processing_construct.IalirtProcessing(
-            scope=ialirt_stack,
-            construct_id=f"IalirtProcessing{primary_or_secondary}",
-            vpc=networking.vpc,
-            processing_name=primary_or_secondary,
-            ports=ports[primary_or_secondary],
-            ialirt_bucket=ialirt_bucket.ialirt_bucket,
-            secret_name=ialirt_secret_name,
-        )
+    ialirt_processing_construct.IalirtProcessing(
+        scope=ialirt_stack,
+        construct_id="IalirtProcessing",
+        vpc=networking.vpc,
+        ports=ialirt_ports,
+        ialirt_bucket=ialirt_bucket.ialirt_bucket,
+        secret_name=ialirt_secret_name,
+    )
 
     # # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
     # ialirt_ingest_lambda_construct.IalirtIngestLambda(

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -16,9 +16,7 @@ from sds_data_manager.constructs import (
     data_bucket_construct,
     database_construct,
     efs_construct,
-    ialirt_api_manager_construct,
     ialirt_bucket_construct,
-    ialirt_ingest_lambda_construct,
     ialirt_processing_construct,
     indexer_lambda_construct,
     instrument_lambdas,
@@ -271,58 +269,59 @@ def build_sds(
     ialirt_bucket = ialirt_bucket_construct.IAlirtBucketConstruct(
         scope=ialirt_stack, construct_id="IAlirtBucket", env=env
     )
-
-    ialirt_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
-        scope=ialirt_stack,
-        id="IAlirtDependencies",
-        layer_dependencies_dir=str(layer_code_directory),
-    )
-
-    ialirt_monitoring = monitoring_construct.MonitoringConstruct(
-        scope=ialirt_stack,
-        construct_id="IAlirtMonitoringConstruct",
-    )
-
-    ialirt_api = api_gateway_construct.ApiGateway(
-        scope=ialirt_stack,
-        construct_id="IAlirtApiGateway",
-        domain_construct=domain,
-        certificate=root_certificate,
-        ialirt_prefix="IAlirt",
-    )
-    ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
-
-    ialirt_api_manager_construct.IalirtApiManager(
-        scope=ialirt_stack,
-        construct_id="IAlirtApiManager",
-        code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
-        api=ialirt_api,
-        env=env,
-        data_bucket=ialirt_bucket.ialirt_bucket,
-        vpc=networking.vpc,
-        layers=[ialirt_lambda_layer],
-    )
+    #
+    # ialirt_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
+    #     scope=ialirt_stack,
+    #     id="IAlirtDependencies",
+    #     layer_dependencies_dir=str(layer_code_directory),
+    # )
+    #
+    # ialirt_monitoring = monitoring_construct.MonitoringConstruct(
+    #     scope=ialirt_stack,
+    #     construct_id="IAlirtMonitoringConstruct",
+    # )
+    #
+    # ialirt_api = api_gateway_construct.ApiGateway(
+    #     scope=ialirt_stack,
+    #     construct_id="IAlirtApiGateway",
+    #     domain_construct=domain,
+    #     certificate=root_certificate,
+    #     ialirt_prefix="IAlirt",
+    # )
+    # ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
+    #
+    # ialirt_api_manager_construct.IalirtApiManager(
+    #     scope=ialirt_stack,
+    #     construct_id="IAlirtApiManager",
+    #     code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
+    #     api=ialirt_api,
+    #     env=env,
+    #     data_bucket=ialirt_bucket.ialirt_bucket,
+    #     vpc=networking.vpc,
+    #     layers=[ialirt_lambda_layer],
+    # )
 
     # All traffic to I-ALiRT is directed to listed container ports
-    ports = {"Primary": [1234, 1235], "Secondary": [1236]}
+    ports = {"Primary": [1234, 1235]}  # , "Secondary": [1236]}
     ialirt_secret_name = "nexus-credentials"  # noqa
 
-    ialirt_processing_construct.IalirtProcessing(
-        scope=ialirt_stack,
-        construct_id="IalirtProcessing",
-        vpc=networking.vpc,
-        primary_ports=ports["Primary"],
-        secondary_ports=ports["Secondary"],
-        ialirt_bucket=ialirt_bucket.ialirt_bucket,
-        secret_name=ialirt_secret_name,
-    )
+    for primary_or_secondary in ports:
+        ialirt_processing_construct.IalirtProcessing(
+            scope=ialirt_stack,
+            construct_id=f"IalirtProcessing{primary_or_secondary}",
+            vpc=networking.vpc,
+            processing_name=primary_or_secondary,
+            ports=ports[primary_or_secondary],
+            ialirt_bucket=ialirt_bucket.ialirt_bucket,
+            secret_name=ialirt_secret_name,
+        )
 
-    # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
-    ialirt_ingest_lambda_construct.IalirtIngestLambda(
-        scope=ialirt_stack,
-        construct_id="IalirtIngestLambda",
-        ialirt_bucket=ialirt_bucket.ialirt_bucket,
-    )
+    # # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
+    # ialirt_ingest_lambda_construct.IalirtIngestLambda(
+    #     scope=ialirt_stack,
+    #     construct_id="IalirtIngestLambda",
+    #     ialirt_bucket=ialirt_bucket.ialirt_bucket,
+    # )
 
 
 def build_backup(scope: App, env: Environment, source_account: str):

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -16,7 +16,9 @@ from sds_data_manager.constructs import (
     data_bucket_construct,
     database_construct,
     efs_construct,
+    ialirt_api_manager_construct,
     ialirt_bucket_construct,
+    ialirt_ingest_lambda_construct,
     ialirt_processing_construct,
     indexer_lambda_construct,
     instrument_lambdas,
@@ -269,37 +271,37 @@ def build_sds(
     ialirt_bucket = ialirt_bucket_construct.IAlirtBucketConstruct(
         scope=ialirt_stack, construct_id="IAlirtBucket", env=env
     )
-    #
-    # ialirt_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
-    #     scope=ialirt_stack,
-    #     id="IAlirtDependencies",
-    #     layer_dependencies_dir=str(layer_code_directory),
-    # )
-    #
-    # ialirt_monitoring = monitoring_construct.MonitoringConstruct(
-    #     scope=ialirt_stack,
-    #     construct_id="IAlirtMonitoringConstruct",
-    # )
-    #
-    # ialirt_api = api_gateway_construct.ApiGateway(
-    #     scope=ialirt_stack,
-    #     construct_id="IAlirtApiGateway",
-    #     domain_construct=domain,
-    #     certificate=root_certificate,
-    #     ialirt_prefix="IAlirt",
-    # )
-    # ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
-    #
-    # ialirt_api_manager_construct.IalirtApiManager(
-    #     scope=ialirt_stack,
-    #     construct_id="IAlirtApiManager",
-    #     code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
-    #     api=ialirt_api,
-    #     env=env,
-    #     data_bucket=ialirt_bucket.ialirt_bucket,
-    #     vpc=networking.vpc,
-    #     layers=[ialirt_lambda_layer],
-    # )
+
+    ialirt_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
+        scope=ialirt_stack,
+        id="IAlirtDependencies",
+        layer_dependencies_dir=str(layer_code_directory),
+    )
+
+    ialirt_monitoring = monitoring_construct.MonitoringConstruct(
+        scope=ialirt_stack,
+        construct_id="IAlirtMonitoringConstruct",
+    )
+
+    ialirt_api = api_gateway_construct.ApiGateway(
+        scope=ialirt_stack,
+        construct_id="IAlirtApiGateway",
+        domain_construct=domain,
+        certificate=root_certificate,
+        ialirt_prefix="IAlirt",
+    )
+    ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
+
+    ialirt_api_manager_construct.IalirtApiManager(
+        scope=ialirt_stack,
+        construct_id="IAlirtApiManager",
+        code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
+        api=ialirt_api,
+        env=env,
+        data_bucket=ialirt_bucket.ialirt_bucket,
+        vpc=networking.vpc,
+        layers=[ialirt_lambda_layer],
+    )
 
     # All traffic to I-ALiRT is directed to listed container ports
     ialirt_ports = [1234, 1235]
@@ -314,12 +316,12 @@ def build_sds(
         secret_name=ialirt_secret_name,
     )
 
-    # # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
-    # ialirt_ingest_lambda_construct.IalirtIngestLambda(
-    #     scope=ialirt_stack,
-    #     construct_id="IalirtIngestLambda",
-    #     ialirt_bucket=ialirt_bucket.ialirt_bucket,
-    # )
+    # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
+    ialirt_ingest_lambda_construct.IalirtIngestLambda(
+        scope=ialirt_stack,
+        construct_id="IalirtIngestLambda",
+        ialirt_bucket=ialirt_bucket.ialirt_bucket,
+    )
 
 
 def build_backup(scope: App, env: Environment, source_account: str):


### PR DESCRIPTION
# Change Summary

## Overview
Reduced to a single running container. OpsSW did not want have a duplicate the datastream for tlm relay. Now everything is processing in a single container w/ autoscaling enabled.

We were treating the second container instance as a hot permanent backup which we do not need if we are using a properly configured ECS service in AWS. Instead, what is needed is a health check so that as soon as IOIS stops responding, we can trigger the health check mechanisms in ECS to schedule a new, healthy task and traffic will route to it.

## Updated Files

- stackbuilder.py
   - Directs datastream to single task now.
- ialirt_processing_construct.py
   - Deleted any redundancy. 

## Testing
Everything work similarly as before.
