### PR TITLE
I-ALiRT: Catalog endpoint

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -1,31 +1,127 @@
-"""Define lambda to support the catalog API."""
+"""Define the lambda function that supports the catalog API."""
 
+import json
 import logging
+import os
+from datetime import datetime, timedelta
+
+import boto3
+import botocore
 
 # Logger setup
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def lambda_handler(event, context):
+def lambda_handler(event, context) -> dict:
     """Entry point to the catalog API lambda.
 
-    Blank function for initial setup.
+    Takes in a date range and ground station, and queries the s3 bucket that holds
+    the pointing schedules for ground stations part of the I-ALiRT network.
+
+    If files exist for the requested date range, the response body returns all file
+    versions for every date, including the file name and its last date modified.
 
     Parameters
     ----------
     event : dict
         The JSON formatted document with the data required for the
-        lambda function to process
+        lambda function to process, i.e., date range and ground station
+        Ex:
+            event = {
+                "start_date": "2025-02-06",  # inclusive
+                "end_date": "2025-02-07",  # exclusive
+                "station": "station1",
+            }
     context : LambdaContext
         This object provides methods and properties that provide
         information about the invocation, function,
         and runtime environment.
+
+    Returns
+    -------
+    dict
+        A dictionary containing headers, status code, and body, designed to be returned
+        as an API response.
+        Ex:
+        {
+            'statusCode': 200,
+            'headers': {
+                'Content-Type': 'application/json'
+            },
+            'body': '{
+                "2025-02-06":
+                    {"file_names":
+                        ["20250206_station1_01.txt", "20250206_station1_02.txt"],
+                     "dates_modified":
+                        ["2025-02-12 18:37", "2025-02-12 18:37"]}
+            }'
+        }
     """
-    logger.info(f"Event: {event}")
-    logger.info(f"Context: {context}")
+    logger.info("Received event: " + json.dumps(event, indent=2))
+
+    day = datetime.strptime(event["start_date"], "%Y-%m-%d")
+    end_date = datetime.strptime(event["end_date"], "%Y-%m-%d")
+
+    if not day < end_date:
+        response_body = (
+            "The start date of the requested time frame is not before the "
+            "end date. Please supply a valid time range."
+        )
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": response_body,
+        }
+
+    if end_date - day > timedelta(days=30):
+        response_body = (
+            "The end date of the requested time frame must not be more "
+            "than 30 days after the start date. Please supply a valid time"
+            " range."
+        )
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": response_body,
+        }
+
+    bucket = os.getenv("S3_BUCKET")
+    region = os.getenv("REGION")
+
+    s3_client = boto3.client(
+        "s3",
+        region_name=region,
+        config=botocore.client.Config(signature_version="s3v4"),
+    )
+
+    response_body = {}
+    while day < end_date:
+        day_path = f"pointing_schedules/{event['station']}/{day.strftime('%Y%m%d')}/"
+        files = s3_client.list_objects_v2(Bucket=bucket, Prefix=day_path)
+        if "Contents" not in files.keys():
+            response_body = (
+                f"There are not files associated with the provided date {day}. "
+                f"Please supply a valid time range that is covered by existing files."
+            )
+            return {
+                "statusCode": 404,
+                "headers": {"Content-Type": "application/json"},
+                "body": response_body,
+            }
+        file_names = []
+        dates_modified = []
+        for file in files["Contents"]:
+            file_names.append(file["Key"].rsplit("/", 1)[1])
+            dates_modified.append(file["LastModified"].strftime("%Y-%m-%d %H:%M"))
+        response_body[f"{day}"] = {
+            "file_names": file_names,
+            "dates_modified": dates_modified,
+        }
+        day += timedelta(days=1)
 
     return {
         "statusCode": 200,
         "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(response_body),
     }

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -64,26 +64,20 @@ def lambda_handler(event, context) -> dict:
     end_date = datetime.strptime(event["end_date"], "%Y-%m-%d")
 
     if not day < end_date:
-        response_body = (
-            "The start date of the requested time frame is not before the "
-            "end date. Please supply a valid time range."
-        )
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},
-            "body": response_body,
+            "body": "The start date of the requested time frame is not before the "
+            "end date. Please supply a valid time range.",
         }
 
     if end_date - day > timedelta(days=30):
-        response_body = (
-            "The end date of the requested time frame must not be more "
-            "than 30 days after the start date. Please supply a valid time"
-            " range."
-        )
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},
-            "body": response_body,
+            "body": "The end date of the requested time frame must not be more "
+            "than 30 days after the start date. Please supply a valid time"
+            " range.",
         }
 
     bucket = os.getenv("S3_BUCKET")
@@ -100,14 +94,12 @@ def lambda_handler(event, context) -> dict:
         day_path = f"pointing_schedules/{event['station']}/{day.strftime('%Y%m%d')}/"
         files = s3_client.list_objects_v2(Bucket=bucket, Prefix=day_path)
         if "Contents" not in files.keys():
-            response_body = (
-                f"There are not files associated with the provided date {day}. "
-                f"Please supply a valid time range that is covered by existing files."
-            )
             return {
                 "statusCode": 404,
                 "headers": {"Content-Type": "application/json"},
-                "body": response_body,
+                "body": "There are not files associated with the provided date {day}. "
+                "Please supply a valid time range that is covered by existing "
+                "files.",
             }
         file_names = []
         dates_modified = []

--- a/tests/lambda_endpoints/test_ialirt_catalog_api.py
+++ b/tests/lambda_endpoints/test_ialirt_catalog_api.py
@@ -1,0 +1,75 @@
+"""Tests for the I-ALiRT Catalog API."""
+
+import json
+
+from sds_data_manager.lambda_code.IAlirtCode import ialirt_catalog_api
+
+
+def test_bad_dates_ialirt_catalog_api(s3_client):
+    """Test a failing call to the catalog endpoint due to bad dates."""
+    event = {
+        "start_date": "2025-02-06",
+        "end_date": "2025-02-06",
+        "station": "station1",
+    }
+    response = ialirt_catalog_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 400
+    assert response["body"] == (
+        "The start date of the requested time frame is not "
+        "before the end date. Please supply a valid time "
+        "range."
+    )
+
+
+def test_too_large_time_range_ialirt_catalog_api(s3_client):
+    """Test a failing call to the endpoint caused by dates that are too far apart."""
+    event = {
+        "start_date": "2025-02-06",
+        "end_date": "2025-03-20",
+        "station": "station1",
+    }
+    response = ialirt_catalog_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 400
+    assert response["body"] == (
+        "The end date of the requested time frame must not be "
+        "more than 30 days after the start date. Please supply "
+        "a valid time range."
+    )
+
+
+def test_no_files_ialirt_catalog_api(s3_client):
+    """Test unsuccessful call to the endpoint caused by an empty response from s3."""
+    event = {
+        "start_date": "2025-02-06",
+        "end_date": "2025-02-07",
+        "station": "station1",
+    }
+    response = ialirt_catalog_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 404
+
+
+def test_success_ialirt_catalog_api(s3_client):
+    """Test a successful call to the catalog endpoint."""
+    test_file1 = "pointing_schedules/station1/20250206/20250206_station1_01.txt"
+    test_file2 = "pointing_schedules/station1/20250206/20250206_station1_02.txt"
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key=test_file1,
+        Body=b"Hello world 1",
+    )
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key=test_file2,
+        Body=b"Hello world 2",
+    )
+    event = {
+        "start_date": "2025-02-06",
+        "end_date": "2025-02-07",
+        "station": "station1",
+    }
+    response = ialirt_catalog_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"])["2025-02-06 00:00:00"]["file_names"] == [
+        "20250206_station1_01.txt",
+        "20250206_station1_02.txt",
+    ]


### PR DESCRIPTION
# Change Summary

## Overview
These changes correspond to the I-ALiRT project tickets #435 and #436. I've filled out the lambda function that supports the catalog endpoint, which is designed to return JSON (as requested by the web team) containing the pointing schedule files for a ground station over a specified coverage window.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- pyproject.toml
   - I had to install numpy, which required an updated python version.
   - To be honest, I don't feel confident about these updates needing to be repo-wide and would appreciate feedback specifically around this and the poetry.lock changes.
- poetry.lock
   - See the above point!
- ialirt_catalog_api.py
   - Flushes out the details of the lambda handler function. 
   - Queries the s3 bucket using `list_catalog_v2()` and then generates presigned urls using an s3_client function.
   - Wraps final results in a json/dictionary design, as requested by the web team, who will be using this endpoint to display pointing schedules on the I-ALiRT website
- test_ialirt_catalog_api.py
   - Tests the expanded lambda handler function.

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
All new code changes are covered by new unit tests in `test_ialirt_catalog_api.py`.
