### PR TITLE
MNT/FIX: Only build Lambda Layers and use Lambdas with x86 architecture

### DIFF
--- a/docs/source/cdk/cdk-deployment.rst
+++ b/docs/source/cdk/cdk-deployment.rst
@@ -70,3 +70,24 @@ with the explicit steps as follows:
    branches of your repository and not wide-open trust to the entire organization.
 #. Attach a policy to the role that allows the role to deploy the CDK stacks, giving
    it the appropriate permissions for the resources you require.
+
+Troubleshooting Lambda Architectures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The project can be built on a local machine, but creating the layers can
+sometimes cause issues if a developer is running on an ARM architecture (e.g. Macs).
+The Lambda layers are designed to be built on an x86 architecture (GitHub Actions CI),
+so if you are running on ARM architecture you may need to set some additional
+environment variables to force the build to run on x86.
+
+Remove all Docker images and build artifacts before running the build command::
+
+    docker builder prune -a
+    docker image prune -a
+    # Remove the cdk.out directory where build artifacts are stored.
+    rm -rf cdk.out
+
+Then, set the environment variable to force Docker to use the x86 architecture::
+
+    DOCKER_DEFAULT_PLATFORM=linux/amd64 cdk synth --context account_name="dev"
+

--- a/sds_data_manager/constructs/database_construct.py
+++ b/sds_data_manager/constructs/database_construct.py
@@ -138,7 +138,6 @@ class SdpDatabase(Construct):
                 "SECRET_NAME": self.secret_name,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
         rds_secret = secrets.Secret.from_secret_name_v2(
             self, "rds_secret", self.secret_name
@@ -194,5 +193,4 @@ class SdpDatabase(Construct):
                 "SECRET_NAME": self.secret_name,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )

--- a/sds_data_manager/constructs/dependency_finder_construct.py
+++ b/sds_data_manager/constructs/dependency_finder_construct.py
@@ -48,7 +48,6 @@ class DependencyFinder(Construct):
             memory_size=512,
             timeout=Duration.minutes(1),
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         api.add_route(

--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -78,7 +78,6 @@ class IalirtApiManager(Construct):
                 "REGION": env.region,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         query_api_lambda.add_to_role_policy(s3_read_policy)
@@ -103,7 +102,6 @@ class IalirtApiManager(Construct):
                 "REGION": env.region,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         download_api.add_to_role_policy(s3_read_policy)
@@ -130,7 +128,6 @@ class IalirtApiManager(Construct):
                 "REGION": env.region,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         catalog_api.add_to_role_policy(s3_read_policy)
@@ -155,7 +152,6 @@ class IalirtApiManager(Construct):
                 "REGION": env.region,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         # Grant the lambda function read/write permissions on the DynamoDB table.

--- a/sds_data_manager/constructs/indexer_lambda_construct.py
+++ b/sds_data_manager/constructs/indexer_lambda_construct.py
@@ -77,7 +77,6 @@ class IndexerLambda(Construct):
                 "SECRET_NAME": db_secret_name,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         # Adding events and s3 permission because indexer

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -91,7 +91,6 @@ class BatchStarterLambda(Construct):
             security_groups=[rds_security_group],
             allow_public_subnet=True,
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         # Permissions to send event to EventBridge

--- a/sds_data_manager/constructs/lambda_layer_construct.py
+++ b/sds_data_manager/constructs/lambda_layer_construct.py
@@ -39,6 +39,14 @@ class IMAPLambdaLayer(lambda_.LayerVersion):
             layer_dependencies_dir,
             bundling=cdk.BundlingOptions(
                 image=runtime.bundling_image,
+                # NOTE: We need to use the x86_64 architecture for the lambda layer
+                #      otherwise people with mac's will produce different shared object
+                #      files from those produced on our CI runners.
+                #      To debug you can look at the psycopg2 linked binaries in the
+                #      assets by adding the following to the commands below:
+                #      ls -al /asset-output/python/psycopg2
+                platform="linux/amd64",
+                environment={"DOCKER_DEFAULT_PLATFORM": "linux/amd64"},
                 command=[
                     "bash",
                     "-c",
@@ -55,5 +63,6 @@ class IMAPLambdaLayer(lambda_.LayerVersion):
             id=f"{id}-Layer",
             code=code_bundle,
             compatible_runtimes=[runtime],
+            compatible_architectures=[lambda_.Architecture.X86_64],
             **kwargs,
         )

--- a/sds_data_manager/constructs/monitoring_lambda_construct.py
+++ b/sds_data_manager/constructs/monitoring_lambda_construct.py
@@ -51,7 +51,6 @@ class MonitoringLambda(Construct):
                 "SNS_TOPIC_ARN": sns_topic.topic_arn,
             },
             allow_public_subnet=True,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         # Uses batch job status of failure

--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -89,7 +89,6 @@ class SdsApiManager(Construct):
                 "REGION": env.region,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
         upload_api_lambda.add_to_role_policy(s3_write_policy)
         upload_api_lambda.add_to_role_policy(s3_read_policy)
@@ -120,7 +119,6 @@ class SdsApiManager(Construct):
                 "SECRET_NAME": db_secret_name,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         api.add_route(
@@ -143,7 +141,6 @@ class SdsApiManager(Construct):
                 "REGION": env.region,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         download_api.add_to_role_policy(s3_read_policy)
@@ -171,7 +168,6 @@ class SdsApiManager(Construct):
                 "SECRET_NAME": db_secret_name,
             },
             layers=layers,
-            architecture=lambda_.Architecture.ARM_64,
         )
 
         rds_secret = secrets.Secret.from_secret_name_v2(


### PR DESCRIPTION
This was causing issues where people with Mac / ARM processors would build a different layer than on GitHub Actions CI on a Linux x86 system. We can specify the platform for the Layer explicitly and indicate what it is compatible with. Then we can remove all ARM64 architectures for the Lambda's we were specifying which aren't needed anymore if we build the layer as an x86.