### PR TITLE
I-ALiRT - s3 bucket name change

### DIFF
--- a/sds_data_manager/constructs/ialirt_bucket_construct.py
+++ b/sds_data_manager/constructs/ialirt_bucket_construct.py
@@ -31,12 +31,14 @@ class IAlirtBucketConstruct(Construct):
 
         """
         super().__init__(scope, construct_id, **kwargs)
+        # Get the current account number so we can use it in the bucket names
+        account = env.account
 
         # This is the S3 bucket used to mount to the container.
         self.ialirt_bucket = s3.Bucket(
             self,
             "IAlirtBucket",
-            bucket_name="ialirt-bucket",
+            bucket_name=f"ialirt-{account}",
             versioned=True,
             event_bridge_enabled=True,
             removal_policy=RemovalPolicy.DESTROY,


### PR DESCRIPTION
# Change Summary

## Overview
Realized that s3 bucket names need to be globally unique. So I reverting back to the original naming.

## Updated Files
 - ialirt_bucket_construct.py
   - dreverting back to the original naming
