### PR TITLE
Adding SWE ancillary dependency

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -123,6 +123,7 @@ swapi, l2, sci, swapi, l3b, combined, HARD, DOWNSTREAM
 
 swe, l0, raw, swe, l1a, sci, HARD, DOWNSTREAM
 swe, l1a, sci, swe, l1b, sci, HARD, DOWNSTREAM
+swe, ancillary, l1b-in-flight-cal, swe, l1b, sci, HARD, DOWNSTREAM
 swe, l1b, sci, swe, l2, sci, HARD, DOWNSTREAM
 swe, l2, sci, swe, l3, sci, HARD, DOWNSTREAM
 swapi, l3a, proton-sw, swe, l3, sci, HARD, DOWNSTREAM

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -34,6 +34,34 @@ def test_get_downstream_dependencies():
 
     assert dependents == expected_complete_dependent
 
+    # Add test for getting back ancillary dependency
+    event = {
+        "queryStringParameters": {
+            "dependency_type": "UPSTREAM",
+            "relationship": "HARD",
+            "data_source": "swe",
+            "data_type": "l1b",
+            "descriptor": "sci",
+        }
+    }
+    dependency_response = dependency.lambda_handler(event, None)
+    dependents = json.loads(dependency_response["body"])
+
+    expected_complete_dependent = [
+        {
+            "data_source": "swe",
+            "data_type": "l1a",
+            "descriptor": "sci",
+        },
+        {
+            "data_source": "swe",
+            "data_type": "ancillary",
+            "descriptor": "l1b-in-flight-cal",
+        },
+    ]
+    assert len(dependents) == 2
+    assert dependents == expected_complete_dependent
+
 
 def test_lambda_handler_no_dependencies():
     """Test lambda_handler when no dependencies are found."""


### PR DESCRIPTION
# Change Summary
closes #475 
## Overview
Adding SWE's ancillary file to dependency tree

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - Adding ancillary file to dependency tree

## Testing
- tests/lambda_endpoints/test_dependency_api.py
