### PR TITLE
Rename I-ALiRT Download Endpoint

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -109,7 +109,7 @@ class IalirtApiManager(Construct):
         download_api.add_to_role_policy(s3_read_policy)
 
         api.add_route(
-            route="ialirt-log-download",
+            route="ialirt-download",
             http_method="GET",
             lambda_function=download_api,
             use_path_params=True,


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
This removes the `-log` prefix in the I-ALiRT download API endpoint, because it will be used to download other files in addition to logs (in conjunction with the `catalog` endpoint to get pointing schedules). Very surface level syntax/clarity code change! 

This is in preparation for my upcoming additions to the `ialirt-data-access` repo to document how to use the new `catalog` endpoint (https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/436).

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- ialirt_api_manager_construct.py

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
No testing necessary.