### PR TITLE
I-ALiRT - updated format of dynamodb

### DIFF
--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -104,10 +104,10 @@ class IalirtIngestLambda(Construct):
             # Restore data to any point in time within the last 35 days.
             # TODO: change to True in production.
             point_in_time_recovery=False,
-            # Partition key (PK) = instrument product_name.
+            # Partition key (PK) = APID.
             partition_key=ddb.Attribute(
-                name="product_name",
-                type=ddb.AttributeType.STRING,
+                name="apid",
+                type=ddb.AttributeType.NUMBER,
             ),
             # Sort key (SK) = Mission Elapsed Time (MET).
             sort_key=ddb.Attribute(
@@ -122,13 +122,24 @@ class IalirtIngestLambda(Construct):
         # Add a GSI for ingest time.
         table.add_global_secondary_index(
             index_name="insert_time",
-            # Partition key (PK) = instrument product_name.
-            partition_key=ddb.Attribute(
-                name="product_name", type=ddb.AttributeType.STRING
-            ),
+            # Partition key (PK) = APID.
+            partition_key=ddb.Attribute(name="apid", type=ddb.AttributeType.NUMBER),
             # Sort key (SK) = Insert Time (ISO).
             sort_key=ddb.Attribute(
                 name="insert_time",
+                type=ddb.AttributeType.STRING,
+            ),
+            projection_type=ddb.ProjectionType.ALL,
+        )
+
+        # Add a GSI for instrument product name.
+        table.add_global_secondary_index(
+            index_name="product_name",
+            # Partition key (PK) = APID.
+            partition_key=ddb.Attribute(name="apid", type=ddb.AttributeType.NUMBER),
+            # Sort key (SK) = Instrument product name.
+            sort_key=ddb.Attribute(
+                name="product_name",
                 type=ddb.AttributeType.STRING,
             ),
             projection_type=ddb.ProjectionType.ALL,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -61,9 +61,10 @@ def lambda_handler(event, context):
 
     # 3. After processing insert data into Algorithm Table.
     item = {
-        "product_name": "hit_product_1",
+        "apid": 478,
         "met": 123,
         "insert_time": "2021-01-01T00:00:00Z",
+        "product_name": "hit_product_1",
         "data_product_1": str(1234.56),
     }
     algorithm_table.put_item(Item=item)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,21 +48,30 @@ def setup_dynamodb():
             TableName=os.environ["ALGORITHM_TABLE"],
             KeySchema=[
                 # Partition key
-                {"AttributeName": "product_name", "KeyType": "HASH"},
+                {"AttributeName": "apid", "KeyType": "HASH"},
                 # Sort key
                 {"AttributeName": "met", "KeyType": "RANGE"},
             ],
             AttributeDefinitions=[
-                {"AttributeName": "product_name", "AttributeType": "S"},
+                {"AttributeName": "apid", "AttributeType": "N"},
                 {"AttributeName": "met", "AttributeType": "N"},
                 {"AttributeName": "insert_time", "AttributeType": "S"},
+                {"AttributeName": "product_name", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
                 {
                     "IndexName": "insert_time",  # Unique index name
                     "KeySchema": [
-                        {"AttributeName": "product_name", "KeyType": "HASH"},
+                        {"AttributeName": "apid", "KeyType": "HASH"},
                         {"AttributeName": "insert_time", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": "product_name",  # Unique index name
+                    "KeySchema": [
+                        {"AttributeName": "apid", "KeyType": "HASH"},
+                        {"AttributeName": "product_name", "KeyType": "RANGE"},
                     ],
                     "Projection": {"ProjectionType": "ALL"},
                 },

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -54,7 +54,7 @@ def test_lambda_handler(setup_dynamodb):
 
     response = algorithm_table.get_item(
         Key={
-            "product_name": "hit_product_1",
+            "apid": 478,
             "met": 123,
         }
     )
@@ -62,4 +62,6 @@ def test_lambda_handler(setup_dynamodb):
 
     assert item is not None
     assert item["met"] == 123
+    assert item["insert_time"] == "2021-01-01T00:00:00Z"
+    assert item["product_name"] == "hit_product_1"
     assert item["data_product_1"] == str(1234.56)

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -1,4 +1,4 @@
-"""Test the IAlirt ingest lambda function."""
+"""Test the I-Alirt ingest lambda function."""
 
 import pytest
 


### PR DESCRIPTION
# Change Summary

## Overview
This PR is based on feedback from Eric Christian. He said that he thinks that people will just want to query all of the latest data products regardless of the data product name. Therefore, I am the partition key = apid, kept the same sort key (met), and first global secondary index (insert_time), and then added a new global secondary index (data_product_name). 

## Updated Files
- ialirt_ingest_lambda_construct.py
   - Made partition key = apid
   - Added a global secondary index = data_product_name
- ialirt_ingest.py
   - Updated the lambda with the new format

## Testing
- test_ialirt_ingest_lambda_construct.py
- test_ialirt_ingest.py
- conftest.py