### PR TITLE
I-ALiRT: add idle timeout settings

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -302,6 +302,21 @@ class IalirtProcessing(Construct):
                 protocol=elbv2.Protocol.TCP,
             )
 
+            # Modify the listener attributes to set the TCP idle timeout
+            # Use node.default_child to get access to the L1 construct
+            # and modify its properties.
+            # https://docs.aws.amazon.com/cdk/v2/guide/cfn_layer.html
+            cfn_listener = listener.node.default_child
+            cfn_listener.add_property_override(
+                "ListenerAttributes",
+                [
+                    {
+                        "Key": "tcp.idle_timeout.seconds",
+                        "Value": str(6000),
+                    }
+                ],
+            )
+
             # Register the ECS service as a target for the listener
             listener.add_targets(
                 f"Target{port}",


### PR DESCRIPTION
# Change Summary

## Overview
NLB has a default of 350 s for tcp timeouts. This just changes is to 6000 s (the max). The reason for this is to absolutely ensure that the tcp connection remains up despite ground station tcp timeout settings or tcp timeout settings for the container.

## Updated Files
- ialirt_processing_construct
   - Change tcp timeout settings from 350s to 6000s 