### PR TITLE
Query parameter variable name bug in batch_starter.py

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -104,7 +104,7 @@ def _get_dependencies(dependency_events: dict):
     # The API returns different output formats depending on the query parameters:
     # Without "start_date": Returns a list of dependency dictionaries.
     #      This functionality is used when searching for downstream dependencies
-    # With "start_date" (requires "version" and "trigger_source"; "end_date" optional):
+    # With "start_date" (requires "version" and "trigger_type"; "end_date" optional):
     # Returns a serialized ProcessingInputCollection of files from S3
     if "start_date" in url:
         dependencies = ProcessingInputCollection()
@@ -288,7 +288,7 @@ def submit_all_jobs(
     job: dict,
     start_date: datetime,
     version: str,
-    trigger_source: str,
+    trigger_type: str,
     end_date: Optional[datetime] = None,
 ):
     """Submit downstream jobs for each upstream primary science dependency file.
@@ -303,7 +303,7 @@ def submit_all_jobs(
         The trigger file start date.
     version : str
         The trigger file version.
-    trigger_source : str
+    trigger_type : str
         The data_source of the file that triggered the batch starter.
     end_date : datetime, optional
         The trigger file end date, by default None.
@@ -321,7 +321,7 @@ def submit_all_jobs(
         "relationship": "HARD",
         "start_date": start_date,
         "version": version,
-        "trigger_source": trigger_source,
+        "trigger_type": trigger_type,
     }
     if end_date:
         dependency_event_msg["end_date"] = end_date

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -63,7 +63,7 @@ def urlopen_side_effect(url):
         params.get("start_date", [None])[0],
         params.get("end_date", [None])[0],
         params.get("version", [None])[0],
-        params.get("trigger_source", [None])[0],
+        params.get("trigger_type", [None])[0],
     )
 
     dependencies = dependency.lambda_handler(event, None)["body"]
@@ -284,7 +284,7 @@ def test_lambda_handler_missing_upstream_dependency(session, mock_urlopen, caplo
             "Upstream dependency not found for: {'data_source': "
             "'swe', 'data_type': 'l2', 'descriptor': 'sci', 'dependency_type': "
             "'UPSTREAM', 'relationship': 'HARD', 'start_date': '20000101', "
-            "'version': 'v001', 'trigger_source': 'l1b'}"
+            "'version': 'v001', 'trigger_type': 'l1b'}"
         )
         # Verify the info statement was logged.
         assert log_str in caplog.text
@@ -478,7 +478,7 @@ def test_api_request_success_empty(session, mock_urlopen: unittest.mock.MagicMoc
         "relationship": "HARD",
         "start_date": "20000101",
         "version": "v001",
-        "trigger_source": "swe",
+        "trigger_type": "swe",
     }
     dependencies = _get_dependencies(dependency_event_msg)
     assert dependencies == imap_data_access.processing_input.ProcessingInputCollection()


### PR DESCRIPTION
# Change Summary
Change query parameter name from "trigger_source" to "trigger_type"

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

## Updated Files
-sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   -"trigger_source" to "trigger_type"
- tests/lambda_endpoints/test_batch_starter.py
   - "trigger_source" to "trigger_type"
