### PR TITLE
SPICE Query API

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,7 @@
 # OS
-ARG VARIANT=bullseye
-FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get install -y firefox-esr
+FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/python:3.12
 RUN sudo apt-get update
-RUN sudo apt-get install -y libgtk-3-dev
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && sudo apt-get install -y nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs
 RUN npm install -g aws-cdk
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip

--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -127,6 +127,32 @@ class SdsApiManager(Construct):
             lambda_function=query_api_lambda,
         )
 
+        # SPICE query API lambda
+        spice_query_api_lambda = lambda_.Function(
+            self,
+            id="SPICEQueryAPILambda",
+            function_name="spice-query-api-handler",
+            code=code,
+            handler="SDSCode.api_lambdas.spice_query_api.lambda_handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            timeout=cdk.Duration.minutes(1),
+            memory_size=1000,
+            allow_public_subnet=True,
+            vpc=vpc,
+            security_groups=[rds_security_group],
+            environment={
+                "REGION": env.region,
+                "SECRET_NAME": db_secret_name,
+            },
+            layers=layers,
+        )
+
+        api.add_route(
+            route="spice-query",
+            http_method="GET",
+            lambda_function=spice_query_api_lambda,
+        )
+
         # download API lambda
         download_api = lambda_.Function(
             self,

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -1,19 +1,18 @@
 """Contains the lambda handler for the 'query' data access API."""
 
-import datetime
 import json
 import logging
 
+from imap_data_access import SPICEFilePath
 from sqlalchemy import func, select
 
 from ..database import database as db
 from ..database import models
 
-from imap_data_access import SPICEFilePath
-
 # Logger setup
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
 
 def lambda_handler(event, context):
     """Entry point to the SPICE query API lambda.
@@ -42,7 +41,7 @@ def lambda_handler(event, context):
 
         # get a list of all valid search parameters
         valid_parameters = ["start_time", "end_time", "type", "latest"]
-        
+
         # go through each query parameter to set up sqlalchemy query conditions
         for param, value in query_params.items():
             # confirm that the query parameter is valid
@@ -63,7 +62,7 @@ def lambda_handler(event, context):
                     " valid options are: {valid_parameters}"
                 )
                 return response
-            
+
             if param == "start_time":
                 try:
                     query = query.where(models.SPICEFiles.max_date_j2000 >= int(value))
@@ -94,7 +93,7 @@ def lambda_handler(event, context):
                     return response
             elif param == "type":
                 query = query.where(models.SPICEFiles.kernel_type == value)
-            elif param == "latest" and value.lower()=='true':
+            elif param == "latest" and value.lower() == "true":
                 # Make a subquery that gives us (file_root, MAX(version))
                 latest_versions_subq = (
                     session.query(
@@ -115,7 +114,9 @@ def lambda_handler(event, context):
 
         search_results = session.execute(query).scalars().all()
 
-    search_results = [_convert_spice_metadata_model_to_dict(result) for result in search_results]
+    search_results = [
+        _convert_spice_metadata_model_to_dict(result) for result in search_results
+    ]
     logger.info(
         "Found [%s] Query Search Results: %s", len(search_results), str(search_results)
     )

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -65,9 +65,33 @@ def lambda_handler(event, context):
                 return response
             
             if param == "start_time":
-                query = query.where(models.SPICEFiles.max_date_j2000 >= int(value))
+                try:
+                    query = query.where(models.SPICEFiles.max_date_j2000 >= int(value))
+                except ValueError:
+                    response = {
+                        "statusCode": 400,
+                        "body": json.dumps(f"Invalid value for {param}: {value}"),
+                        "headers": {
+                            "Content-Type": "application/json",
+                            "Access-Control-Allow-Origin": "*",  # Allow CORS
+                        },
+                    }
+                    logger.debug(f"Invalid value for {param}: {value}")
+                    return response
             elif param == "end_time":
-                query = query.where(models.SPICEFiles.min_date_j2000 <= int(value))
+                try:
+                    query = query.where(models.SPICEFiles.min_date_j2000 <= int(value))
+                except ValueError:
+                    response = {
+                        "statusCode": 400,
+                        "body": json.dumps(f"Invalid value for {param}: {value}"),
+                        "headers": {
+                            "Content-Type": "application/json",
+                            "Access-Control-Allow-Origin": "*",  # Allow CORS
+                        },
+                    }
+                    logger.debug(f"Invalid value for {param}: {value}")
+                    return response
             elif param == "type":
                 query = query.where(models.SPICEFiles.kernel_type == value)
             elif param == "latest" and value.lower()=='true':

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -1,0 +1,148 @@
+"""Contains the lambda handler for the 'query' data access API."""
+
+import datetime
+import json
+import logging
+
+from sqlalchemy import func, select
+
+from ..database import database as db
+from ..database import models
+
+from imap_data_access import SPICEFilePath
+
+# Logger setup
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+def lambda_handler(event, context):
+    """Entry point to the SPICE query API lambda.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process
+    context : LambdaContext
+        This object provides methods and properties that provide
+        information about the invocation, function,
+        and runtime environment.
+
+    """
+    logger.info(f"Event: {event}")
+    logger.info(f"Context: {context}")
+
+    logger.info("Received event: " + json.dumps(event, indent=2))
+
+    # add session, pick model like in indexer and add query to filter_as
+    query_params = event["queryStringParameters"]
+    with db.Session() as session:
+        # select the SPICE files table for the query
+        query = select(models.SPICEFiles)
+
+        # get a list of all valid search parameters
+        valid_parameters = ["start_time", "end_time", "type", "latest"]
+        
+        # go through each query parameter to set up sqlalchemy query conditions
+        for param, value in query_params.items():
+            # confirm that the query parameter is valid
+            if param not in valid_parameters:
+                response = {
+                    "statusCode": 400,
+                    "body": json.dumps(
+                        f"{param} is not a valid query parameter. "
+                        + f"Valid query parameters are: {valid_parameters}"
+                    ),
+                    "headers": {
+                        "Content-Type": "application/json",
+                        "Access-Control-Allow-Origin": "*",  # Allow CORS
+                    },
+                }
+                logger.debug(
+                    f"Received an invalid query parameter [{param}],"
+                    " valid options are: {valid_parameters}"
+                )
+                return response
+            
+            if param == "start_time":
+                query = query.where(models.SPICEFiles.max_date_j2000 >= int(value))
+            elif param == "end_time":
+                query = query.where(models.SPICEFiles.min_date_j2000 <= int(value))
+            elif param == "type":
+                query = query.where(models.SPICEFiles.kernel_type == value)
+            elif param == "latest" and value.lower()=='true':
+                # Make a subquery that gives us (file_root, MAX(version))
+                latest_versions_subq = (
+                    session.query(
+                        models.SPICEFiles.file_root,
+                        func.max(models.SPICEFiles.version).label("max_version"),
+                    )
+                    .group_by(models.SPICEFiles.file_root)
+                    .subquery()
+                )
+
+                # Join main query to subquery so that we only keep rows
+                # with the matching max version for each file_root
+                query = query.join(
+                    latest_versions_subq,
+                    (models.SPICEFiles.file_root == latest_versions_subq.c.file_root)
+                    & (models.SPICEFiles.version == latest_versions_subq.c.max_version),
+                )
+
+        search_results = session.execute(query).scalars().all()
+
+    search_results = [_convert_spice_metadata_model_to_dict(result) for result in search_results]
+    logger.info(
+        "Found [%s] Query Search Results: %s", len(search_results), str(search_results)
+    )
+
+    # Format the response
+    response = {
+        "statusCode": 200,
+        "body": json.dumps(search_results),  # returns a list of tuples
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",  # Allow CORS
+        },
+    }
+
+    return response
+
+
+def _convert_spice_metadata_model_to_dict(file: models.SPICEFiles) -> dict:
+    """Convert a sqlalchemy query to SPICEFiles to a dictionary.
+
+    Paramters
+    ----------
+    file: models.SPICEFiles
+        A single row from the SPICEFiles table
+
+    Returns
+    -------
+    spice_file_dict: dict
+        The SPICE file query as a dictionary
+    """
+    spice_file_dict = {
+        "file_name": (
+            SPICEFilePath(file.file_name).construct_path().parent.name
+            + "/"
+            + file.file_name
+        ),
+        "file_root": file.file_root,
+        "kernel_type": file.kernel_type,
+        "version": file.version,
+        "min_date_j2000": file.min_date_j2000,
+        "max_date_j2000": file.max_date_j2000,
+        "file_intervals_j2000": file.file_intervals_j2000,
+        "min_date_datetime": file.min_date_datetime.strftime("%Y-%m-%d, %H:%M:%S"),
+        "max_date_datetime": file.max_date_datetime.strftime("%Y-%m-%d, %H:%M:%S"),
+        "file_intervals_datetime": file.file_intervals_datetime,
+        "min_date_sclk": file.min_date_sclk,
+        "max_date_sclk": file.max_date_sclk,
+        "file_intervals_sclk": file.file_intervals_sclk,
+        "sclk_kernel": file.sclk_kernel,
+        "lsk_kernel": file.lsk_kernel,
+        "ingestion_date": file.ingestion_date.strftime("%Y-%m-%d, %H:%M:%S"),
+        "timestamp": file.ingestion_date.timestamp(),
+    }
+    return spice_file_dict

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -40,7 +40,7 @@ def lambda_handler(event, context):
         query = select(models.SPICEFiles)
 
         # get a list of all valid search parameters
-        valid_parameters = ["start_time", "end_time", "type", "latest"]
+        valid_parameters = ["file_name", "start_time", "end_time", "type", "latest"]
 
         # go through each query parameter to set up sqlalchemy query conditions
         for param, value in query_params.items():
@@ -93,6 +93,8 @@ def lambda_handler(event, context):
                     return response
             elif param == "type":
                 query = query.where(models.SPICEFiles.kernel_type == value)
+            elif param == "file_name":
+                query = query.where(models.SPICEFiles.file_name == value)
             elif param == "latest" and value.lower() == "true":
                 # Make a subquery that gives us (file_root, MAX(version))
                 latest_versions_subq = (

--- a/tests/infrastructure/test_sds_api_manager_construct.py
+++ b/tests/infrastructure/test_sds_api_manager_construct.py
@@ -42,6 +42,6 @@ def template(stack, env):
 
 def test_indexer_role(template):
     """Ensure that the template has appropriate IAM roles."""
-    template.resource_count_is("AWS::IAM::Role", 7)
+    template.resource_count_is("AWS::IAM::Role", 8)
     # Ensure that the template has appropriate lambda count
-    template.resource_count_is("AWS::Lambda::Function", 5)
+    template.resource_count_is("AWS::Lambda::Function", 6)

--- a/tests/lambda_endpoints/test_spice_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_spice_indexer_lambda.py
@@ -1,9 +1,10 @@
 """Tests for the SPICE indexer lambda."""
 
+import json
 import os
 from datetime import datetime
 
-from sds_data_manager.lambda_code.SDSCode.database import models
+from sds_data_manager.lambda_code.SDSCode.api_lambdas import spice_query_api
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import spice_indexer
 
 
@@ -91,23 +92,31 @@ def test_s3_spice_files(session, s3_client, events_client):
     assert os.path.exists(temp_path + "/ck/imap_2025_118_2025_120_001.ah.bc")
 
     # Verify that the database was populated appropriately
-    result = (
-        session.query(models.SPICEFiles)
-        .filter_by(file_name="imap_2025_118_2025_120_001.ah.bc")
-        .one()
+    # NOTE: This is also testing the spice_query_api, to help ensure compatibility
+    result = spice_query_api.lambda_handler(
+        {"queryStringParameters": {"type": "attitude_history"}}, None
     )
-    assert result.kernel_type == "attitude_history"
-    assert result.version == 1
-    assert len(result.file_intervals_datetime) == 2  # 1 significant gap detected
-
-    result = session.query(models.SPICEFiles).filter_by(file_name="naif0012.tls").one()
-    assert result.kernel_type == "leapseconds"
-    assert result.version == 12
-    assert len(result.file_intervals_datetime) == 1  # Default time range
-
-    result = (
-        session.query(models.SPICEFiles).filter_by(file_name="imap_sclk_0012.tsc").one()
+    result = json.loads(result["body"])
+    assert len(result) == 1
+    assert result[0]["kernel_type"] == "attitude_history"
+    assert result[0]["version"] == 1
+    assert len(result[0]["file_intervals_datetime"]) == 2  # 1 significant gap detected
+    print(result)
+    result = spice_query_api.lambda_handler(
+        {"queryStringParameters": {"type": "leapseconds"}}, None
     )
-    assert result.kernel_type == "spacecraft_clock"
-    assert result.version == 12
-    assert len(result.file_intervals_datetime) == 1  # Default time range
+    result = json.loads(result["body"])
+    assert len(result) == 1
+    assert result[0]["kernel_type"] == "leapseconds"
+    assert result[0]["version"] == 12
+    assert len(result[0]["file_intervals_datetime"]) == 1  # Default time range
+    print(result)
+    result = spice_query_api.lambda_handler(
+        {"queryStringParameters": {"type": "spacecraft_clock"}}, None
+    )
+    result = json.loads(result["body"])
+    assert len(result) == 1
+    assert result[0]["kernel_type"] == "spacecraft_clock"
+    assert result[0]["version"] == 12
+    assert len(result[0]["file_intervals_datetime"]) == 1  # Default time range
+    print(result)

--- a/tests/lambda_endpoints/test_spice_query_api.py
+++ b/tests/lambda_endpoints/test_spice_query_api.py
@@ -1,7 +1,7 @@
 """Tests for the SPICE Query API."""
 
-from datetime import datetime
 import json
+from datetime import datetime
 
 import pytest
 
@@ -11,83 +11,120 @@ from sds_data_manager.lambda_code.SDSCode.database import models
 
 def _insert_ck_test_data(session):
     """Put a filepath into the test data."""
-
-    metadata_params = {'file_name': 'imap_2025_118_2025_120_009.ah.bc', 
-                        'file_root': 'imap_2025_118_2025_120_.ah.bc', 
-                        'kernel_type': 'attitude_history', 
-                        'version': 9, 
-                        'min_date_j2000': 799240876.0732585, 
-                        'max_date_j2000': 799244783.0732579, 
-                        'file_intervals_j2000': [[799240876.0732585, 799240921.0732585], 
-                                                [799242436.0732583, 799244783.0732579]], 
-                        'min_date_datetime': datetime(2025,4,29,23,20,6), 
-                        'max_date_datetime': datetime(2025,4,30,0,25,13), 
-                        'file_intervals_datetime': [['2025-04-29T23:20:06.887765+00:00', '2025-04-29T23:20:51.887765+00:00'],
-                                                    ['2025-04-29T23:46:06.887765+00:00', '2025-04-30T00:25:13.887765+00:00']], 
-                        'min_date_sclk': '1/0512204570:32482', 
-                        'max_date_sclk': '1/0512208477:32482', 
-                        'file_intervals_sclk': [['1/0512204570:32482', '1/0512204615:32482'], 
-                                                ['1/0512206130:32482', '1/0512208477:32482']], 
-                        'sclk_kernel': 'naif0012.tls', 
-                        'lsk_kernel': 'imap_sclk_0012.tsc', 
-                        'ingestion_date': datetime(2025,4,9,21,12,53)}
+    metadata_params = {
+        "file_name": "imap_2025_118_2025_120_009.ah.bc",
+        "file_root": "imap_2025_118_2025_120_.ah.bc",
+        "kernel_type": "attitude_history",
+        "version": 9,
+        "min_date_j2000": 799240876.0732585,
+        "max_date_j2000": 799244783.0732579,
+        "file_intervals_j2000": [
+            [799240876.0732585, 799240921.0732585],
+            [799242436.0732583, 799244783.0732579],
+        ],
+        "min_date_datetime": datetime(2025, 4, 29, 23, 20, 6),
+        "max_date_datetime": datetime(2025, 4, 30, 0, 25, 13),
+        "file_intervals_datetime": [
+            ["2025-04-29T23:20:06.887765+00:00", "2025-04-29T23:20:51.887765+00:00"],
+            ["2025-04-29T23:46:06.887765+00:00", "2025-04-30T00:25:13.887765+00:00"],
+        ],
+        "min_date_sclk": "1/0512204570:32482",
+        "max_date_sclk": "1/0512208477:32482",
+        "file_intervals_sclk": [
+            ["1/0512204570:32482", "1/0512204615:32482"],
+            ["1/0512206130:32482", "1/0512208477:32482"],
+        ],
+        "sclk_kernel": "naif0012.tls",
+        "lsk_kernel": "imap_sclk_0012.tsc",
+        "ingestion_date": datetime(2025, 4, 9, 21, 12, 53),
+    }
 
     # Add data to the ScienceFiles table and return the session
     session.add(models.SPICEFiles(**metadata_params))
     session.commit()
 
+
 def _insert_many_versions_test_data(session):
     """Put a filepath into the test data."""
-    for version in range(0,10):
-        metadata_params = {'file_name': f'imap_2025_118_2025_120_00{version}.ah.bc', 
-                            'file_root': 'imap_2025_118_2025_120_.ah.bc', 
-                            'kernel_type': 'attitude_history', 
-                            'version': version, 
-                            'min_date_j2000': 799240876.0732585, 
-                            'max_date_j2000': 799244783.0732579, 
-                            'file_intervals_j2000': [[799240876.0732585, 799240921.0732585], 
-                                                    [799242436.0732583, 799244783.0732579]], 
-                            'min_date_datetime': datetime(2025,4,29,23,20,6), 
-                            'max_date_datetime': datetime(2025,4,30,0,25,13), 
-                            'file_intervals_datetime': [['2025-04-29T23:20:06.887765+00:00', '2025-04-29T23:20:51.887765+00:00'],
-                                                        ['2025-04-29T23:46:06.887765+00:00', '2025-04-30T00:25:13.887765+00:00']], 
-                            'min_date_sclk': '1/0512204570:32482', 
-                            'max_date_sclk': '1/0512208477:32482', 
-                            'file_intervals_sclk': [['1/0512204570:32482', '1/0512204615:32482'], 
-                                                    ['1/0512206130:32482', '1/0512208477:32482']], 
-                            'sclk_kernel': 'naif0012.tls', 
-                            'lsk_kernel': 'imap_sclk_0012.tsc', 
-                            'ingestion_date': datetime(2025,4,9,21,12,53)}
+    for version in range(0, 10):
+        metadata_params = {
+            "file_name": f"imap_2025_118_2025_120_00{version}.ah.bc",
+            "file_root": "imap_2025_118_2025_120_.ah.bc",
+            "kernel_type": "attitude_history",
+            "version": version,
+            "min_date_j2000": 799240876.0732585,
+            "max_date_j2000": 799244783.0732579,
+            "file_intervals_j2000": [
+                [799240876.0732585, 799240921.0732585],
+                [799242436.0732583, 799244783.0732579],
+            ],
+            "min_date_datetime": datetime(2025, 4, 29, 23, 20, 6),
+            "max_date_datetime": datetime(2025, 4, 30, 0, 25, 13),
+            "file_intervals_datetime": [
+                [
+                    "2025-04-29T23:20:06.887765+00:00",
+                    "2025-04-29T23:20:51.887765+00:00",
+                ],
+                [
+                    "2025-04-29T23:46:06.887765+00:00",
+                    "2025-04-30T00:25:13.887765+00:00",
+                ],
+            ],
+            "min_date_sclk": "1/0512204570:32482",
+            "max_date_sclk": "1/0512208477:32482",
+            "file_intervals_sclk": [
+                ["1/0512204570:32482", "1/0512204615:32482"],
+                ["1/0512206130:32482", "1/0512208477:32482"],
+            ],
+            "sclk_kernel": "naif0012.tls",
+            "lsk_kernel": "imap_sclk_0012.tsc",
+            "ingestion_date": datetime(2025, 4, 9, 21, 12, 53),
+        }
 
         # Add data to the ScienceFiles table and return the session
         session.add(models.SPICEFiles(**metadata_params))
         session.commit()
+
 
 @pytest.fixture
 def expected_ck_response():
     """Return the expected response."""
     expected_response = json.dumps(
         [
-            {'file_name': 'ck/imap_2025_118_2025_120_009.ah.bc', 
-            'file_root': 'imap_2025_118_2025_120_.ah.bc', 
-            'kernel_type': 'attitude_history', 
-            'version': 9, 
-            'min_date_j2000': 799240876.0732585, 
-            'max_date_j2000': 799244783.0732579, 
-            'file_intervals_j2000': [[799240876.0732585, 799240921.0732585], 
-                                    [799242436.0732583, 799244783.0732579]], 
-            'min_date_datetime': '2025-04-29, 23:20:06', 
-            'max_date_datetime': '2025-04-30, 00:25:13', 
-            'file_intervals_datetime': [['2025-04-29T23:20:06.887765+00:00', '2025-04-29T23:20:51.887765+00:00'],
-                                        ['2025-04-29T23:46:06.887765+00:00', '2025-04-30T00:25:13.887765+00:00']], 
-            'min_date_sclk': '1/0512204570:32482', 
-            'max_date_sclk': '1/0512208477:32482', 
-            'file_intervals_sclk': [['1/0512204570:32482', '1/0512204615:32482'], 
-                                    ['1/0512206130:32482', '1/0512208477:32482']], 
-            'sclk_kernel': 'naif0012.tls', 
-            'lsk_kernel': 'imap_sclk_0012.tsc', 
-            'ingestion_date': '2025-04-09, 21:12:53',
-            'timestamp': 1744233173.0}
+            {
+                "file_name": "ck/imap_2025_118_2025_120_009.ah.bc",
+                "file_root": "imap_2025_118_2025_120_.ah.bc",
+                "kernel_type": "attitude_history",
+                "version": 9,
+                "min_date_j2000": 799240876.0732585,
+                "max_date_j2000": 799244783.0732579,
+                "file_intervals_j2000": [
+                    [799240876.0732585, 799240921.0732585],
+                    [799242436.0732583, 799244783.0732579],
+                ],
+                "min_date_datetime": "2025-04-29, 23:20:06",
+                "max_date_datetime": "2025-04-30, 00:25:13",
+                "file_intervals_datetime": [
+                    [
+                        "2025-04-29T23:20:06.887765+00:00",
+                        "2025-04-29T23:20:51.887765+00:00",
+                    ],
+                    [
+                        "2025-04-29T23:46:06.887765+00:00",
+                        "2025-04-30T00:25:13.887765+00:00",
+                    ],
+                ],
+                "min_date_sclk": "1/0512204570:32482",
+                "max_date_sclk": "1/0512208477:32482",
+                "file_intervals_sclk": [
+                    ["1/0512204570:32482", "1/0512204615:32482"],
+                    ["1/0512206130:32482", "1/0512208477:32482"],
+                ],
+                "sclk_kernel": "naif0012.tls",
+                "lsk_kernel": "imap_sclk_0012.tsc",
+                "ingestion_date": "2025-04-09, 21:12:53",
+                "timestamp": 1744233173.0,
+            }
         ]
     )
     return expected_response
@@ -128,9 +165,7 @@ def test_end_time_query(session, expected_ck_response):
 
 def test_start_and_end_time_query(session, expected_ck_response):
     """Test that both start and end date can be queried."""
-    event = {
-        "queryStringParameters": {"start_time": "0", "end_time": "1000000000"}
-    }
+    event = {"queryStringParameters": {"start_time": "0", "end_time": "1000000000"}}
     _insert_ck_test_data(session)
     returned_query = spice_query_api.lambda_handler(event=event, context={})
 
@@ -174,16 +209,17 @@ def test_invalid_query(session):
     assert returned_query["statusCode"] == 400
     assert returned_query["body"] == expected_response
 
+
 def test_latest_query(session, expected_ck_response):
-    """Test 'latest' filters out older versions"""
+    """Test 'latest' filters out older versions."""
     _insert_many_versions_test_data(session)
 
     # First, assert all 10 would be returned with no filter
     event = {"queryStringParameters": {}}
     returned_query = spice_query_api.lambda_handler(event=event, context={})
-    assert len(json.loads(returned_query['body']))==10
+    assert len(json.loads(returned_query["body"])) == 10
 
     # Next, assert that only one returns if latest=True
-    event = {"queryStringParameters": {'latest':'True'}}
+    event = {"queryStringParameters": {"latest": "True"}}
     returned_query = spice_query_api.lambda_handler(event=event, context={})
     assert returned_query["body"] == expected_ck_response

--- a/tests/lambda_endpoints/test_spice_query_api.py
+++ b/tests/lambda_endpoints/test_spice_query_api.py
@@ -1,0 +1,189 @@
+"""Tests for the SPICE Query API."""
+
+from datetime import datetime
+import json
+
+import pytest
+
+from sds_data_manager.lambda_code.SDSCode.api_lambdas import spice_query_api
+from sds_data_manager.lambda_code.SDSCode.database import models
+
+
+def _insert_ck_test_data(session):
+    """Put a filepath into the test data."""
+
+    metadata_params = {'file_name': 'imap_2025_118_2025_120_009.ah.bc', 
+                        'file_root': 'imap_2025_118_2025_120_.ah.bc', 
+                        'kernel_type': 'attitude_history', 
+                        'version': 9, 
+                        'min_date_j2000': 799240876.0732585, 
+                        'max_date_j2000': 799244783.0732579, 
+                        'file_intervals_j2000': [[799240876.0732585, 799240921.0732585], 
+                                                [799242436.0732583, 799244783.0732579]], 
+                        'min_date_datetime': datetime(2025,4,29,23,20,6), 
+                        'max_date_datetime': datetime(2025,4,30,0,25,13), 
+                        'file_intervals_datetime': [['2025-04-29T23:20:06.887765+00:00', '2025-04-29T23:20:51.887765+00:00'],
+                                                    ['2025-04-29T23:46:06.887765+00:00', '2025-04-30T00:25:13.887765+00:00']], 
+                        'min_date_sclk': '1/0512204570:32482', 
+                        'max_date_sclk': '1/0512208477:32482', 
+                        'file_intervals_sclk': [['1/0512204570:32482', '1/0512204615:32482'], 
+                                                ['1/0512206130:32482', '1/0512208477:32482']], 
+                        'sclk_kernel': 'naif0012.tls', 
+                        'lsk_kernel': 'imap_sclk_0012.tsc', 
+                        'ingestion_date': datetime(2025,4,9,21,12,53)}
+
+    # Add data to the ScienceFiles table and return the session
+    session.add(models.SPICEFiles(**metadata_params))
+    session.commit()
+
+def _insert_many_versions_test_data(session):
+    """Put a filepath into the test data."""
+    for version in range(0,10):
+        metadata_params = {'file_name': f'imap_2025_118_2025_120_00{version}.ah.bc', 
+                            'file_root': 'imap_2025_118_2025_120_.ah.bc', 
+                            'kernel_type': 'attitude_history', 
+                            'version': version, 
+                            'min_date_j2000': 799240876.0732585, 
+                            'max_date_j2000': 799244783.0732579, 
+                            'file_intervals_j2000': [[799240876.0732585, 799240921.0732585], 
+                                                    [799242436.0732583, 799244783.0732579]], 
+                            'min_date_datetime': datetime(2025,4,29,23,20,6), 
+                            'max_date_datetime': datetime(2025,4,30,0,25,13), 
+                            'file_intervals_datetime': [['2025-04-29T23:20:06.887765+00:00', '2025-04-29T23:20:51.887765+00:00'],
+                                                        ['2025-04-29T23:46:06.887765+00:00', '2025-04-30T00:25:13.887765+00:00']], 
+                            'min_date_sclk': '1/0512204570:32482', 
+                            'max_date_sclk': '1/0512208477:32482', 
+                            'file_intervals_sclk': [['1/0512204570:32482', '1/0512204615:32482'], 
+                                                    ['1/0512206130:32482', '1/0512208477:32482']], 
+                            'sclk_kernel': 'naif0012.tls', 
+                            'lsk_kernel': 'imap_sclk_0012.tsc', 
+                            'ingestion_date': datetime(2025,4,9,21,12,53)}
+
+        # Add data to the ScienceFiles table and return the session
+        session.add(models.SPICEFiles(**metadata_params))
+        session.commit()
+
+@pytest.fixture
+def expected_ck_response():
+    """Return the expected response."""
+    expected_response = json.dumps(
+        [
+            {'file_name': 'ck/imap_2025_118_2025_120_009.ah.bc', 
+            'file_root': 'imap_2025_118_2025_120_.ah.bc', 
+            'kernel_type': 'attitude_history', 
+            'version': 9, 
+            'min_date_j2000': 799240876.0732585, 
+            'max_date_j2000': 799244783.0732579, 
+            'file_intervals_j2000': [[799240876.0732585, 799240921.0732585], 
+                                    [799242436.0732583, 799244783.0732579]], 
+            'min_date_datetime': '2025-04-29, 23:20:06', 
+            'max_date_datetime': '2025-04-30, 00:25:13', 
+            'file_intervals_datetime': [['2025-04-29T23:20:06.887765+00:00', '2025-04-29T23:20:51.887765+00:00'],
+                                        ['2025-04-29T23:46:06.887765+00:00', '2025-04-30T00:25:13.887765+00:00']], 
+            'min_date_sclk': '1/0512204570:32482', 
+            'max_date_sclk': '1/0512208477:32482', 
+            'file_intervals_sclk': [['1/0512204570:32482', '1/0512204615:32482'], 
+                                    ['1/0512206130:32482', '1/0512208477:32482']], 
+            'sclk_kernel': 'naif0012.tls', 
+            'lsk_kernel': 'imap_sclk_0012.tsc', 
+            'ingestion_date': '2025-04-09, 21:12:53',
+            'timestamp': 1744233173.0}
+        ]
+    )
+    return expected_response
+
+
+def test_query_result_body(session):
+    """Tests that the query result body can be loaded."""
+    _insert_ck_test_data(session)
+    event = {"queryStringParameters": {}}
+
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+
+    assert json.loads(returned_query["body"])
+
+
+def test_start_time_query(session, expected_ck_response):
+    """Test that start date can be queried."""
+    _insert_ck_test_data(session)
+    event = {"queryStringParameters": {"start_time": "0"}}
+
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert returned_query["body"] == expected_ck_response
+
+
+def test_end_time_query(session, expected_ck_response):
+    """Test that end date can be queried."""
+    _insert_ck_test_data(session)
+    event = {
+        "queryStringParameters": {"end_time": "1000000000"},
+    }
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert returned_query["body"] == expected_ck_response
+
+
+def test_start_and_end_time_query(session, expected_ck_response):
+    """Test that both start and end date can be queried."""
+    event = {
+        "queryStringParameters": {"start_time": "0", "end_time": "1000000000"}
+    }
+    _insert_ck_test_data(session)
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert returned_query["body"] == expected_ck_response
+
+
+def test_empty_start_time_query(session):
+    """Test that a start_date query with no matches returns an empty list."""
+    _insert_ck_test_data(session)
+    event = {"queryStringParameters": {"start_time": "1000000000"}}
+    expected_response = json.dumps([])
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert returned_query["body"] == expected_response
+
+
+def test_empty_end_date_query(session):
+    """Test that an end_time query with no matches returns an empty list."""
+    _insert_ck_test_data(session)
+    event = {"queryStringParameters": {"end_time": "0"}}
+    expected_response = json.dumps([])
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert returned_query["body"] == expected_response
+
+
+def test_invalid_query(session):
+    """Test that invalid parameters return a 400 status with explanation."""
+    _insert_ck_test_data(session)
+    event = {"queryStringParameters": {"size": "500"}}
+    expected_response = json.dumps(
+        "size is not a valid query parameter. "
+        + "Valid query parameters are: "
+        + "['start_time', 'end_time', 'type', 'latest']"
+    )
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 400
+    assert returned_query["body"] == expected_response
+
+def test_latest_query(session, expected_ck_response):
+    """Test 'latest' filters out older versions"""
+    _insert_many_versions_test_data(session)
+
+    # First, assert all 10 would be returned with no filter
+    event = {"queryStringParameters": {}}
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+    assert len(json.loads(returned_query['body']))==10
+
+    # Next, assert that only one returns if latest=True
+    event = {"queryStringParameters": {'latest':'True'}}
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+    assert returned_query["body"] == expected_ck_response

--- a/tests/lambda_endpoints/test_spice_query_api.py
+++ b/tests/lambda_endpoints/test_spice_query_api.py
@@ -140,6 +140,17 @@ def test_query_result_body(session):
     assert json.loads(returned_query["body"])
 
 
+def test_file_name_query(session, expected_ck_response):
+    """Test that start date can be queried."""
+    _insert_ck_test_data(session)
+    event = {"queryStringParameters": {"file_name": "imap_2025_118_2025_120_009.ah.bc"}}
+
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert returned_query["body"] == expected_ck_response
+
+
 def test_start_time_query(session, expected_ck_response):
     """Test that start date can be queried."""
     _insert_ck_test_data(session)
@@ -202,7 +213,7 @@ def test_invalid_query(session):
     expected_response = json.dumps(
         "size is not a valid query parameter. "
         + "Valid query parameters are: "
-        + "['start_time', 'end_time', 'type', 'latest']"
+        + "['file_name', 'start_time', 'end_time', 'type', 'latest']"
     )
     returned_query = spice_query_api.lambda_handler(event=event, context={})
 


### PR DESCRIPTION
# Change Summary

## Overview
Adds an API to our API gateway to enable querying for SPICE files

## New Files
- spice_query_api.py
   - The logic for querying the spice database
- test_spice_query_api.py
   - Unit tests for the SPICE queries 

## Updated Files
- tests/infrastructure/test_sds_api_manager_construct.py
   - Fixing the unit test now that we have a new endpoint
- tests/lambda_endpoints/test_spice_indexer_lambda.py
   - The spice indexer tests will use the lambda API for queries 

Minor Update:
- .devcontainer/Dockerfile
   - Updated the devcontainer to run on python 3.12

## Testing
New unit tests are in test_spice_query_api.py, and I update the unit tests in test_spice_indexer_lambda.py to use the new logic 
