### PR TITLE
MNT: update imap-data-access with ancillary filename convention fix

### DIFF
--- a/lambda_layer/python/requirements.txt
+++ b/lambda_layer/python/requirements.txt
@@ -171,8 +171,9 @@ greenlet==3.1.1 ; python_version < "3.14" and (platform_machine == "aarch64" or 
 idna==3.10 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.14.0 ; python_version >= "3.9" and python_version < "4" \
-    --hash=sha256:b05309e081cf94edce29926a55525c2c0152bb4f50e70c6c0a6b43af0092138a
+imap-data-access==0.15.1 ; python_version >= "3.9" and python_version < "4" \
+    --hash=sha256:5db37072122f867150657ee78bedd553656893d52fc30fe5b60a5f855a238d39 \
+    --hash=sha256:68c11dfc9c1ca03daef09ea149eca8789a68a63c540dcb127c4c058c2f2e9aca
 psycopg2-binary==2.9.10 ; python_version >= "3.9" and python_version < "4" \
     --hash=sha256:04392983d0bb89a8717772a193cfaac58871321e3ec69514e1c4e0d4957b5aff \
     --hash=sha256:056470c3dc57904bbf63d6f534988bafc4e970ffd50f6271fc4ee7daad9498a5 \

--- a/poetry.lock
+++ b/poetry.lock
@@ -782,12 +782,13 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.14.0"
+version = "0.15.1"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap_data_access-0.14.0.tar.gz", hash = "sha256:b05309e081cf94edce29926a55525c2c0152bb4f50e70c6c0a6b43af0092138a"},
+    {file = "imap_data_access-0.15.1-py3-none-any.whl", hash = "sha256:68c11dfc9c1ca03daef09ea149eca8789a68a63c540dcb127c4c058c2f2e9aca"},
+    {file = "imap_data_access-0.15.1.tar.gz", hash = "sha256:5db37072122f867150657ee78bedd553656893d52fc30fe5b60a5f855a238d39"},
 ]
 
 [package.extras]
@@ -1990,4 +1991,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "751716d6ec358869744ef75104316d26719d6c0a88654eeb6b0ccd7ed760c3b0"
+content-hash = "b0917f92013d1099245840adfeab13f768cd063118fa64269e5e21e66b16c23c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4"
-imap-data-access = ">=0.14.0"
+imap-data-access = ">=0.15.1"
 
 # Optional dependencies - install with `poetry install -E docs`
 sphinx = {version="^7.1.0", optional=true}


### PR DESCRIPTION
# Change Summary
closes #487 

## Overview
Update imap-data-access


## Updated Files
- pyproject.toml
   - updates to imap-data-access version `0.15.1`


## Testing

