### PR TITLE
I-ALiRT: Initial setup of catalog API lambda

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -110,3 +110,29 @@ class IalirtApiManager(Construct):
             lambda_function=download_api,
             use_path_params=True,
         )
+
+        # catalog API lambda
+        catalog_api = lambda_.Function(
+            self,
+            id="IAlirtCatalogAPILambda",
+            function_name="ialirt-catalog-api-handler",
+            code=code,
+            handler="IAlirtCode.ialirt_catalog_api.lambda_handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            timeout=cdk.Duration.minutes(1),
+            environment={
+                "S3_BUCKET": data_bucket.bucket_name,
+                "REGION": env.region,
+            },
+            layers=layers,
+            architecture=lambda_.Architecture.ARM_64,
+        )
+
+        catalog_api.add_to_role_policy(s3_read_policy)
+
+        api.add_route(
+            route="ialirt-catalog",
+            http_method="GET",
+            lambda_function=catalog_api,
+            use_path_params=True,
+        )

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -1,5 +1,4 @@
 """Define lambda to support the catalog API."""
-
 import logging
 
 # Logger setup

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -9,6 +9,7 @@ logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
     """Entry point to the catalog API lambda.
+
     Blank function for initial setup.
 
     Parameters
@@ -20,7 +21,6 @@ def lambda_handler(event, context):
         This object provides methods and properties that provide
         information about the invocation, function,
         and runtime environment.
-
     """
     logger.info(f"Event: {event}")
     logger.info(f"Context: {context}")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -1,4 +1,5 @@
 """Define lambda to support the catalog API."""
+
 import logging
 
 # Logger setup

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -1,0 +1,31 @@
+"""Define lambda to support the catalog API."""
+
+import logging
+
+# Logger setup
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event, context):
+    """Entry point to the catalog API lambda.
+    Blank function for initial setup.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process
+    context : LambdaContext
+        This object provides methods and properties that provide
+        information about the invocation, function,
+        and runtime environment.
+
+    """
+    logger.info(f"Event: {event}")
+    logger.info(f"Context: {context}")
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+    }


### PR DESCRIPTION
# Change Summary

## Overview
This is the first MR in the series of changes needed to set up the API endpoint that will be used to distribute our ephemeris pointing schedules. The ticket is [here](https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/377). 
These changes are the skeleton of the new `catalog` endpoint, which will eventually return a list of file names and links to them in s3. 

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- IAlirtCode/ialirt_catalog_api.py
   - This will house the definition of the lambda function that will retrieve the files from s3 and return them from the API call. Right now, this file is fairly empty.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- ialirt_api_manager_construct.py
   - Adds a lambda function, role policy and route to the I-ALiRT API Gateway structure for the new `catalog` endpoint.

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
I've deployed these changes to the IalirtStack in our `dev` account, and queried the new endpoint using Postman. The message that was returned was "Missing Authentication Token", which makes sense considering there isn't any s3 client code in the lambda definition yet.