### PR TITLE
I-ALiRT - Add Static EIP to NLB

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -194,7 +194,7 @@ class IalirtProcessing(Construct):
         container = task_definition.add_container(
             "IalirtContainer",
             image=ecs.ContainerImage.from_registry(
-                "lasp-registry.colorado.edu/ialirt/ialirt:test",
+                "lasp-registry.colorado.edu/ialirt/ialirt:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -250,6 +250,10 @@ class IalirtProcessing(Construct):
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             vpc=self.vpc,
             desired_capacity=2,
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PUBLIC,
+                availability_zones=["us-west-2b", "us-west-2c"],
+            ),
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -194,7 +194,7 @@ class IalirtProcessing(Construct):
         container = task_definition.add_container(
             "IalirtContainer",
             image=ecs.ContainerImage.from_registry(
-                "lasp-registry.colorado.edu/ialirt/ialirt:latest",
+                "lasp-registry.colorado.edu/ialirt/ialirt:test",
                 credentials=nexus_secret,
             ),
             # Allowable values:
@@ -286,13 +286,19 @@ class IalirtProcessing(Construct):
         """Add a load balancer for a container."""
         # Create the Network Load Balancer and
         # place it in a public subnet.
+        selected_subnets = ec2.SubnetSelection(
+            availability_zones=["us-west-2b", "us-west-2c"],
+            subnet_type=ec2.SubnetType.PUBLIC,
+        )
+
         self.load_balancer = elbv2.NetworkLoadBalancer(
             self,
             "IalirtNLB",
             vpc=self.vpc,
             security_groups=[self.load_balancer_security_group],
             internet_facing=True,
-            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
+            vpc_subnets=selected_subnets,
+            cross_zone_enabled=True,
         )
 
         # Create a listener for each port specified


### PR DESCRIPTION
# Change Summary

## Overview
After a Network Load Balancer is created, you can't modify its existing subnets or Network Load Balancer node Elastic IP addresses. This ticket does the following things:
1. Deploys to only AZs us-west-2b and us-west-2c
2. Adds the ability for the NLB in one AZ to direct traffic to an EC2 in another AZ

This gives us the capability to add another AZ (us-west-2a) with a statically defined EIP to the NLB using the terminal:

`aws ec2 allocate-address --domain vpc`

`aws elbv2 set-subnets --load-balancer-arn <load balancer arn> --subnet-mappings SubnetId=<subnet id for us-west-2b> SubnetId=<subnet id for us-west-2c> SubnetId=<subnet id for us-west-2a>,AllocationId=<allocation id>`

## Updated Files
- ialirt_processing_construct.py
   - See Overview description 

## Testing
http://44.233.128.234:7526
And I see:
Hello from Port 7526!
