### PR TITLE
I-ALiRT: Remove NLB

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -1,7 +1,6 @@
-"""Configure the i-alirt processing stack.
-"""
+"""Configure the i-alirt processing stack."""
 
-from aws_cdk import CfnOutput, Duration, RemovalPolicy
+from aws_cdk import RemovalPolicy
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
@@ -77,7 +76,7 @@ class IalirtProcessing(Construct):
                 self.ecs_security_group.add_ingress_rule(
                     # TODO: allow IP addresses from partners
                     peer=ec2.Peer.ipv4(ip_range),
-                    connection=ec2.Port.all_tcp(),
+                    connection=ec2.Port.tcp(port),
                     description=f"Allow inbound traffic on TCP port {port}",
                 )
 
@@ -157,7 +156,7 @@ class IalirtProcessing(Construct):
 
         # Adds a container to the ECS task definition
         # Logging is configured to use AWS CloudWatch Logs.
-        container = task_definition.add_container(
+        task_definition.add_container(
             "IalirtContainer",
             image=ecs.ContainerImage.from_registry(
                 "lasp-registry.colorado.edu/ialirt/ialirt:test",
@@ -202,7 +201,7 @@ class IalirtProcessing(Construct):
             vpc=self.vpc,
             desired_capacity=1,
             min_capacity=1,
-            max_capacity=2, # Allow one extra instance during updates
+            max_capacity=2,  # Allow one extra instance during updates
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC,
             ),

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -1,17 +1,10 @@
 """Configure the i-alirt processing stack.
-
-This is the module containing the general stack to be built for computation of
-I-ALiRT algorithms. It was built using best practices as shown here:
-
-https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/networking-inbound.html
-https://aws.amazon.com/elasticloadbalancing/features/#Product_comparisons
 """
 
 from aws_cdk import CfnOutput, Duration, RemovalPolicy
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
-from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_secretsmanager as secretsmanager
@@ -58,16 +51,11 @@ class IalirtProcessing(Construct):
         self.s3_bucket_name = ialirt_bucket.bucket_name
         self.secret_name = secret_name
 
-        # Add a security group in which network load balancer will reside
-        self.create_load_balancer_security_group()
-
         # Create security group in which containers will reside
         self.create_ecs_security_group()
 
         # Add an ecs service and cluster for each container
         self.add_compute_resources()
-        # Add load balancer for each container
-        self.add_load_balancer()
         # Add autoscaling for each container
         self.add_autoscaling()
 
@@ -81,32 +69,12 @@ class IalirtProcessing(Construct):
             allow_all_outbound=True,
         )
 
-        # Only allow traffic from the NLB security group
-        for port in self.ports:
-            self.ecs_security_group.add_ingress_rule(
-                peer=ec2.Peer.security_group_id(
-                    self.load_balancer_security_group.security_group_id
-                ),
-                connection=ec2.Port.tcp(port),
-                description=f"Allow inbound traffic from the NLB on TCP port {port}",
-            )
-
-    def create_load_balancer_security_group(self):
-        """Create and return a security group for load balancers."""
-        # Create a security group for the NLB
-        self.load_balancer_security_group = ec2.SecurityGroup(
-            self,
-            "NLBSecurityGroup",
-            vpc=self.vpc,
-            description="Security group for the Ialirt NLB",
-        )
-
         # Allow inbound and outbound traffic from a specific port and IP.
         # IPs: LASP IP, BlueNet (tlm relay)
         ip_ranges = ["128.138.131.0/24", "198.118.1.14/32"]
         for port in self.ports:
             for ip_range in ip_ranges:
-                self.load_balancer_security_group.add_ingress_rule(
+                self.ecs_security_group.add_ingress_rule(
                     # TODO: allow IP addresses from partners
                     peer=ec2.Peer.ipv4(ip_range),
                     connection=ec2.Port.tcp(port),
@@ -114,7 +82,7 @@ class IalirtProcessing(Construct):
                 )
 
                 # Allow outbound traffic.
-                self.load_balancer_security_group.add_egress_rule(
+                self.ecs_security_group.add_egress_rule(
                     peer=ec2.Peer.ipv4(ip_range),
                     connection=ec2.Port.tcp(port),
                     description=f"Allow outbound traffic on TCP port {port}",
@@ -179,12 +147,10 @@ class IalirtProcessing(Construct):
         )
 
         # Specifies the networking mode as AWS_VPC.
-        # ECS tasks in AWS_VPC mode can be registered with
-        # Network Load Balancers (NLB).
         task_definition = ecs.Ec2TaskDefinition(
             self,
             "IalirtTaskDef",
-            network_mode=ecs.NetworkMode.AWS_VPC,
+            network_mode=ecs.NetworkMode.HOST,
             task_role=task_role,
             execution_role=execution_role,
         )
@@ -194,7 +160,7 @@ class IalirtProcessing(Construct):
         container = task_definition.add_container(
             "IalirtContainer",
             image=ecs.ContainerImage.from_registry(
-                "lasp-registry.colorado.edu/ialirt/ialirt:latest",
+                "lasp-registry.colorado.edu/ialirt/ialirt:test",
                 credentials=nexus_secret,
             ),
             # Allowable values:
@@ -210,7 +176,7 @@ class IalirtProcessing(Construct):
         )
 
         # Map ports to container
-        # NLB needs to know which port on the EC2 instances
+        # ECS needs to know which port on the EC2 instances
         # it should forward the traffic to
         for port in self.ports:
             port_mapping = ecs.PortMapping(
@@ -228,12 +194,8 @@ class IalirtProcessing(Construct):
             "IalirtService",
             cluster=self.ecs_cluster,
             task_definition=task_definition,
-            security_groups=[self.ecs_security_group],
             desired_count=1,
             health_check_grace_period=Duration.seconds(3600),
-            vpc_subnets=ec2.SubnetSelection(
-                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
-            ),
         )
 
     def add_autoscaling(self):
@@ -241,6 +203,7 @@ class IalirtProcessing(Construct):
         # This auto-scaling group is used to manage the
         # number of instances in the ECS cluster. If an instance
         # becomes unhealthy, the auto-scaling group will replace it.
+
         auto_scaling_group = autoscaling.AutoScalingGroup(
             self,
             "AutoScalingGroup",
@@ -252,8 +215,9 @@ class IalirtProcessing(Construct):
             desired_capacity=2,
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC,
-                availability_zones=["us-west-2b", "us-west-2c"],
             ),
+            associate_public_ip_address=True,
+            security_group=self.ecs_security_group,
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
@@ -277,87 +241,3 @@ class IalirtProcessing(Construct):
         )
 
         self.ecs_cluster.add_asg_capacity_provider(capacity_provider)
-
-        # Allow inbound traffic from the Network Load Balancer
-        # to the security groups associated with the EC2 instances
-        # within the Auto Scaling Group.
-        for port in self.ports:
-            auto_scaling_group.connections.allow_from(
-                self.load_balancer, ec2.Port.tcp(port)
-            )
-
-    def add_load_balancer(self):
-        """Add a load balancer for a container."""
-        # Create the Network Load Balancer and
-        # place it in a public subnet.
-        selected_subnets = ec2.SubnetSelection(
-            availability_zones=["us-west-2b", "us-west-2c"],
-            subnet_type=ec2.SubnetType.PUBLIC,
-        )
-
-        self.load_balancer = elbv2.NetworkLoadBalancer(
-            self,
-            "IalirtNLB",
-            vpc=self.vpc,
-            security_groups=[self.load_balancer_security_group],
-            internet_facing=True,
-            vpc_subnets=selected_subnets,
-            cross_zone_enabled=True,
-        )
-
-        # Create a listener for each port specified
-        for port in self.ports:
-            listener = self.load_balancer.add_listener(
-                f"Listener{port}",
-                port=port,
-                protocol=elbv2.Protocol.TCP,
-            )
-
-            # Modify the listener attributes to set the TCP idle timeout
-            # Use node.default_child to get access to the L1 construct
-            # and modify its properties.
-            # https://docs.aws.amazon.com/cdk/v2/guide/cfn_layer.html
-            cfn_listener = listener.node.default_child
-            cfn_listener.add_property_override(
-                "ListenerAttributes",
-                [
-                    {
-                        "Key": "tcp.idle_timeout.seconds",
-                        "Value": str(6000),
-                    }
-                ],
-            )
-
-            # Register the ECS service as a target for the listener
-            listener.add_targets(
-                f"Target{port}",
-                port=port,
-                # Specifies the container and port to route traffic to.
-                targets=[
-                    self.ecs_service.load_balancer_target(
-                        container_name="IalirtContainer",
-                        container_port=port,
-                    )
-                ],
-                # Configures health checks for the target group
-                # to ensure traffic is routed only to healthy ECS tasks.
-                # Port 7568 is a dummy port used by IOIS to check the
-                # health of the container.
-                health_check=elbv2.HealthCheck(
-                    enabled=True,
-                    port=str(7568),
-                    protocol=elbv2.Protocol.TCP,
-                    interval=Duration.seconds(60),
-                    timeout=Duration.seconds(30),
-                    unhealthy_threshold_count=5,
-                    healthy_threshold_count=5,
-                ),
-            )
-
-            # This simply prints the DNS name of the
-            # load balancer in the terminal.
-            CfnOutput(
-                self,
-                f"LoadBalancerDNS{port}",
-                value=f"http://{self.load_balancer.load_balancer_dns_name}:{port}",
-            )

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -77,7 +77,7 @@ class IalirtProcessing(Construct):
                 self.ecs_security_group.add_ingress_rule(
                     # TODO: allow IP addresses from partners
                     peer=ec2.Peer.ipv4(ip_range),
-                    connection=ec2.Port.tcp(port),
+                    connection=ec2.Port.all_tcp(),
                     description=f"Allow inbound traffic on TCP port {port}",
                 )
 
@@ -175,17 +175,6 @@ class IalirtProcessing(Construct):
             privileged=True,
         )
 
-        # Map ports to container
-        # ECS needs to know which port on the EC2 instances
-        # it should forward the traffic to
-        for port in self.ports:
-            port_mapping = ecs.PortMapping(
-                container_port=port,
-                host_port=port,
-                protocol=ecs.Protocol.TCP,
-            )
-            container.add_port_mappings(port_mapping)
-
         # ECS Service is a configuration that
         # ensures application can run and maintain
         # instances of a task definition.
@@ -195,7 +184,6 @@ class IalirtProcessing(Construct):
             cluster=self.ecs_cluster,
             task_definition=task_definition,
             desired_count=1,
-            health_check_grace_period=Duration.seconds(3600),
         )
 
     def add_autoscaling(self):
@@ -212,7 +200,9 @@ class IalirtProcessing(Construct):
             ),
             machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
             vpc=self.vpc,
-            desired_capacity=2,
+            desired_capacity=1,
+            min_capacity=1,
+            max_capacity=2, # Allow one extra instance during updates
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC,
             ),

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -159,7 +159,7 @@ class IalirtProcessing(Construct):
         task_definition.add_container(
             "IalirtContainer",
             image=ecs.ContainerImage.from_registry(
-                "lasp-registry.colorado.edu/ialirt/ialirt:test",
+                "lasp-registry.colorado.edu/ialirt/ialirt:latest",
                 credentials=nexus_secret,
             ),
             # Allowable values:
@@ -190,7 +190,6 @@ class IalirtProcessing(Construct):
         # This auto-scaling group is used to manage the
         # number of instances in the ECS cluster. If an instance
         # becomes unhealthy, the auto-scaling group will replace it.
-
         auto_scaling_group = autoscaling.AutoScalingGroup(
             self,
             "AutoScalingGroup",

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -145,7 +145,11 @@ class IalirtProcessing(Construct):
             )
         )
 
-        # Specifies the networking mode as AWS_VPC.
+        # Specifies the networking mode as HOST.
+        # In "HOST" you can access the container using the EC2 public IP
+        # that is automatically assigned.
+        # The ECS tasks to automatically inherit the EC2 instance
+        # Elastic IP so that they always use a publicly accessible IP address.
         task_definition = ecs.Ec2TaskDefinition(
             self,
             "IalirtTaskDef",


### PR DESCRIPTION
# Change Summary

## Overview
The NLB can only forward to 5 targets for an ECS service. This is the first of two Pull Requests to remove the NLB. This ticket allows a direct connection from the incoming datastreams to the ECS. However it does not account for EC2 instances changing their IP addresses. That will be addressed in the second PR.

## Updated Files
- ialirt_processing_construct.py
   - Removed Network Load Balancer Security Group
   - ECS Security Group now has the properties of the Network Load Balancer Security group.
   - Changed the Network Mode to "HOST". Before it was using "AWS_VPC" because that was the only allowable Network Mode for Network Load Balancers. 
   - In AWS_VPC network mode, ECS tasks are assigned their own ENI with private IPs, and the EC2 instances are not automatically assigned public IPs for these tasks. This means that tasks cannot be reached via a public IP and require external routing (e.g., an NLB) to expose them—which is not what we want.
   - In "HOST" you can access the container using the EC2 public IP that is automatically assigned. I chose this mode because I want the ECS tasks to automatically inherit the EC2 instance’s Elastic IP so that they always use a publicly accessible IP address.
   - In the next PR I will assign static EIPs to the EC2 instances and I will need the ECS tasks to be able to use those.
   - ECS service runs directly on the EC2 instances, so it automatically uses the security group and subnet of the Auto Scaling Group (ASG). Therefore, I removed those from the ECS service parameters and added them to the ASG.
   - Set the EC2 instance desired, min, and max capacity to correct settings for ASG.
   
## Testing
**Test 1:**
Verify that I can connect using the IP address for the EC2 instance while CONNECTED to the VPN.
`http://<EC2 Public IP>:7526`
Result Test 1:
Hello from Port 7526!
**Test 2:**
Verify that I cannot connect using the IP address for the EC2 instance while DISCONNECTED from the LASP VPN.
Result Test 2:
Timeout
