### PR TITLE
Reconfigure lambda to use non-proxy integration and queryStringParameters

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -124,6 +124,7 @@ class IalirtApiManager(Construct):
             handler="IAlirtCode.ialirt_catalog_api.lambda_handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
             timeout=cdk.Duration.minutes(1),
+            memory_size=1000,
             environment={
                 "S3_BUCKET": data_bucket.bucket_name,
                 "REGION": env.region,
@@ -138,7 +139,6 @@ class IalirtApiManager(Construct):
             route="ialirt-catalog",
             http_method="GET",
             lambda_function=catalog_api,
-            use_path_params=True,
         )
 
         ialirt_db_query_handler = lambda_.Function(

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -60,8 +60,10 @@ def lambda_handler(event, context) -> dict:
     """
     logger.info("Received event: " + json.dumps(event, indent=2))
 
-    day = datetime.strptime(event["start_date"], "%Y-%m-%d")
-    end_date = datetime.strptime(event["end_date"], "%Y-%m-%d")
+    query_params = event["queryStringParameters"]
+    day = datetime.strptime(query_params.get("start_date"), "%Y-%m-%d")
+    end_date = datetime.strptime(query_params.get("end_date"), "%Y-%m-%d")
+    station = query_params.get("station")
 
     if not day < end_date:
         return {
@@ -91,7 +93,7 @@ def lambda_handler(event, context) -> dict:
 
     response_body = {}
     while day < end_date:
-        day_path = f"pointing_schedules/{event['station']}/{day.strftime('%Y%m%d')}/"
+        day_path = f"pointing_schedules/{station}/{day.strftime('%Y%m%d')}/"
         files = s3_client.list_objects_v2(Bucket=bucket, Prefix=day_path)
         if "Contents" not in files.keys():
             return {

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -22,6 +22,9 @@ def lambda_handler(event, context) -> dict:
     If files exist for the requested date range, the response body returns all file
     versions for every date, including the file name and its last date modified.
 
+    An example of a query to this endpoint as a URL is:
+    "https://ialirt.dev.imap-mission.com/ialirt-catalog?start_date=2025-02-06&end_date=2025-02-07&station=test_station"
+
     Parameters
     ----------
     event : dict
@@ -29,9 +32,11 @@ def lambda_handler(event, context) -> dict:
         lambda function to process, i.e., date range and ground station
         Ex:
             event = {
-                "start_date": "2025-02-06",  # inclusive
-                "end_date": "2025-02-07",  # exclusive
-                "station": "station1",
+                "queryStringParameters": {
+                    "start_date": "2025-02-06",
+                    "end_date": "2025-02-07",
+                    "station": "station1",
+                }
             }
     context : LambdaContext
         This object provides methods and properties that provide

--- a/tests/lambda_endpoints/test_ialirt_catalog_api.py
+++ b/tests/lambda_endpoints/test_ialirt_catalog_api.py
@@ -8,9 +8,11 @@ from sds_data_manager.lambda_code.IAlirtCode import ialirt_catalog_api
 def test_bad_dates_ialirt_catalog_api(s3_client):
     """Test a failing call to the catalog endpoint due to bad dates."""
     event = {
-        "start_date": "2025-02-06",
-        "end_date": "2025-02-06",
-        "station": "station1",
+        "queryStringParameters": {
+            "start_date": "2025-02-06",
+            "end_date": "2025-02-06",
+            "station": "station1",
+        }
     }
     response = ialirt_catalog_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 400
@@ -24,9 +26,11 @@ def test_bad_dates_ialirt_catalog_api(s3_client):
 def test_too_large_time_range_ialirt_catalog_api(s3_client):
     """Test a failing call to the endpoint caused by dates that are too far apart."""
     event = {
-        "start_date": "2025-02-06",
-        "end_date": "2025-03-20",
-        "station": "station1",
+        "queryStringParameters": {
+            "start_date": "2025-02-06",
+            "end_date": "2025-03-20",
+            "station": "station1",
+        }
     }
     response = ialirt_catalog_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 400
@@ -40,9 +44,11 @@ def test_too_large_time_range_ialirt_catalog_api(s3_client):
 def test_no_files_ialirt_catalog_api(s3_client):
     """Test unsuccessful call to the endpoint caused by an empty response from s3."""
     event = {
-        "start_date": "2025-02-06",
-        "end_date": "2025-02-07",
-        "station": "station1",
+        "queryStringParameters": {
+            "start_date": "2025-02-06",
+            "end_date": "2025-02-07",
+            "station": "station1",
+        }
     }
     response = ialirt_catalog_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 404
@@ -63,9 +69,11 @@ def test_success_ialirt_catalog_api(s3_client):
         Body=b"Hello world 2",
     )
     event = {
-        "start_date": "2025-02-06",
-        "end_date": "2025-02-07",
-        "station": "station1",
+        "queryStringParameters": {
+            "start_date": "2025-02-06",
+            "end_date": "2025-02-07",
+            "station": "station1",
+        }
     }
     response = ialirt_catalog_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 200


### PR DESCRIPTION
# Change Summary
I recently configured this endpoint, but upon testing today realized that something was missing. The issue was that it was neither fully set up to use a proxy integration OR a non-proxy integration, which are the two options offered by AWS APIGateway. 

I went with the non-proxy, 'custom' integration because it made more sense to me than the proxy version.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- ialirt_api_manager_construct.py
   - remove the `use_path_params` variable, which is meant to be used with a proxy integration
   - add a memory parameter, because it's used in other lambda function definitions
- ialirt_catalog_api.py
   - add queryStringParameters wrapping to the request parameters
- test_ialirt_catalog_api.py
   - add queryStringParameters wrapping to the request parameters


## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Updated the unit tests, they all pass. I also deployed the IalirtStack with these changes, and was able to get a successful response back from the endpoint using Postman.