### PR TITLE
I-ALiRT - Remove NLB 2

### DIFF
--- a/docs/source/cdk/ialirt-setup.rst
+++ b/docs/source/cdk/ialirt-setup.rst
@@ -8,6 +8,10 @@ Ensure you have a secret in AWS Secrets Manager with a username and password for
 
     aws secretsmanager create-secret --name nexus-credentials --description "Credentials for Nexus Docker registry" --secret-string '{"username":"your-username", "password":"your-password"}'
 
+Also ensure you have created a static elastic ip that will be assigned to the EC2::
+
+    aws ec2 allocate-address --domain vpc
+    aws secretsmanager create-secret --name allocation-credentials --description "Credentials for Static EIP" --secret-string '{"eip_allocation_id":"<eip_allocation_id>"}'
 Image Versioning
 ~~~~~~~~~
 We will rely on semantic versioning for the images MAJOR.MINOR (e.g., 1.0).
@@ -44,6 +48,7 @@ We will have a versioned image and latest image in the Nexus repo. The versioned
 
     docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:X.Y.Z
     docker push docker-registry.pdmz.lasp.colorado.edu/ialirt/ialirt:latest
+
 #. Images may be viewed on the Nexus website: https://artifacts.pdmz.lasp.colorado.edu
 #. To verify that the latest image and the most recent version image are the same, run the following and compare the image IDs::
 

--- a/docs/source/cdk/ialirt-setup.rst
+++ b/docs/source/cdk/ialirt-setup.rst
@@ -58,5 +58,6 @@ ECS Recognition of a New Image
 ~~~~~~~~~~~~~
 To have ECS recognize a new image the cdk must be redeployed::
 
-    aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment --deployment-configuration maximumPercent=200,minimumHealthyPercent=0
+    aws ecs update-service --cluster <cluster name> --service <service name> --force-new-deployment --deployment-configuration maximumPercent=100,minimumHealthyPercent=0
 
+The reason that we can only have a single task running is that the same ports would be in use by the old task, and as a result, the new task will fail to start because it wouldn't be able bind to the required ports.

--- a/docs/source/cdk/ialirt-setup.rst
+++ b/docs/source/cdk/ialirt-setup.rst
@@ -8,10 +8,6 @@ Ensure you have a secret in AWS Secrets Manager with a username and password for
 
     aws secretsmanager create-secret --name nexus-credentials --description "Credentials for Nexus Docker registry" --secret-string '{"username":"your-username", "password":"your-password"}'
 
-Also ensure you have created a static elastic ip that will be assigned to the EC2::
-
-    aws ec2 allocate-address --domain vpc
-    aws secretsmanager create-secret --name allocation-credentials --description "Credentials for Static EIP" --secret-string '{"eip_allocation_id":"<eip_allocation_id>"}'
 Image Versioning
 ~~~~~~~~~
 We will rely on semantic versioning for the images MAJOR.MINOR (e.g., 1.0).

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -1,10 +1,16 @@
 """Configure the i-alirt processing stack."""
 
-from aws_cdk import RemovalPolicy
+import pathlib
+
+from aws_cdk import Duration, RemovalPolicy
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_events as events
+from aws_cdk import aws_events_targets as targets
 from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_lambda_python_alpha as lambda_alpha_
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_secretsmanager as secretsmanager
 from constructs import Construct
@@ -21,6 +27,7 @@ class IalirtProcessing(Construct):
         ports: list[int],
         ialirt_bucket: s3.Bucket,
         secret_name: str,
+        eip_secret_name: str,
         **kwargs,
     ) -> None:
         """Construct the i-alirt processing stack.
@@ -39,6 +46,8 @@ class IalirtProcessing(Construct):
             S3 bucket
         secret_name : str,
             Database secret_name for Secrets Manager
+        eip_secret_name : str,
+            EIP secret_name for Secrets Manager
         kwargs : dict
             Keyword arguments
 
@@ -49,6 +58,7 @@ class IalirtProcessing(Construct):
         self.vpc = vpc
         self.s3_bucket_name = ialirt_bucket.bucket_name
         self.secret_name = secret_name
+        self.eip_secret_name = eip_secret_name
 
         # Create security group in which containers will reside
         self.create_ecs_security_group()
@@ -92,7 +102,7 @@ class IalirtProcessing(Construct):
         # ECS Cluster manages EC2 instances on which containers are deployed.
         self.ecs_cluster = ecs.Cluster(self, "IalirtCluster", vpc=self.vpc)
 
-        # Retrieve the secret from Secrets Manager.
+        # Retrieve the secrets from Secrets Manager.
         nexus_secret = secretsmanager.Secret.from_secret_name_v2(
             self, "NexusCredentials", secret_name=self.secret_name
         )
@@ -148,7 +158,7 @@ class IalirtProcessing(Construct):
         # Specifies the networking mode as HOST.
         # In "HOST" you can access the container using the EC2 public IP
         # that is automatically assigned.
-        # The ECS tasks to automatically inherit the EC2 instance
+        # The ECS tasks automatically inherit the EC2 instance
         # Elastic IP so that they always use a publicly accessible IP address.
         task_definition = ecs.Ec2TaskDefinition(
             self,
@@ -189,8 +199,79 @@ class IalirtProcessing(Construct):
             desired_count=1,
         )
 
+    def create_autoscaling_event_rule(
+            self,
+            assign_eip_lambda: lambda_alpha_.PythonFunction,
+    ) -> None:
+        """Create an EventBridge rule to trigger Lambda on Auto Scaling Group instance launch."""
+
+        # Create the EventBridge rule
+        asg_lifecycle_rule = events.Rule(
+            self,
+            "AssignEipOnInstanceLaunch",
+            rule_name="assign-eip-instance-launch",
+            event_pattern=events.EventPattern(
+                source=["aws.autoscaling"],
+                detail_type=["EC2 Instance-launch Lifecycle Action"],
+                detail={"AutoScalingGroupName": [{"exists": True}]},
+            ),
+        )
+
+        # Add the Lambda function as the target
+        asg_lifecycle_rule.add_target(
+            targets.LambdaFunction(assign_eip_lambda)
+        )
+
+    def create_lambda_function(
+        self,
+        eip_allocation_ids: secretsmanager.Secret,
+    ) -> lambda_alpha_.PythonFunction:
+        """Create and return the Lambda function."""
+        lambda_role = iam.Role(
+            self,
+            "IalirtEipLambdaRole",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("AWSLambdaBasicExecutionRole"),
+                iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEC2FullAccess"),
+                iam.ManagedPolicy.from_aws_managed_policy_name("AutoScalingFullAccess"),
+            ],
+        )
+
+        eip_lambda = lambda_alpha_.PythonFunction(
+            self,
+            id="IalirtAssignEipLambda",
+            function_name="ialirt-eip",
+            entry=str(
+                pathlib.Path(__file__).parent.joinpath("..", "lambda_code").resolve()
+            ),
+            index="IAlirtCode/ialirt_eip.py",
+            handler="lambda_handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            timeout=Duration.minutes(1),
+            memory_size=1000,
+            role=lambda_role,
+            environment={
+                "EIP_SECRET_ARN": eip_allocation_ids.secret_arn,
+                "REGION": self.region,
+                "SECRET_NAME": self.secret_name,
+            },
+        )
+
+        # Grant Lambda permission to access Secrets Manager
+        eip_allocation_ids.grant_read(eip_lambda)
+
+        # The resource is deleted when the stack is deleted.
+        eip_lambda.apply_removal_policy(RemovalPolicy.DESTROY)
+
+        return eip_lambda
+
     def add_autoscaling(self):
         """Add autoscaling resources."""
+        eip_allocation_ids = secretsmanager.Secret.from_secret_name_v2(
+            self, "IalirtEipCredentials", secret_name=self.eip_secret_name
+        )
+
         # This auto-scaling group is used to manage the
         # number of instances in the ECS cluster. If an instance
         # becomes unhealthy, the auto-scaling group will replace it.
@@ -213,12 +294,25 @@ class IalirtProcessing(Construct):
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
+        eip_lambda = self.create_lambda_function(eip_allocation_ids)
+        self.create_autoscaling_event_rule(eip_lambda)
 
         # Attach the AmazonSSMManagedInstanceCore policy for SSM access
         auto_scaling_group.role.add_managed_policy(
             iam.ManagedPolicy.from_aws_managed_policy_name(
-                "AmazonSSMManagedInstanceCore"
+                "AmazonSSMManagedInstanceCore",
+                "AmazonEventBridgeFullAccess",
             )
+        )
+
+        autoscaling.LifecycleHook(
+            auto_scaling_group=auto_scaling_group,
+            lifecycle_transition=autoscaling.LifecycleTransition.INSTANCE_LAUNCHING,
+            default_result=autoscaling.DefaultResult.CONTINUE,  # Continue if timeout occurs
+            heartbeat_timeout=Duration.minutes(5),  # Allow up to 5 minutes for EIP assignment
+            lifecycle_hook_name="EipAssignmentHook",
+            notification_metadata="EIP Assignment Lifecycle Hook",
+            notification_target=autoscaling.ILifecycleHookTarget.to_event_bridge(),
         )
 
         # integrates ECS with EC2 Auto Scaling Groups

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -209,9 +209,7 @@ class IalirtProcessing(Construct):
         assign_eip_lambda: lambda_alpha_.PythonFunction,
         auto_scaling_group: autoscaling.AutoScalingGroup,
     ) -> None:
-        """Create Rule to trigger Lambda on Auto Scaling Group instance launch."""
-        # If the instance goes to a running state, make certain that it has
-        # the proper Elastic IP to it. If it does not, assign the proper Elastic IP.
+        """Create Rules to trigger Lambda on Auto Scaling Group instance launch."""
         deploy_rule = events.Rule(
             self,
             "AssignEipOnEc2InstanceLaunch",
@@ -237,7 +235,6 @@ class IalirtProcessing(Construct):
             ),
         )
 
-        # Add the Lambda function as the target
         deploy_rule.add_target(targets.LambdaFunction(assign_eip_lambda))
         asg_lifecycle_rule.add_target(targets.LambdaFunction(assign_eip_lambda))
 

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -294,7 +294,7 @@ class IalirtProcessing(Construct):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC,
             ),
-            associate_public_ip_address=True,
+            associate_public_ip_address=False,
             security_group=self.ecs_security_group,
         )
 

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -1,6 +1,7 @@
 """Configure the i-alirt processing stack."""
 
 import pathlib
+import aws_cdk as cdk
 
 from aws_cdk import Duration, RemovalPolicy
 from aws_cdk import aws_autoscaling as autoscaling
@@ -23,6 +24,7 @@ class IalirtProcessing(Construct):
         self,
         scope: Construct,
         construct_id: str,
+        env: cdk.Environment,
         vpc: ec2.Vpc,
         ports: list[int],
         ialirt_bucket: s3.Bucket,
@@ -59,6 +61,7 @@ class IalirtProcessing(Construct):
         self.s3_bucket_name = ialirt_bucket.bucket_name
         self.secret_name = secret_name
         self.eip_secret_name = eip_secret_name
+        self.region = env.region
 
         # Create security group in which containers will reside
         self.create_ecs_security_group()
@@ -202,6 +205,7 @@ class IalirtProcessing(Construct):
     def create_autoscaling_event_rule(
             self,
             assign_eip_lambda: lambda_alpha_.PythonFunction,
+            auto_scaling_group: autoscaling.AutoScalingGroup,
     ) -> None:
         """Create an EventBridge rule to trigger Lambda on Auto Scaling Group instance launch."""
 
@@ -213,7 +217,7 @@ class IalirtProcessing(Construct):
             event_pattern=events.EventPattern(
                 source=["aws.autoscaling"],
                 detail_type=["EC2 Instance-launch Lifecycle Action"],
-                detail={"AutoScalingGroupName": [{"exists": True}]},
+                detail={"AutoScalingGroupName": [auto_scaling_group.auto_scaling_group_name]},
             ),
         )
 
@@ -295,24 +299,27 @@ class IalirtProcessing(Construct):
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
         eip_lambda = self.create_lambda_function(eip_allocation_ids)
-        self.create_autoscaling_event_rule(eip_lambda)
+        self.create_autoscaling_event_rule(eip_lambda, auto_scaling_group)
+
 
         # Attach the AmazonSSMManagedInstanceCore policy for SSM access
         auto_scaling_group.role.add_managed_policy(
-            iam.ManagedPolicy.from_aws_managed_policy_name(
-                "AmazonSSMManagedInstanceCore",
-                "AmazonEventBridgeFullAccess",
-            )
+            iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore")
+        )
+        # Add EventBridgeFullAccess policy for EventBridge access
+        auto_scaling_group.role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEventBridgeFullAccess")
         )
 
         autoscaling.LifecycleHook(
+            self,
+            "EipAssignmentHook",
             auto_scaling_group=auto_scaling_group,
             lifecycle_transition=autoscaling.LifecycleTransition.INSTANCE_LAUNCHING,
             default_result=autoscaling.DefaultResult.CONTINUE,  # Continue if timeout occurs
             heartbeat_timeout=Duration.minutes(5),  # Allow up to 5 minutes for EIP assignment
             lifecycle_hook_name="EipAssignmentHook",
             notification_metadata="EIP Assignment Lifecycle Hook",
-            notification_target=autoscaling.ILifecycleHookTarget.to_event_bridge(),
         )
 
         # integrates ECS with EC2 Auto Scaling Groups

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -29,7 +29,6 @@ class IalirtProcessing(Construct):
         ports: list[int],
         ialirt_bucket: s3.Bucket,
         secret_name: str,
-        eip_secret_name: str,
         **kwargs,
     ) -> None:
         """Construct the i-alirt processing stack.
@@ -50,8 +49,6 @@ class IalirtProcessing(Construct):
             S3 bucket
         secret_name : str,
             Database secret_name for Secrets Manager
-        eip_secret_name : str,
-            EIP secret_name for Secrets Manager
         kwargs : dict
             Keyword arguments
 
@@ -62,7 +59,6 @@ class IalirtProcessing(Construct):
         self.vpc = vpc
         self.s3_bucket_name = ialirt_bucket.bucket_name
         self.secret_name = secret_name
-        self.eip_secret_name = eip_secret_name
         self.region = env.region
 
         # Create security group in which containers will reside
@@ -240,7 +236,6 @@ class IalirtProcessing(Construct):
 
     def create_lambda_function(
         self,
-        eip_allocation_id: secretsmanager.Secret,
     ) -> lambda_alpha_.PythonFunction:
         """Create and return the Lambda function."""
         lambda_role = iam.Role(
@@ -261,7 +256,7 @@ class IalirtProcessing(Construct):
             id="IalirtAssignEipLambda",
             function_name="ialirt-eip",
             entry=str(
-                pathlib.Path(__file__).parent.joinpath("..", "lambda_code").resolve()
+                pathlib.Path(__file__).parent.parent.joinpath("lambda_code").resolve()
             ),
             index="IAlirtCode/ialirt_eip.py",
             handler="lambda_handler",
@@ -269,13 +264,7 @@ class IalirtProcessing(Construct):
             timeout=Duration.minutes(1),
             memory_size=1000,
             role=lambda_role,
-            environment={
-                "EIP_SECRET_NAME": self.eip_secret_name,
-            },
         )
-
-        # Grant Lambda permission to access Secrets Manager
-        eip_allocation_id.grant_read(eip_lambda)
 
         # The resource is deleted when the stack is deleted.
         eip_lambda.apply_removal_policy(RemovalPolicy.DESTROY)
@@ -284,10 +273,6 @@ class IalirtProcessing(Construct):
 
     def add_autoscaling(self):
         """Add autoscaling resources."""
-        eip_allocation_id = secretsmanager.Secret.from_secret_name_v2(
-            self, "IalirtEipCredentials", secret_name=self.eip_secret_name
-        )
-
         # This auto-scaling group is used to manage the
         # number of instances in the ECS cluster. If an instance
         # becomes unhealthy, the auto-scaling group will replace it.
@@ -310,7 +295,7 @@ class IalirtProcessing(Construct):
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
-        eip_lambda = self.create_lambda_function(eip_allocation_id)
+        eip_lambda = self.create_lambda_function()
         self.create_autoscaling_event_rule(eip_lambda, auto_scaling_group)
 
         # Attach the AmazonSSMManagedInstanceCore policy for SSM access

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -210,7 +210,20 @@ class IalirtProcessing(Construct):
         auto_scaling_group: autoscaling.AutoScalingGroup,
     ) -> None:
         """Create Rule to trigger Lambda on Auto Scaling Group instance launch."""
-        # Create the EventBridge rule
+        # If the instance goes to a running state, make certain that it has
+        # the proper Elastic IP to it. If it does not, assign the proper Elastic IP.
+        deploy_rule = events.Rule(
+            self,
+            "AssignEipOnEc2InstanceLaunch",
+            rule_name="assign-eip-ec2-instance-launch",
+            event_pattern=events.EventPattern(
+                source=["aws.ec2"],
+                detail_type=["EC2 Instance State-change Notification"],
+                detail={
+                    "state": ["running"],
+                },
+            ),
+        )
         asg_lifecycle_rule = events.Rule(
             self,
             "AssignEipOnInstanceLaunch",
@@ -225,6 +238,7 @@ class IalirtProcessing(Construct):
         )
 
         # Add the Lambda function as the target
+        deploy_rule.add_target(targets.LambdaFunction(assign_eip_lambda))
         asg_lifecycle_rule.add_target(targets.LambdaFunction(assign_eip_lambda))
 
     def create_lambda_function(

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -294,7 +294,7 @@ class IalirtProcessing(Construct):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PUBLIC,
             ),
-            associate_public_ip_address=False,
+            associate_public_ip_address=True,
             security_group=self.ecs_security_group,
         )
 

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -1,8 +1,8 @@
 """Configure the i-alirt processing stack."""
 
 import pathlib
-import aws_cdk as cdk
 
+import aws_cdk as cdk
 from aws_cdk import Duration, RemovalPolicy
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
@@ -40,6 +40,8 @@ class IalirtProcessing(Construct):
             Parent construct.
         construct_id : str
             A unique string identifier for this construct.
+        env : cdk.Environment
+            The environment in which to deploy the stack.
         vpc : ec2.Vpc
             VPC into which to put the resources that require networking.
         ports : list[int]
@@ -203,12 +205,11 @@ class IalirtProcessing(Construct):
         )
 
     def create_autoscaling_event_rule(
-            self,
-            assign_eip_lambda: lambda_alpha_.PythonFunction,
-            auto_scaling_group: autoscaling.AutoScalingGroup,
+        self,
+        assign_eip_lambda: lambda_alpha_.PythonFunction,
+        auto_scaling_group: autoscaling.AutoScalingGroup,
     ) -> None:
-        """Create an EventBridge rule to trigger Lambda on Auto Scaling Group instance launch."""
-
+        """Create Rule to trigger Lambda on Auto Scaling Group instance launch."""
         # Create the EventBridge rule
         asg_lifecycle_rule = events.Rule(
             self,
@@ -217,18 +218,18 @@ class IalirtProcessing(Construct):
             event_pattern=events.EventPattern(
                 source=["aws.autoscaling"],
                 detail_type=["EC2 Instance-launch Lifecycle Action"],
-                detail={"AutoScalingGroupName": [auto_scaling_group.auto_scaling_group_name]},
+                detail={
+                    "AutoScalingGroupName": [auto_scaling_group.auto_scaling_group_name]
+                },
             ),
         )
 
         # Add the Lambda function as the target
-        asg_lifecycle_rule.add_target(
-            targets.LambdaFunction(assign_eip_lambda)
-        )
+        asg_lifecycle_rule.add_target(targets.LambdaFunction(assign_eip_lambda))
 
     def create_lambda_function(
         self,
-        eip_allocation_ids: secretsmanager.Secret,
+        eip_allocation_id: secretsmanager.Secret,
     ) -> lambda_alpha_.PythonFunction:
         """Create and return the Lambda function."""
         lambda_role = iam.Role(
@@ -236,7 +237,9 @@ class IalirtProcessing(Construct):
             "IalirtEipLambdaRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
             managed_policies=[
-                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole"),
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AWSLambdaBasicExecutionRole"
+                ),
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEC2FullAccess"),
                 iam.ManagedPolicy.from_aws_managed_policy_name("AutoScalingFullAccess"),
             ],
@@ -261,7 +264,7 @@ class IalirtProcessing(Construct):
         )
 
         # Grant Lambda permission to access Secrets Manager
-        eip_allocation_ids.grant_read(eip_lambda)
+        eip_allocation_id.grant_read(eip_lambda)
 
         # The resource is deleted when the stack is deleted.
         eip_lambda.apply_removal_policy(RemovalPolicy.DESTROY)
@@ -270,7 +273,7 @@ class IalirtProcessing(Construct):
 
     def add_autoscaling(self):
         """Add autoscaling resources."""
-        eip_allocation_ids = secretsmanager.Secret.from_secret_name_v2(
+        eip_allocation_id = secretsmanager.Secret.from_secret_name_v2(
             self, "IalirtEipCredentials", secret_name=self.eip_secret_name
         )
 
@@ -296,17 +299,20 @@ class IalirtProcessing(Construct):
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
-        eip_lambda = self.create_lambda_function(eip_allocation_ids)
+        eip_lambda = self.create_lambda_function(eip_allocation_id)
         self.create_autoscaling_event_rule(eip_lambda, auto_scaling_group)
-
 
         # Attach the AmazonSSMManagedInstanceCore policy for SSM access
         auto_scaling_group.role.add_managed_policy(
-            iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore")
+            iam.ManagedPolicy.from_aws_managed_policy_name(
+                "AmazonSSMManagedInstanceCore"
+            )
         )
         # Add EventBridgeFullAccess policy for EventBridge access
         auto_scaling_group.role.add_managed_policy(
-            iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEventBridgeFullAccess")
+            iam.ManagedPolicy.from_aws_managed_policy_name(
+                "AmazonEventBridgeFullAccess"
+            )
         )
 
         autoscaling.LifecycleHook(
@@ -314,8 +320,10 @@ class IalirtProcessing(Construct):
             "EipAssignmentHook",
             auto_scaling_group=auto_scaling_group,
             lifecycle_transition=autoscaling.LifecycleTransition.INSTANCE_LAUNCHING,
-            default_result=autoscaling.DefaultResult.CONTINUE,  # Continue if timeout occurs
-            heartbeat_timeout=Duration.minutes(5),  # Allow up to 5 minutes for EIP assignment
+            default_result=autoscaling.DefaultResult.CONTINUE,
+            heartbeat_timeout=Duration.minutes(
+                5
+            ),  # Allow up to 5 minutes for EIP assignment
             lifecycle_hook_name="EipAssignmentHook",
             notification_metadata="EIP Assignment Lifecycle Hook",
         )

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -236,7 +236,7 @@ class IalirtProcessing(Construct):
             "IalirtEipLambdaRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
             managed_policies=[
-                iam.ManagedPolicy.from_aws_managed_policy_name("AWSLambdaBasicExecutionRole"),
+                iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSLambdaBasicExecutionRole"),
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEC2FullAccess"),
                 iam.ManagedPolicy.from_aws_managed_policy_name("AutoScalingFullAccess"),
             ],
@@ -256,9 +256,7 @@ class IalirtProcessing(Construct):
             memory_size=1000,
             role=lambda_role,
             environment={
-                "EIP_SECRET_ARN": eip_allocation_ids.secret_arn,
-                "REGION": self.region,
-                "SECRET_NAME": self.secret_name,
+                "EIP_SECRET_NAME": self.eip_secret_name,
             },
         )
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -1,0 +1,167 @@
+"""IALiRT Elastic IP Assignment Lambda."""
+
+import json
+import logging
+import os
+
+import boto3
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Create a batch client
+SECRETS = boto3.client("secretsmanager", region_name="us-west-2")
+EC2 = boto3.client("ec2", region_name="us-west-2")
+
+
+def check_existing_eip(instance_id):
+    """Check if the instance already has an Elastic IP assigned.
+
+    Parameters
+    ----------
+    instance_id : str
+        The EC2 instance ID.
+
+    Returns
+    -------
+    str or None
+        The existing Elastic IP allocation ID, or None if not found.
+    """
+    try:
+        addresses = EC2.describe_addresses(Filters=[{"Name": "instance-id", "Values": [instance_id]}])
+        if addresses["Addresses"]:
+            existing_eip = addresses["Addresses"][0]["PublicIp"]
+            logger.info("Instance %s already has Elastic IP: %s", instance_id, existing_eip)
+            return existing_eip
+        return None
+    except Exception as e:
+        logger.error("Error checking existing Elastic IP for instance %s: %s", instance_id, str(e))
+        return None
+
+
+def is_eip_available(eip_allocation_id):
+    """Check if an Elastic IP is available (not currently associated with any instance).
+
+    Parameters
+    ----------
+    eip_allocation_id : str
+        The Elastic IP allocation ID.
+
+    Returns
+    -------
+    bool
+        True if the EIP is available, False if it is already assigned.
+    """
+    try:
+        response = EC2.describe_addresses(AllocationIds=[eip_allocation_id])
+        if response["Addresses"] and "InstanceId" in response["Addresses"][0]:
+            logger.info("EIP %s is already associated with instance %s.", eip_allocation_id, response["Addresses"][0]["InstanceId"])
+            return False  # EIP is assigned, not available
+        logger.info("EIP %s is available.", eip_allocation_id)
+        return True  # EIP is unassociated and available
+    except Exception as e:
+        logger.error("Error checking EIP availability for %s: %s", eip_allocation_id, str(e))
+        return False
+
+
+def get_eip_allocation_ids():
+    """Retrieve Elastic IP allocation IDs from AWS Secrets Manager.
+
+    Returns
+    -------
+    list[str]
+        A list of Elastic IP allocation IDs.
+    """
+    secret_arn = os.environ.get("EIP_SECRET_ARN")
+    if not secret_arn:
+        logger.error("EIP_SECRET_ARN environment variable is not set.")
+        return []
+
+    try:
+        secret_name = os.getenv("SECRET_NAME")
+        secret_string = SECRETS.get_secret_value(SecretId=secret_name)["SecretString"]
+        secret_data = json.loads(secret_string)
+        eip_ids = [value for key, value in secret_data.items() if key.startswith("eip_allocation_id")]
+        logger.info("Retrieved %d Elastic IPs from Secrets Manager.", len(eip_ids))
+        return eip_ids
+
+    except Exception as e:
+        logger.error("Error retrieving Elastic IPs from Secrets Manager: %s", str(e))
+        return []
+
+
+def assign_elastic_ip(instance_id, eip_allocation_ids):
+    """Assign an Elastic IP to the specified EC2 instance.
+
+    Parameters
+    ----------
+    instance_id : str
+        The EC2 instance ID.
+    eip_allocation_ids : list[str]
+        A list of available Elastic IP allocation IDs.
+
+    Returns
+    -------
+    str or None
+        The assigned Elastic IP allocation ID, or None if assignment failed.
+    """
+    existing_eip = check_existing_eip(instance_id)
+    if existing_eip:
+        logger.info("Skipping EIP assignment for instance %s as it already has EIP %s", instance_id, existing_eip)
+        return existing_eip
+
+    if not eip_allocation_ids:
+        logger.error("No Elastic IP allocation IDs provided.")
+        return None
+
+    for eip_allocation_id in eip_allocation_ids:
+        if is_eip_available(eip_allocation_id):  # ✅ Only assign if truly available
+            try:
+                EC2.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
+                logger.info("Elastic IP %s assigned to instance %s.", eip_allocation_id, instance_id)
+                return eip_allocation_id
+            except Exception as e:
+                logger.error("Error assigning Elastic IP to instance %s: %s", instance_id, str(e))
+                return None
+
+    logger.error("No available Elastic IPs found to assign.")
+    return None  # No available EIPs found
+
+
+def lambda_handler(event, context):
+    """Assign an Elastic IP to a newly launched instance.
+
+    This function is triggered by an EventBridge rule listening for
+    Auto Scaling Group instance launch events.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted event data from EventBridge.
+    context : LambdaContext
+        Provides runtime information for the function.
+
+    """
+    logger.info("Received event: %s", json.dumps(event, indent=2))
+
+    instance_id = event["detail"]["EC2InstanceId"]
+    if not instance_id:
+        logger.error("No EC2 Instance ID found in event.")
+        return
+
+    logger.info("Instance ID: %s", instance_id)
+
+    # Retrieve Elastic IP allocation IDs from Secrets Manager
+    eip_allocation_ids = get_eip_allocation_ids()
+    if not eip_allocation_ids:
+        logger.error("No available Elastic IPs found in Secrets Manager.")
+        return
+
+    # Assign the first available Elastic IP to the instance
+    assigned_ip = assign_elastic_ip(instance_id, eip_allocation_ids)
+
+    if assigned_ip:
+        logger.info("Successfully assigned Elastic IP %s to instance %s", assigned_ip, instance_id)
+    else:
+        logger.error("Failed to assign an Elastic IP to instance %s", instance_id)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import time
 
 import boto3
 
@@ -10,152 +11,93 @@ import boto3
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# Create a batch client
+# AWS Clients
 SECRETS = boto3.client("secretsmanager", region_name="us-west-2")
 EC2 = boto3.client("ec2", region_name="us-west-2")
 ASG = boto3.client("autoscaling", region_name="us-west-2")
 
 
 def check_existing_eip(instance_id):
-    """Check if the instance already has an Elastic IP assigned.
-
-    Parameters
-    ----------
-    instance_id : str
-        The EC2 instance ID.
-
-    Returns
-    -------
-    str or None
-        The existing Elastic IP allocation ID, or None if not found.
-    """
+    """Check if the instance already has an Elastic IP assigned."""
     try:
         addresses = EC2.describe_addresses(Filters=[{"Name": "instance-id", "Values": [instance_id]}])
         if addresses["Addresses"]:
             existing_eip = addresses["Addresses"][0]["PublicIp"]
             logger.info("Instance %s already has Elastic IP: %s", instance_id, existing_eip)
             return existing_eip
-        return None
     except Exception as e:
         logger.error("Error checking existing Elastic IP for instance %s: %s", instance_id, str(e))
-        return None
+    return None
 
 
 def is_eip_available(eip_allocation_id):
-    """Check if an Elastic IP is available (not currently associated with any instance).
-
-    Parameters
-    ----------
-    eip_allocation_id : str
-        The Elastic IP allocation ID.
-
-    Returns
-    -------
-    bool
-        True if the EIP is available, False if it is already assigned.
-    """
+    """Check if an Elastic IP is available (not currently associated)."""
     try:
         response = EC2.describe_addresses(AllocationIds=[eip_allocation_id])
         if response["Addresses"] and "InstanceId" in response["Addresses"][0]:
             logger.info("EIP %s is already associated with instance %s.", eip_allocation_id, response["Addresses"][0]["InstanceId"])
-            return False  # EIP is assigned, not available
+            return False  # EIP is assigned
         logger.info("EIP %s is available.", eip_allocation_id)
-        return True  # EIP is unassociated and available
+        return True  # EIP is unassociated
     except Exception as e:
         logger.error("Error checking EIP availability for %s: %s", eip_allocation_id, str(e))
         return False
 
 
 def get_eip_allocation_ids():
-    """Retrieve Elastic IP allocation IDs from AWS Secrets Manager.
-
-    Returns
-    -------
-    list[str]
-        A list of Elastic IP allocation IDs.
-    """
-    secret_arn = os.environ.get("EIP_SECRET_ARN")
-    if not secret_arn:
-        logger.error("EIP_SECRET_ARN environment variable is not set.")
+    """Retrieve Elastic IP allocation IDs from AWS Secrets Manager."""
+    secret_name = os.getenv("SECRET_NAME")
+    if not secret_name:
+        logger.error("SECRET_NAME environment variable is not set.")
         return []
 
     try:
-        secret_name = os.getenv("SECRET_NAME")
         secret_string = SECRETS.get_secret_value(SecretId=secret_name)["SecretString"]
         secret_data = json.loads(secret_string)
         eip_ids = [value for key, value in secret_data.items() if key.startswith("eip_allocation_id")]
         logger.info("Retrieved %d Elastic IPs from Secrets Manager.", len(eip_ids))
         return eip_ids
-
     except Exception as e:
         logger.error("Error retrieving Elastic IPs from Secrets Manager: %s", str(e))
         return []
 
 
 def assign_elastic_ip(instance_id, eip_allocation_ids):
-    """Assign an Elastic IP to the specified EC2 instance.
+    """Assign an available Elastic IP to the specified EC2 instance."""
+    if not eip_allocation_ids:
+        logger.error("No Elastic IP allocation IDs provided.")
+        return None
 
-    Parameters
-    ----------
-    instance_id : str
-        The EC2 instance ID.
-    eip_allocation_ids : list[str]
-        A list of available Elastic IP allocation IDs.
-
-    Returns
-    -------
-    str or None
-        The assigned Elastic IP allocation ID, or None if assignment failed.
-    """
     existing_eip = check_existing_eip(instance_id)
     if existing_eip:
         logger.info("Skipping EIP assignment for instance %s as it already has EIP %s", instance_id, existing_eip)
         return existing_eip
 
-    if not eip_allocation_ids:
-        logger.error("No Elastic IP allocation IDs provided.")
-        return None
-
     for eip_allocation_id in eip_allocation_ids:
-        if is_eip_available(eip_allocation_id):  # ✅ Only assign if truly available
+        if is_eip_available(eip_allocation_id):
             try:
                 EC2.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
                 logger.info("Elastic IP %s assigned to instance %s.", eip_allocation_id, instance_id)
                 return eip_allocation_id
             except Exception as e:
-                logger.error("Error assigning Elastic IP to instance %s: %s", instance_id, str(e))
-                return None
+                logger.error("Error assigning Elastic IP %s to instance %s: %s", eip_allocation_id, instance_id, str(e))
 
     logger.error("No available Elastic IPs found to assign.")
     return None  # No available EIPs found
 
 
 def complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, result):
-    """Complete the Auto Scaling Lifecycle Hook.
-
-    Parameters
-    ----------
-    asg_name : str
-        The name of the Auto Scaling Group.
-    lifecycle_hook_name : str
-        The name of the lifecycle hook.
-    lifecycle_token : str
-        The lifecycle action token.
-    result : str
-        The result of the lifecycle action ('CONTINUE' or 'ABANDON').
-
-    """
+    """Complete the Auto Scaling Lifecycle Hook."""
     try:
-        response = ASG.complete_lifecycle_action(
+        ASG.complete_lifecycle_action(
             AutoScalingGroupName=asg_name,
             LifecycleHookName=lifecycle_hook_name,
             LifecycleActionToken=lifecycle_token,
             LifecycleActionResult=result
         )
-        logger.info("Completed lifecycle action: %s", result)
+        logger.info("Completed lifecycle action with result: %s", result)
     except Exception as e:
         logger.error("Error completing lifecycle action: %s", str(e))
-
 
 
 def lambda_handler(event, context):
@@ -163,34 +105,52 @@ def lambda_handler(event, context):
 
     This function is triggered by an EventBridge rule listening for
     Auto Scaling Group instance launch events.
-
-    Parameters
-    ----------
-    event : dict
-        The JSON formatted event data from EventBridge.
-    context : LambdaContext
-        Provides runtime information for the function.
-
     """
     logger.info("Received event: %s", json.dumps(event, indent=2))
 
-    instance_id = event["detail"]["EC2InstanceId"]
-    if not instance_id:
-        logger.error("No EC2 Instance ID found in event.")
+    # Extract event details
+    instance_id = event["detail"].get("EC2InstanceId")
+    asg_name = event["detail"].get("AutoScalingGroupName")
+    lifecycle_hook_name = event["detail"].get("LifecycleHookName")
+    lifecycle_token = event["detail"].get("LifecycleActionToken")
+
+    if not instance_id or not asg_name or not lifecycle_hook_name or not lifecycle_token:
+        logger.error("Missing required event details. Abandoning lifecycle action.")
+        complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, "ABANDON")
         return
 
-    logger.info("Instance ID: %s", instance_id)
+    logger.info("Processing instance: %s", instance_id)
 
-    # Retrieve Elastic IP allocation IDs from Secrets Manager
+    # Retrieve Elastic IP allocation IDs
     eip_allocation_ids = get_eip_allocation_ids()
     if not eip_allocation_ids:
-        logger.error("No available Elastic IPs found in Secrets Manager.")
+        logger.error("No available Elastic IPs found in Secrets Manager. Abandoning lifecycle action.")
+        complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, "ABANDON")
         return
 
-    # Assign the first available Elastic IP to the instance
-    assigned_ip = assign_elastic_ip(instance_id, eip_allocation_ids)
+    success = False
+    retries = 10  # Max retries for EIP assignment
 
-    if assigned_ip:
-        logger.info("Successfully assigned Elastic IP %s to instance %s", assigned_ip, instance_id)
-    else:
-        logger.error("Failed to assign an Elastic IP to instance %s", instance_id)
+    while not success and retries > 0:
+        retries -= 1
+        try:
+            assigned_ip = assign_elastic_ip(instance_id, eip_allocation_ids)
+
+            if assigned_ip:
+                logger.info("Successfully assigned Elastic IP %s to instance %s", assigned_ip, instance_id)
+                success = True
+                break
+            else:
+                logger.warning("Failed to assign an Elastic IP to instance %s. Retrying...", instance_id)
+
+            time.sleep(2 + (retries % 3))  # Random delay between 2-4 seconds
+
+        except Exception as e:
+            logger.error("Error during EIP assignment: %s", str(e))
+            if retries == 0:
+                logger.error("Max retries reached. Abandoning lifecycle action.")
+                complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, "ABANDON")
+                return
+
+
+    complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, "CONTINUE")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -13,6 +13,7 @@ logger.setLevel(logging.INFO)
 # Create a batch client
 SECRETS = boto3.client("secretsmanager", region_name="us-west-2")
 EC2 = boto3.client("ec2", region_name="us-west-2")
+ASG = boto3.client("autoscaling", region_name="us-west-2")
 
 
 def check_existing_eip(instance_id):
@@ -127,6 +128,34 @@ def assign_elastic_ip(instance_id, eip_allocation_ids):
 
     logger.error("No available Elastic IPs found to assign.")
     return None  # No available EIPs found
+
+
+def complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, result):
+    """Complete the Auto Scaling Lifecycle Hook.
+
+    Parameters
+    ----------
+    asg_name : str
+        The name of the Auto Scaling Group.
+    lifecycle_hook_name : str
+        The name of the lifecycle hook.
+    lifecycle_token : str
+        The lifecycle action token.
+    result : str
+        The result of the lifecycle action ('CONTINUE' or 'ABANDON').
+
+    """
+    try:
+        response = ASG.complete_lifecycle_action(
+            AutoScalingGroupName=asg_name,
+            LifecycleHookName=lifecycle_hook_name,
+            LifecycleActionToken=lifecycle_token,
+            LifecycleActionResult=result
+        )
+        logger.info("Completed lifecycle action: %s", result)
+    except Exception as e:
+        logger.error("Error completing lifecycle action: %s", str(e))
+
 
 
 def lambda_handler(event, context):

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -10,9 +10,6 @@ import boto3
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# AWS Clients
-SECRETS = boto3.client("secretsmanager", region_name="us-west-2")
-
 
 def get_eip_allocation_ids():
     """Retrieve Elastic IP allocation IDs from AWS Secrets Manager.
@@ -22,20 +19,15 @@ def get_eip_allocation_ids():
     list[str]
         A list of Elastic IP allocation IDs.
     """
-    secret_name = os.getenv("SECRET_NAME")
-    if not secret_name:
-        logger.error("SECRET_NAME environment variable is not set.")
-        return []
+    secret_name = os.getenv("EIP_SECRET_NAME")
+    SECRETS = boto3.client("secretsmanager", region_name="us-west-2")
 
-    try:
-        secret_string = SECRETS.get_secret_value(SecretId=secret_name)["SecretString"]
-        secret_data = json.loads(secret_string)
-        eip_ids = [value for key, value in secret_data.items() if key.startswith("eip_allocation_id")]
-        logger.info("Retrieved %d Elastic IPs from Secrets Manager: %s", len(eip_ids), eip_ids)
-        return eip_ids
-    except Exception as e:
-        logger.error("Error retrieving Elastic IPs from Secrets Manager: %s", str(e))
-        return []
+    secret_string = SECRETS.get_secret_value(SecretId=secret_name)["SecretString"]
+    secret_data = json.loads(secret_string)
+    eip_ids = [value for key, value in secret_data.items() if key.startswith("eip_allocation_id")]
+    logger.info("Retrieved %d Elastic IPs from Secrets Manager: %s", len(eip_ids), eip_ids)
+
+    return eip_ids
 
 
 def lambda_handler(event, context):
@@ -55,11 +47,6 @@ def lambda_handler(event, context):
     logger.info("Received event: %s", json.dumps(event, indent=2))
 
     instance_id = event["detail"].get("EC2InstanceId")
-
-    if not instance_id:
-        logger.error("No EC2 Instance ID found in event.")
-        return
-
     logger.info("Instance %s has been launched.", instance_id)
 
     # Retrieve Elastic IP allocation IDs from Secrets Manager

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -23,17 +23,20 @@ def get_eip_allocation_id():
 
     secret_string = secrets.get_secret_value(SecretId=secret_name)["SecretString"]
     secret_data = json.loads(secret_string)
-    eip_id = secret_data.items()
-    logger.info("Retrieved Elastic IP from Secrets Manager: %s", eip_id)
+    eip_allocation_id = secret_data.get("eip_allocation_id")
+    logger.info("Retrieved Elastic IP from Secrets Manager: %s", eip_allocation_id)
 
-    return eip_id
+    return eip_allocation_id
 
 
 def assign_elastic_ip(instance_id, eip_allocation_id):
     """Assign an available Elastic IP to the specified EC2 instance."""
     ec2 = boto3.client("ec2", region_name="us-west-2")
+    response = ec2.describe_addresses(AllocationIds=[eip_allocation_id])
     # Disassociate any existing Elastic IP and associate the new one
-    ec2.disassociate_address(AllocationId=eip_allocation_id)
+    if 'AssociationId' in response["Addresses"][0]:
+        association_id = response['Addresses'][0]['AssociationId']
+        ec2.disassociate_address(AssociationId=association_id)
     ec2.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
 
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -1,5 +1,3 @@
-"""IALiRT Elastic IP Debugging Lambda."""
-
 import json
 import logging
 import os
@@ -11,13 +9,6 @@ logger.setLevel(logging.INFO)
 
 
 def get_eip_allocation_id():
-    """Retrieve Elastic IP allocation IDs from AWS Secrets Manager.
-
-    Returns
-    -------
-    eip_id: str
-        Elastic IP allocation ID.
-    """
     secret_name = os.getenv("EIP_SECRET_NAME")
     secrets = boto3.client("secretsmanager", region_name="us-west-2")
 
@@ -30,18 +21,31 @@ def get_eip_allocation_id():
 
 
 def assign_elastic_ip(instance_id, eip_allocation_id):
-    """Assign an available Elastic IP to the specified EC2 instance."""
     ec2 = boto3.client("ec2", region_name="us-west-2")
-    response = ec2.describe_addresses(AllocationIds=[eip_allocation_id])
-    # Disassociate any existing Elastic IP and associate the new one
-    if "AssociationId" in response["Addresses"][0]:
-        association_id = response["Addresses"][0]["AssociationId"]
+    eip_description = ec2.describe_addresses(AllocationIds=[eip_allocation_id])
+    logger.info("response: %s", eip_description)
+    # Describe the instance properties
+    ec2_description = ec2.describe_instances(InstanceIds=[instance_id])
+    logger.info("response2: %s", ec2_description)
+    if (
+        ec2_description["Addresses"][0]["PublicIp"]
+        == ec2_description["Addresses"][0]["PublicIp"]
+    ):
+        logger.info("Elastic IP is already associated with this instance.")
+        return
+    elif "AssociationId" in eip_description["Addresses"][0]:
+        # Allocation ID is associated with another instance
+        # and needs to be disassociated.
+        association_id = eip_description["Addresses"][0]["AssociationId"]
         ec2.disassociate_address(AssociationId=association_id)
+        logger.info("Elastic IP disassociated from old instance.")
+
+    # Associate the Elastic IP with instance if not already associated with it.
     ec2.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
+    logger.info("Elastic IP associated with instance %s", instance_id)
 
 
 def complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, result):
-    """Complete the Auto Scaling Lifecycle Hook."""
     ec2_client = boto3.client("autoscaling", region_name="us-west-2")
     ec2_client.complete_lifecycle_action(
         AutoScalingGroupName=asg_name,
@@ -68,9 +72,6 @@ def lambda_handler(event, context):
     """
     logger.info("Received event: %s", json.dumps(event, indent=2))
 
-    instance_id = event["detail"].get("EC2InstanceId")
-    logger.info("Instance %s has been launched.", instance_id)
-
     # Retrieve Elastic IP allocation IDs from Secrets Manager
     eip_allocation_id = get_eip_allocation_id()
 
@@ -79,13 +80,25 @@ def lambda_handler(event, context):
     else:
         logger.warning("No available Elastic IPs found.")
 
+    details = event["detail"]
+    if "EC2InstanceId" in details:
+        # Instance launch event.
+        instance_id = details.get("EC2InstanceId")
+    else:
+        # Deployment event.
+        instance_id = details["instance-id"]
+
     # Assign Elastic IP to the instance.
     assign_elastic_ip(instance_id, eip_allocation_id)
 
-    # Complete the lifecycle action
-    lifecycle_token = event["detail"]["LifecycleActionToken"]
-    asg_name = event["detail"]["AutoScalingGroupName"]
-    lifecycle_hook_name = event["detail"]["LifecycleHookName"]
-    complete_lifecycle_action(
-        asg_name, lifecycle_hook_name, lifecycle_token, "CONTINUE"
-    )
+    if "EC2InstanceId" in details:
+        # Complete the lifecycle action
+        lifecycle_token = event["detail"]["LifecycleActionToken"]
+        asg_name = event["detail"]["AutoScalingGroupName"]
+        lifecycle_hook_name = event["detail"]["LifecycleHookName"]
+        complete_lifecycle_action(
+            asg_name, lifecycle_hook_name, lifecycle_token, "CONTINUE"
+        )
+        logger.info("Lifecycle Action Completed")
+    else:
+        logger.info("Instance launch event completed.")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -34,10 +34,22 @@ def assign_elastic_ip(instance_id, eip_allocation_id):
     ec2 = boto3.client("ec2", region_name="us-west-2")
     response = ec2.describe_addresses(AllocationIds=[eip_allocation_id])
     # Disassociate any existing Elastic IP and associate the new one
-    if 'AssociationId' in response["Addresses"][0]:
-        association_id = response['Addresses'][0]['AssociationId']
+    if "AssociationId" in response["Addresses"][0]:
+        association_id = response["Addresses"][0]["AssociationId"]
         ec2.disassociate_address(AssociationId=association_id)
     ec2.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
+
+
+def complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, result):
+    """Complete the Auto Scaling Lifecycle Hook."""
+    ec2_client = boto3.client("autoscaling", region_name="us-west-2")
+    ec2_client.complete_lifecycle_action(
+        AutoScalingGroupName=asg_name,
+        LifecycleHookName=lifecycle_hook_name,
+        LifecycleActionToken=lifecycle_token,
+        LifecycleActionResult=result,
+    )
+    logger.info("Completed lifecycle action with result: %s", result)
 
 
 def lambda_handler(event, context):
@@ -69,3 +81,11 @@ def lambda_handler(event, context):
 
     # Assign Elastic IP to the instance.
     assign_elastic_ip(instance_id, eip_allocation_id)
+
+    # Complete the lifecycle action
+    lifecycle_token = event["detail"]["LifecycleActionToken"]
+    asg_name = event["detail"]["AutoScalingGroupName"]
+    lifecycle_hook_name = event["detail"]["LifecycleHookName"]
+    complete_lifecycle_action(
+        asg_name, lifecycle_hook_name, lifecycle_token, "CONTINUE"
+    )

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -1,3 +1,5 @@
+"""Test the I-Alirt EIP lambda function."""
+
 import json
 import logging
 import os
@@ -8,7 +10,14 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def get_eip_allocation_id():
+def get_eip_allocation_id() -> str:
+    """Get EIP Allocation ID from Secrets Manager.
+
+    Returns
+    -------
+    eip_allocation_id : str
+        Elastic IP Allocation ID.
+    """
     secret_name = os.getenv("EIP_SECRET_NAME")
     secrets = boto3.client("secretsmanager", region_name="us-west-2")
 
@@ -20,47 +29,66 @@ def get_eip_allocation_id():
     return eip_allocation_id
 
 
-def assign_elastic_ip(instance_id, eip_allocation_id):
+def assign_elastic_ip(instance_id: str, eip_allocation_id: str, eventtype: str):
+    """Assign EIP to Instance.
+
+    Parameters
+    ----------
+    instance_id : str
+        Instance ID.
+    eip_allocation_id : str
+        Elastic IP Allocation ID.
+    eventtype : str
+        Event type (launch or deploy).
+    """
     ec2 = boto3.client("ec2", region_name="us-west-2")
     eip_description = ec2.describe_addresses(AllocationIds=[eip_allocation_id])
-    logger.info("response: %s", eip_description)
-    # Describe the instance properties
     ec2_description = ec2.describe_instances(InstanceIds=[instance_id])
-    logger.info("response2: %s", ec2_description)
+    logger.info("eventtype%s", eventtype)
+    logger.info("Elastic IP Description: %s", eip_description)
+    logger.info("EC2 Description: %s", ec2_description)
+
     if (
-        ec2_description["Addresses"][0]["PublicIp"]
-        == ec2_description["Addresses"][0]["PublicIp"]
+        ec2_description["Reservations"][0]["Instances"][0]["PublicIpAddress"]
+        == eip_description["Addresses"][0]["PublicIp"]
     ):
         logger.info("Elastic IP is already associated with this instance.")
         return
     elif "AssociationId" in eip_description["Addresses"][0]:
-        # Allocation ID is associated with another instance
-        # and needs to be disassociated.
         association_id = eip_description["Addresses"][0]["AssociationId"]
         ec2.disassociate_address(AssociationId=association_id)
         logger.info("Elastic IP disassociated from old instance.")
 
-    # Associate the Elastic IP with instance if not already associated with it.
     ec2.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
     logger.info("Elastic IP associated with instance %s", instance_id)
 
 
-def complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, result):
+def complete_lifecycle_action(
+    asg_name: str, lifecycle_hook_name: str, lifecycle_token: str
+):
+    """Complete the lifecycle transition.
+
+    Parameters
+    ----------
+    asg_name : str
+        AutoScaling Group Name.
+    lifecycle_hook_name : str
+        Lifecycle hook name.
+    lifecycle_token : str
+        Lifecycle token.
+    """
     ec2_client = boto3.client("autoscaling", region_name="us-west-2")
     ec2_client.complete_lifecycle_action(
         AutoScalingGroupName=asg_name,
         LifecycleHookName=lifecycle_hook_name,
         LifecycleActionToken=lifecycle_token,
-        LifecycleActionResult=result,
+        LifecycleActionResult="CONTINUE",
     )
-    logger.info("Completed lifecycle action with result: %s", result)
+    logger.info("Completed lifecycle action with result CONTINUE")
 
 
 def lambda_handler(event, context):
-    """Print available Elastic IPs when an instance launches.
-
-    This function is triggered by an EventBridge rule listening for
-    Auto Scaling Group instance launch events.
+    """Assign Elastic IPs when an instance launches.
 
     Parameters
     ----------
@@ -72,7 +100,6 @@ def lambda_handler(event, context):
     """
     logger.info("Received event: %s", json.dumps(event, indent=2))
 
-    # Retrieve Elastic IP allocation IDs from Secrets Manager
     eip_allocation_id = get_eip_allocation_id()
 
     if eip_allocation_id:
@@ -84,21 +111,17 @@ def lambda_handler(event, context):
     if "EC2InstanceId" in details:
         # Instance launch event.
         instance_id = details.get("EC2InstanceId")
+        assign_elastic_ip(instance_id, eip_allocation_id, "launch")
     else:
         # Deployment event.
         instance_id = details["instance-id"]
-
-    # Assign Elastic IP to the instance.
-    assign_elastic_ip(instance_id, eip_allocation_id)
+        assign_elastic_ip(instance_id, eip_allocation_id, "deploy")
 
     if "EC2InstanceId" in details:
-        # Complete the lifecycle action
         lifecycle_token = event["detail"]["LifecycleActionToken"]
         asg_name = event["detail"]["AutoScalingGroupName"]
         lifecycle_hook_name = event["detail"]["LifecycleHookName"]
-        complete_lifecycle_action(
-            asg_name, lifecycle_hook_name, lifecycle_token, "CONTINUE"
-        )
+        complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token)
         logger.info("Lifecycle Action Completed")
     else:
         logger.info("Instance launch event completed.")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -1,9 +1,8 @@
-"""IALiRT Elastic IP Assignment Lambda."""
+"""IALiRT Elastic IP Debugging Lambda."""
 
 import json
 import logging
 import os
-import time
 
 import boto3
 
@@ -13,39 +12,16 @@ logger.setLevel(logging.INFO)
 
 # AWS Clients
 SECRETS = boto3.client("secretsmanager", region_name="us-west-2")
-EC2 = boto3.client("ec2", region_name="us-west-2")
-ASG = boto3.client("autoscaling", region_name="us-west-2")
-
-
-def check_existing_eip(instance_id):
-    """Check if the instance already has an Elastic IP assigned."""
-    try:
-        addresses = EC2.describe_addresses(Filters=[{"Name": "instance-id", "Values": [instance_id]}])
-        if addresses["Addresses"]:
-            existing_eip = addresses["Addresses"][0]["PublicIp"]
-            logger.info("Instance %s already has Elastic IP: %s", instance_id, existing_eip)
-            return existing_eip
-    except Exception as e:
-        logger.error("Error checking existing Elastic IP for instance %s: %s", instance_id, str(e))
-    return None
-
-
-def is_eip_available(eip_allocation_id):
-    """Check if an Elastic IP is available (not currently associated)."""
-    try:
-        response = EC2.describe_addresses(AllocationIds=[eip_allocation_id])
-        if response["Addresses"] and "InstanceId" in response["Addresses"][0]:
-            logger.info("EIP %s is already associated with instance %s.", eip_allocation_id, response["Addresses"][0]["InstanceId"])
-            return False  # EIP is assigned
-        logger.info("EIP %s is available.", eip_allocation_id)
-        return True  # EIP is unassociated
-    except Exception as e:
-        logger.error("Error checking EIP availability for %s: %s", eip_allocation_id, str(e))
-        return False
 
 
 def get_eip_allocation_ids():
-    """Retrieve Elastic IP allocation IDs from AWS Secrets Manager."""
+    """Retrieve Elastic IP allocation IDs from AWS Secrets Manager.
+
+    Returns
+    -------
+    list[str]
+        A list of Elastic IP allocation IDs.
+    """
     secret_name = os.getenv("SECRET_NAME")
     if not secret_name:
         logger.error("SECRET_NAME environment variable is not set.")
@@ -55,102 +31,41 @@ def get_eip_allocation_ids():
         secret_string = SECRETS.get_secret_value(SecretId=secret_name)["SecretString"]
         secret_data = json.loads(secret_string)
         eip_ids = [value for key, value in secret_data.items() if key.startswith("eip_allocation_id")]
-        logger.info("Retrieved %d Elastic IPs from Secrets Manager.", len(eip_ids))
+        logger.info("Retrieved %d Elastic IPs from Secrets Manager: %s", len(eip_ids), eip_ids)
         return eip_ids
     except Exception as e:
         logger.error("Error retrieving Elastic IPs from Secrets Manager: %s", str(e))
         return []
 
 
-def assign_elastic_ip(instance_id, eip_allocation_ids):
-    """Assign an available Elastic IP to the specified EC2 instance."""
-    if not eip_allocation_ids:
-        logger.error("No Elastic IP allocation IDs provided.")
-        return None
-
-    existing_eip = check_existing_eip(instance_id)
-    if existing_eip:
-        logger.info("Skipping EIP assignment for instance %s as it already has EIP %s", instance_id, existing_eip)
-        return existing_eip
-
-    for eip_allocation_id in eip_allocation_ids:
-        if is_eip_available(eip_allocation_id):
-            try:
-                EC2.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
-                logger.info("Elastic IP %s assigned to instance %s.", eip_allocation_id, instance_id)
-                return eip_allocation_id
-            except Exception as e:
-                logger.error("Error assigning Elastic IP %s to instance %s: %s", eip_allocation_id, instance_id, str(e))
-
-    logger.error("No available Elastic IPs found to assign.")
-    return None  # No available EIPs found
-
-
-def complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, result):
-    """Complete the Auto Scaling Lifecycle Hook."""
-    try:
-        ASG.complete_lifecycle_action(
-            AutoScalingGroupName=asg_name,
-            LifecycleHookName=lifecycle_hook_name,
-            LifecycleActionToken=lifecycle_token,
-            LifecycleActionResult=result
-        )
-        logger.info("Completed lifecycle action with result: %s", result)
-    except Exception as e:
-        logger.error("Error completing lifecycle action: %s", str(e))
-
-
 def lambda_handler(event, context):
-    """Assign an Elastic IP to a newly launched instance.
+    """Print available Elastic IPs when an instance launches.
 
     This function is triggered by an EventBridge rule listening for
     Auto Scaling Group instance launch events.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted event data from EventBridge.
+    context : LambdaContext
+        Provides runtime information for the function.
+
     """
     logger.info("Received event: %s", json.dumps(event, indent=2))
 
-    # Extract event details
     instance_id = event["detail"].get("EC2InstanceId")
-    asg_name = event["detail"].get("AutoScalingGroupName")
-    lifecycle_hook_name = event["detail"].get("LifecycleHookName")
-    lifecycle_token = event["detail"].get("LifecycleActionToken")
 
-    if not instance_id or not asg_name or not lifecycle_hook_name or not lifecycle_token:
-        logger.error("Missing required event details. Abandoning lifecycle action.")
-        complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, "ABANDON")
+    if not instance_id:
+        logger.error("No EC2 Instance ID found in event.")
         return
 
-    logger.info("Processing instance: %s", instance_id)
+    logger.info("Instance %s has been launched.", instance_id)
 
-    # Retrieve Elastic IP allocation IDs
+    # Retrieve Elastic IP allocation IDs from Secrets Manager
     eip_allocation_ids = get_eip_allocation_ids()
-    if not eip_allocation_ids:
-        logger.error("No available Elastic IPs found in Secrets Manager. Abandoning lifecycle action.")
-        complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, "ABANDON")
-        return
 
-    success = False
-    retries = 10  # Max retries for EIP assignment
-
-    while not success and retries > 0:
-        retries -= 1
-        try:
-            assigned_ip = assign_elastic_ip(instance_id, eip_allocation_ids)
-
-            if assigned_ip:
-                logger.info("Successfully assigned Elastic IP %s to instance %s", assigned_ip, instance_id)
-                success = True
-                break
-            else:
-                logger.warning("Failed to assign an Elastic IP to instance %s. Retrying...", instance_id)
-
-            time.sleep(2 + (retries % 3))  # Random delay between 2-4 seconds
-
-        except Exception as e:
-            logger.error("Error during EIP assignment: %s", str(e))
-            if retries == 0:
-                logger.error("Max retries reached. Abandoning lifecycle action.")
-                complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, "ABANDON")
-                return
-
-
-    complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token, "CONTINUE")
+    if eip_allocation_ids:
+        logger.info("Available Elastic IPs: %s", eip_allocation_ids)
+    else:
+        logger.warning("No available Elastic IPs found.")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -45,8 +45,6 @@ def assign_elastic_ip(instance_id: str, eip_allocation_id: str, eventtype: str):
     eip_description = ec2.describe_addresses(AllocationIds=[eip_allocation_id])
     ec2_description = ec2.describe_instances(InstanceIds=[instance_id])
     logger.info("eventtype%s", eventtype)
-    logger.info("Elastic IP Description: %s", eip_description)
-    logger.info("EC2 Description: %s", ec2_description)
 
     if (
         ec2_description["Reservations"][0]["Instances"][0]["PublicIpAddress"]
@@ -124,4 +122,4 @@ def lambda_handler(event, context):
         complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token)
         logger.info("Lifecycle Action Completed")
     else:
-        logger.info("Instance launch event completed.")
+        logger.info("Instance deploy event completed.")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -6,28 +6,35 @@ import os
 
 import boto3
 
-# Configure logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def get_eip_allocation_ids():
+def get_eip_allocation_id():
     """Retrieve Elastic IP allocation IDs from AWS Secrets Manager.
 
     Returns
     -------
-    list[str]
-        A list of Elastic IP allocation IDs.
+    eip_id: str
+        Elastic IP allocation ID.
     """
     secret_name = os.getenv("EIP_SECRET_NAME")
-    SECRETS = boto3.client("secretsmanager", region_name="us-west-2")
+    secrets = boto3.client("secretsmanager", region_name="us-west-2")
 
-    secret_string = SECRETS.get_secret_value(SecretId=secret_name)["SecretString"]
+    secret_string = secrets.get_secret_value(SecretId=secret_name)["SecretString"]
     secret_data = json.loads(secret_string)
-    eip_ids = [value for key, value in secret_data.items() if key.startswith("eip_allocation_id")]
-    logger.info("Retrieved %d Elastic IPs from Secrets Manager: %s", len(eip_ids), eip_ids)
+    eip_id = secret_data.items()
+    logger.info("Retrieved Elastic IP from Secrets Manager: %s", eip_id)
 
-    return eip_ids
+    return eip_id
+
+
+def assign_elastic_ip(instance_id, eip_allocation_id):
+    """Assign an available Elastic IP to the specified EC2 instance."""
+    ec2 = boto3.client("ec2", region_name="us-west-2")
+    # Disassociate any existing Elastic IP and associate the new one
+    ec2.disassociate_address(AllocationId=eip_allocation_id)
+    ec2.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
 
 
 def lambda_handler(event, context):
@@ -50,9 +57,12 @@ def lambda_handler(event, context):
     logger.info("Instance %s has been launched.", instance_id)
 
     # Retrieve Elastic IP allocation IDs from Secrets Manager
-    eip_allocation_ids = get_eip_allocation_ids()
+    eip_allocation_id = get_eip_allocation_id()
 
-    if eip_allocation_ids:
-        logger.info("Available Elastic IPs: %s", eip_allocation_ids)
+    if eip_allocation_id:
+        logger.info("Available Elastic IPs: %s", eip_allocation_id)
     else:
         logger.warning("No available Elastic IPs found.")
+
+    # Assign Elastic IP to the instance.
+    assign_elastic_ip(instance_id, eip_allocation_id)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 
 import boto3
 
@@ -10,23 +9,36 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def get_eip_allocation_id() -> str:
-    """Get EIP Allocation ID from Secrets Manager.
+def get_or_allocate_eip() -> str:
+    """Get or Create EIP Allocation ID.
 
     Returns
     -------
-    eip_allocation_id : str
+    allocation_id : str
         Elastic IP Allocation ID.
     """
-    secret_name = os.getenv("EIP_SECRET_NAME")
-    secrets = boto3.client("secretsmanager", region_name="us-west-2")
-
-    secret_string = secrets.get_secret_value(SecretId=secret_name)["SecretString"]
-    secret_data = json.loads(secret_string)
-    eip_allocation_id = secret_data.get("eip_allocation_id")
-    logger.info("Retrieved Elastic IP from Secrets Manager: %s", eip_allocation_id)
-
-    return eip_allocation_id
+    tag_name = "I-Alirt EIP"
+    ec2 = boto3.client("ec2", region_name="us-west-2")
+    eip_description = ec2.describe_addresses(
+        Filters=[{"Name": "tag:Name", "Values": [tag_name]}]
+    )
+    addresses = eip_description.get("Addresses", [])
+    if addresses:
+        allocation_id = addresses[0]["AllocationId"]
+        logger.info("Found existing EIP allocation: %s", allocation_id)
+        return allocation_id
+    else:
+        response = ec2.allocate_address(Domain="vpc")
+        allocation_id = response["AllocationId"]
+        public_ip = response["PublicIp"]
+        logger.info(
+            "Allocated new EIP: %s (Allocation ID: %s)", public_ip, allocation_id
+        )
+        ec2.create_tags(
+            Resources=[allocation_id],
+            Tags=[{"Key": "Name", "Value": tag_name}],
+        )
+        return allocation_id
 
 
 def assign_elastic_ip(instance_id: str, eip_allocation_id: str, eventtype: str):
@@ -74,12 +86,8 @@ def lambda_handler(event, context):
     """
     logger.info("Received event: %s", json.dumps(event, indent=2))
 
-    eip_allocation_id = get_eip_allocation_id()
-
-    if eip_allocation_id:
-        logger.info("Available Elastic IPs: %s", eip_allocation_id)
-    else:
-        logger.warning("No available Elastic IPs found.")
+    eip_allocation_id = get_or_allocate_eip()
+    logger.info("Using Elastic IP allocation ID: %s", eip_allocation_id)
 
     details = event["detail"]
     if "EC2InstanceId" in details:
@@ -103,6 +111,5 @@ def lambda_handler(event, context):
             LifecycleActionResult="CONTINUE",
         )
         logger.info("Completed lifecycle action with result CONTINUE")
-        logger.info("Lifecycle Action Completed")
     else:
         logger.info("Instance deploy event completed.")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -61,30 +61,6 @@ def assign_elastic_ip(instance_id: str, eip_allocation_id: str, eventtype: str):
     logger.info("Elastic IP associated with instance %s", instance_id)
 
 
-def complete_lifecycle_action(
-    asg_name: str, lifecycle_hook_name: str, lifecycle_token: str
-):
-    """Complete the lifecycle transition.
-
-    Parameters
-    ----------
-    asg_name : str
-        AutoScaling Group Name.
-    lifecycle_hook_name : str
-        Lifecycle hook name.
-    lifecycle_token : str
-        Lifecycle token.
-    """
-    ec2_client = boto3.client("autoscaling", region_name="us-west-2")
-    ec2_client.complete_lifecycle_action(
-        AutoScalingGroupName=asg_name,
-        LifecycleHookName=lifecycle_hook_name,
-        LifecycleActionToken=lifecycle_token,
-        LifecycleActionResult="CONTINUE",
-    )
-    logger.info("Completed lifecycle action with result CONTINUE")
-
-
 def lambda_handler(event, context):
     """Assign Elastic IPs when an instance launches.
 
@@ -119,7 +95,14 @@ def lambda_handler(event, context):
         lifecycle_token = event["detail"]["LifecycleActionToken"]
         asg_name = event["detail"]["AutoScalingGroupName"]
         lifecycle_hook_name = event["detail"]["LifecycleHookName"]
-        complete_lifecycle_action(asg_name, lifecycle_hook_name, lifecycle_token)
+        ec2_client = boto3.client("autoscaling", region_name="us-west-2")
+        ec2_client.complete_lifecycle_action(
+            AutoScalingGroupName=asg_name,
+            LifecycleHookName=lifecycle_hook_name,
+            LifecycleActionToken=lifecycle_token,
+            LifecycleActionResult="CONTINUE",
+        )
+        logger.info("Completed lifecycle action with result CONTINUE")
         logger.info("Lifecycle Action Completed")
     else:
         logger.info("Instance deploy event completed.")

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -314,7 +314,6 @@ def build_sds(
     # All traffic to I-ALiRT is directed to listed container ports
     ialirt_ports = [7526, 7560, 7564, 7566, 7568]
     ialirt_secret_name = "nexus-credentials"  # noqa
-    eip_secret_name = "allocation-credentials"  # noqa
 
     ialirt_processing_construct.IalirtProcessing(
         scope=ialirt_stack,
@@ -324,7 +323,6 @@ def build_sds(
         ports=ialirt_ports,
         ialirt_bucket=ialirt_bucket.ialirt_bucket,
         secret_name=ialirt_secret_name,
-        eip_secret_name=eip_secret_name,
     )
 
 

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -314,6 +314,7 @@ def build_sds(
     # All traffic to I-ALiRT is directed to listed container ports
     ialirt_ports = [7526, 7560, 7564, 7566, 7568]
     ialirt_secret_name = "nexus-credentials"  # noqa
+    eip_secret_name = "eip-credentials" # noqa
 
     ialirt_processing_construct.IalirtProcessing(
         scope=ialirt_stack,
@@ -322,6 +323,7 @@ def build_sds(
         ports=ialirt_ports,
         ialirt_bucket=ialirt_bucket.ialirt_bucket,
         secret_name=ialirt_secret_name,
+        eip_secret_name=eip_secret_name,
     )
 
 

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -314,11 +314,12 @@ def build_sds(
     # All traffic to I-ALiRT is directed to listed container ports
     ialirt_ports = [7526, 7560, 7564, 7566, 7568]
     ialirt_secret_name = "nexus-credentials"  # noqa
-    eip_secret_name = "eip-credentials" # noqa
+    eip_secret_name = "allocation-credentials"  # noqa
 
     ialirt_processing_construct.IalirtProcessing(
         scope=ialirt_stack,
         construct_id="IalirtProcessing",
+        env=env,
         vpc=networking.vpc,
         ports=ialirt_ports,
         ialirt_bucket=ialirt_bucket.ialirt_bucket,

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -24,6 +24,7 @@ def _set_env(monkeypatch):
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("EIP_SECRET_NAME", "eip-credentials")
 
 
 @pytest.fixture(scope="module")

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -24,7 +24,6 @@ def _set_env(monkeypatch):
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
-    monkeypatch.setenv("EIP_SECRET_NAME", "eip-credentials")
 
 
 @pytest.fixture(scope="module")

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -1,7 +1,6 @@
 """Test the I-Alirt EIP lambda function."""
 
 import json
-import pytest
 
 import boto3
 from moto import mock_ec2, mock_secretsmanager
@@ -27,7 +26,7 @@ def test_get_eip_allocation_id(monkeypatch):
     eip_allocation_id = get_eip_allocation_id()
 
     # Modify the assertion to expect a string instead of a list
-    assert eip_allocation_id == "eip-12345678"  # Expected to return a string
+    assert eip_allocation_id == "eip-12345678"
 
 
 @mock_ec2
@@ -77,7 +76,9 @@ def test_assign_elastic_ip_disassociate(caplog):
     eip_allocation_id = eip_response["AllocationId"]
 
     # Associate the EIP with the second instance
-    ec2_client.associate_address(InstanceId=instance_id_2, AllocationId=eip_allocation_id)
+    ec2_client.associate_address(
+        InstanceId=instance_id_2, AllocationId=eip_allocation_id
+    )
 
     # Run the function to assign the EIP to the first instance
     with caplog.at_level("INFO"):
@@ -90,8 +91,3 @@ def test_assign_elastic_ip_disassociate(caplog):
     response = ec2_client.describe_addresses(AllocationIds=[eip_allocation_id])
     assert response["Addresses"][0]["InstanceId"] == instance_id_1
     assert response["Addresses"][0]["AllocationId"] == eip_allocation_id
-
-    # Check that the association with the second instance has been removed
-    with pytest.raises(Exception):
-        ec2_client.describe_addresses(AllocationIds=[eip_allocation_id, instance_id_2])
-

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -6,6 +6,7 @@ from moto import mock_ec2
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_eip import (
     assign_elastic_ip,
     get_or_allocate_eip,
+    lambda_handler,
 )
 
 
@@ -80,3 +81,18 @@ def test_assign_elastic_ip_disassociate(caplog):
     with caplog.at_level("INFO"):
         assign_elastic_ip(instance_id_1, eip_allocation_id, "deploy")
         assert "Elastic IP disassociated from old instance." in caplog.text
+
+
+@mock_ec2
+def test_lambda_handler_deploy(monkeypatch):
+    """Test lambda_handler function."""
+    monkeypatch.setattr(
+        "sds_data_manager.lambda_code.IAlirtCode.ialirt_eip.assign_elastic_ip",
+        lambda instance_id, eip_allocation_id, eventtype: None,
+    )
+
+    # Create a minimal event that uses the deploy branch.
+    event = {"detail": {"instance-id": "i-0abcdef1234567890"}}
+
+    # Call lambda_handler with a dummy context (None).
+    lambda_handler(event, None)

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -30,7 +30,7 @@ def test_get_eip_allocation_id(monkeypatch):
 
 
 @mock_ec2
-def test_assign_elastic_ip():
+def test_assign_elastic_ip(caplog):
     """Test the assign_elastic_ip function."""
     # Mock EC2 client
     ec2_client = boto3.client("ec2", region_name="us-west-2")
@@ -45,12 +45,9 @@ def test_assign_elastic_ip():
     eip_response = ec2_client.allocate_address(Domain="vpc")
     eip_allocation_id = eip_response["AllocationId"]
 
-    # Before the test, associate the EIP to the instance
-    ec2_client.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
-
-    # Run the function to assign the EIP
-    assign_elastic_ip(instance_id, eip_allocation_id)
-
-    # Verify that the address is still associated
-    response = ec2_client.describe_addresses(AllocationIds=[eip_allocation_id])
-    assert response["Addresses"][0]["AllocationId"] == eip_allocation_id
+    with caplog.at_level("INFO"):
+        # Run the function to assign the EIP
+        assign_elastic_ip(instance_id, eip_allocation_id, "deploy")
+        assert f"Elastic IP associated with instance {instance_id}" in caplog.text
+        assign_elastic_ip(instance_id, eip_allocation_id, "deploy")
+        assert "Elastic IP is already associated with this instance." in caplog.text

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -12,34 +12,21 @@ from sds_data_manager.lambda_code.IAlirtCode.ialirt_eip import (
 
 
 @mock_secretsmanager
-def test_get_eip_allocation_id():
+def test_get_eip_allocation_id(monkeypatch):
     """Tests the lambda handler."""
     client = boto3.client("secretsmanager", region_name="us-west-2")
+    monkeypatch.setenv("EIP_SECRET_NAME", "allocation-credentials")
 
     # Mock secret data
     secret_name = "allocation-credentials"  # noqa
     secret_data = {"eip_allocation_id": "eip-12345678"}
     client.create_secret(Name=secret_name, SecretString=json.dumps(secret_data))
 
-    eip_allocation_ids = get_eip_allocation_id()
-    assert eip_allocation_ids == ["eip-12345678"]
+    # Call the function to retrieve the EIP allocation ID
+    eip_allocation_id = get_eip_allocation_id()
 
-
-from moto import mock_secretsmanager
-
-
-@mock_secretsmanager
-def test_get_eip_allocation_id():
-    """Test the retrieval of the EIP allocation ID from Secrets Manager."""
-    client = boto3.client("secretsmanager", region_name="us-west-2")
-
-    # Mock secret data
-    secret_name = "allocation-credentials"  # noqa
-    secret_data = {"eip_allocation_id": "eip-12345678"}
-    client.create_secret(Name=secret_name, SecretString=json.dumps(secret_data))
-
-    eip_allocation_ids = get_eip_allocation_id()
-    assert eip_allocation_ids == ["eip-12345678"]
+    # Modify the assertion to expect a string instead of a list
+    assert eip_allocation_id == "eip-12345678"  # Expected to return a string
 
 
 @mock_ec2
@@ -60,10 +47,6 @@ def test_assign_elastic_ip():
 
     # Before the test, associate the EIP to the instance
     ec2_client.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
-
-    # Verify that the address is associated
-    response = ec2_client.describe_addresses(AllocationIds=[eip_allocation_id])
-    assert response["Addresses"][0]["AllocationId"] == eip_allocation_id
 
     # Run the function to assign the EIP
     assign_elastic_ip(instance_id, eip_allocation_id)

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -83,11 +83,4 @@ def test_assign_elastic_ip_disassociate(caplog):
     # Run the function to assign the EIP to the first instance
     with caplog.at_level("INFO"):
         assign_elastic_ip(instance_id_1, eip_allocation_id, "deploy")
-
-        # Check if the disassociation log message is present
         assert "Elastic IP disassociated from old instance." in caplog.text
-
-    # Verify that the EIP is now associated with the first instance
-    response = ec2_client.describe_addresses(AllocationIds=[eip_allocation_id])
-    assert response["Addresses"][0]["InstanceId"] == instance_id_1
-    assert response["Addresses"][0]["AllocationId"] == eip_allocation_id

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -1,0 +1,27 @@
+import pytest
+import boto3
+import json
+from moto import mock_secretsmanager
+
+from sds_data_manager.lambda_code.IAlirtCode.ialirt_eip import lambda_handler, get_eip_allocation_ids
+
+
+@mock_secretsmanager
+def test_lambda_handler():
+    # Mock AWS Secrets Manager
+    client = boto3.client("secretsmanager", region_name="us-west-2")
+
+    # Mock secret data
+    secret_name = "eip-credentials"
+    secret_data = {"eip_allocation_id_1": "eip-12345678", "eip_allocation_id_2": "eip-87654321"}
+    client.create_secret(Name=secret_name, SecretString=json.dumps(secret_data))
+
+    eip_allocation_ids = get_eip_allocation_ids()
+    assert eip_allocation_ids == ["eip-12345678", "eip-87654321"]
+
+    event = {
+        "detail": {
+            "EC2InstanceId": "i-0123456789abcdef0"
+        }
+    }
+    lambda_handler(event, {})

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -1,27 +1,28 @@
-import pytest
-import boto3
+"""Test the I-Alirt EIP lambda function."""
+
 import json
+
+import boto3
 from moto import mock_secretsmanager
 
-from sds_data_manager.lambda_code.IAlirtCode.ialirt_eip import lambda_handler, get_eip_allocation_ids
+from sds_data_manager.lambda_code.IAlirtCode.ialirt_eip import (
+    get_eip_allocation_id,
+    lambda_handler,
+)
 
 
 @mock_secretsmanager
 def test_lambda_handler():
-    # Mock AWS Secrets Manager
+    """Tests the lambda handler."""
     client = boto3.client("secretsmanager", region_name="us-west-2")
 
     # Mock secret data
-    secret_name = "eip-credentials"
-    secret_data = {"eip_allocation_id_1": "eip-12345678", "eip_allocation_id_2": "eip-87654321"}
+    secret_name = "allocation-credentials"  # noqa
+    secret_data = {"eip_allocation_id": "eip-12345678"}
     client.create_secret(Name=secret_name, SecretString=json.dumps(secret_data))
 
-    eip_allocation_ids = get_eip_allocation_ids()
-    assert eip_allocation_ids == ["eip-12345678", "eip-87654321"]
+    eip_allocation_ids = get_eip_allocation_id()
+    assert eip_allocation_ids == ["eip-12345678"]
 
-    event = {
-        "detail": {
-            "EC2InstanceId": "i-0123456789abcdef0"
-        }
-    }
+    event = {"detail": {"EC2InstanceId": "i-0123456789abcdef0"}}
     lambda_handler(event, {})

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -3,16 +3,16 @@
 import json
 
 import boto3
-from moto import mock_secretsmanager
+from moto import mock_ec2, mock_secretsmanager
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_eip import (
+    assign_elastic_ip,
     get_eip_allocation_id,
-    lambda_handler,
 )
 
 
 @mock_secretsmanager
-def test_lambda_handler():
+def test_get_eip_allocation_id():
     """Tests the lambda handler."""
     client = boto3.client("secretsmanager", region_name="us-west-2")
 
@@ -24,5 +24,50 @@ def test_lambda_handler():
     eip_allocation_ids = get_eip_allocation_id()
     assert eip_allocation_ids == ["eip-12345678"]
 
-    event = {"detail": {"EC2InstanceId": "i-0123456789abcdef0"}}
-    lambda_handler(event, {})
+
+from moto import mock_secretsmanager
+
+
+@mock_secretsmanager
+def test_get_eip_allocation_id():
+    """Test the retrieval of the EIP allocation ID from Secrets Manager."""
+    client = boto3.client("secretsmanager", region_name="us-west-2")
+
+    # Mock secret data
+    secret_name = "allocation-credentials"  # noqa
+    secret_data = {"eip_allocation_id": "eip-12345678"}
+    client.create_secret(Name=secret_name, SecretString=json.dumps(secret_data))
+
+    eip_allocation_ids = get_eip_allocation_id()
+    assert eip_allocation_ids == ["eip-12345678"]
+
+
+@mock_ec2
+def test_assign_elastic_ip():
+    """Test the assign_elastic_ip function."""
+    # Mock EC2 client
+    ec2_client = boto3.client("ec2", region_name="us-west-2")
+
+    # Create a mock EC2 instance
+    instance_response = ec2_client.run_instances(
+        ImageId="ami-0abcdef1234567890", InstanceType="t2.micro", MinCount=1, MaxCount=1
+    )
+    instance_id = instance_response["Instances"][0]["InstanceId"]
+
+    # Allocate a new EIP and get the AllocationId
+    eip_response = ec2_client.allocate_address(Domain="vpc")
+    eip_allocation_id = eip_response["AllocationId"]
+
+    # Before the test, associate the EIP to the instance
+    ec2_client.associate_address(InstanceId=instance_id, AllocationId=eip_allocation_id)
+
+    # Verify that the address is associated
+    response = ec2_client.describe_addresses(AllocationIds=[eip_allocation_id])
+    assert response["Addresses"][0]["AllocationId"] == eip_allocation_id
+
+    # Run the function to assign the EIP
+    assign_elastic_ip(instance_id, eip_allocation_id)
+
+    # Verify that the address is still associated
+    response = ec2_client.describe_addresses(AllocationIds=[eip_allocation_id])
+    assert response["Addresses"][0]["AllocationId"] == eip_allocation_id

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -1,32 +1,28 @@
 """Test the I-Alirt EIP lambda function."""
 
-import json
-
 import boto3
-from moto import mock_ec2, mock_secretsmanager
+from moto import mock_ec2
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_eip import (
     assign_elastic_ip,
-    get_eip_allocation_id,
+    get_or_allocate_eip,
 )
 
 
-@mock_secretsmanager
-def test_get_eip_allocation_id(monkeypatch):
-    """Tests the lambda handler."""
-    client = boto3.client("secretsmanager", region_name="us-west-2")
-    monkeypatch.setenv("EIP_SECRET_NAME", "allocation-credentials")
+@mock_ec2
+def test_get_or_allocate_eip():
+    """Tests the get_or_allocate_eip function using a mocked EC2 client."""
+    ec2 = boto3.client("ec2", region_name="us-west-2")
 
-    # Mock secret data
-    secret_name = "allocation-credentials"  # noqa
-    secret_data = {"eip_allocation_id": "eip-12345678"}
-    client.create_secret(Name=secret_name, SecretString=json.dumps(secret_data))
+    allocation_id = get_or_allocate_eip()
+    addresses = ec2.describe_addresses().get("Addresses", [])
 
-    # Call the function to retrieve the EIP allocation ID
-    eip_allocation_id = get_eip_allocation_id()
+    # Assert that an address was allocated
+    assert addresses[0]["AllocationId"] == allocation_id
 
-    # Modify the assertion to expect a string instead of a list
-    assert eip_allocation_id == "eip-12345678"
+    # Verify that the allocated address has the proper tag
+    tags = addresses[0].get("Tags", [])
+    assert any(tag["Key"] == "Name" and tag["Value"] == "I-Alirt EIP" for tag in tags)
 
 
 @mock_ec2

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -1,6 +1,7 @@
 """Test the I-Alirt EIP lambda function."""
 
 import json
+import pytest
 
 import boto3
 from moto import mock_ec2, mock_secretsmanager
@@ -51,3 +52,46 @@ def test_assign_elastic_ip(caplog):
         assert f"Elastic IP associated with instance {instance_id}" in caplog.text
         assign_elastic_ip(instance_id, eip_allocation_id, "deploy")
         assert "Elastic IP is already associated with this instance." in caplog.text
+
+
+@mock_ec2
+def test_assign_elastic_ip_disassociate(caplog):
+    """Test the Elastic IP disassociation functionality."""
+    # Mock EC2 client
+    ec2_client = boto3.client("ec2", region_name="us-west-2")
+
+    # Create a mock EC2 instance
+    instance_response = ec2_client.run_instances(
+        ImageId="ami-0abcdef1234567890", InstanceType="t2.micro", MinCount=1, MaxCount=1
+    )
+    instance_id_1 = instance_response["Instances"][0]["InstanceId"]
+
+    # Create another mock EC2 instance for disassociation
+    instance_response_2 = ec2_client.run_instances(
+        ImageId="ami-0abcdef1234567890", InstanceType="t2.micro", MinCount=1, MaxCount=1
+    )
+    instance_id_2 = instance_response_2["Instances"][0]["InstanceId"]
+
+    # Allocate a new EIP and get the AllocationId
+    eip_response = ec2_client.allocate_address(Domain="vpc")
+    eip_allocation_id = eip_response["AllocationId"]
+
+    # Associate the EIP with the second instance
+    ec2_client.associate_address(InstanceId=instance_id_2, AllocationId=eip_allocation_id)
+
+    # Run the function to assign the EIP to the first instance
+    with caplog.at_level("INFO"):
+        assign_elastic_ip(instance_id_1, eip_allocation_id, "deploy")
+
+        # Check if the disassociation log message is present
+        assert "Elastic IP disassociated from old instance." in caplog.text
+
+    # Verify that the EIP is now associated with the first instance
+    response = ec2_client.describe_addresses(AllocationIds=[eip_allocation_id])
+    assert response["Addresses"][0]["InstanceId"] == instance_id_1
+    assert response["Addresses"][0]["AllocationId"] == eip_allocation_id
+
+    # Check that the association with the second instance has been removed
+    with pytest.raises(Exception):
+        ec2_client.describe_addresses(AllocationIds=[eip_allocation_id, instance_id_2])
+


### PR DESCRIPTION
# Change Summary

## Overview
Changes to replace NLB. Everything worked before, but only as long as the EC2 instance wasn't replaced by AutoScaling. This PR addresses that issue. Now the EC2 instance will always have the same static EIP.

## New Files
- ialirt_eip.py
   - Lambda that is kicked off as a result of the EventBridge Rules. This assigns a static EIP to the EC2 instance

## Updated Files
- stackbuilder.py
   - pass in eip secret name
- ialirt_processing_construct.py
   - Created autoscaling lifecycle hook that triggers when an EC2 instance is launching and allows up to 5 minutes for the Elastic IP (EIP) assignment.
   - Created an EventBridge rule that triggers the lambda either by the lifecycle hook or upon deployment (when EC2 instance transitions into running state)
- ialirt-setup.rst
   - Description of creating and saving static eip
   - New description of switching out containers. 

## Testing
test_ialirt_eip.py - Tests ialirt_eip.py

I also tested different situations:
1. Tested how long it took to switch out a container (my test image and OpsSW test image) - 1 minute
2. Looked to see if it was possible to have two running tasks at a time (it's not with the HOST Network). This might make us revert to the primary/secondary container scenerio.
3. Tested that EC2 instance has assigned public IP upon deployment
4. Tested that EC2 instance has assigned public IP upon deleting the EC2 (and autoscaling brining it back up)
