### PR TITLE
MNT: Make sure all default/external loggers get INFO logs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ci:
   autofix_prs: false
   autoupdate_schedule: 'quarterly'
-  skip: [poetry-lock, generate-requirements-files]
+  skip: [poetry-lock]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -24,14 +24,14 @@ repos:
     rev: '1.8.0'  # add version here
     hooks:
       - id: poetry-check
+      - id: poetry-export
+        name: export layer db requirements.txt
+        args: ["-f", "requirements.txt", "-o", "lambda_layer/database/requirements.txt", "--with", "layer-database"]
+      - id: poetry-export
+        name: export layer spice requirements.txt
+        args: ["-f", "requirements.txt", "-o", "lambda_layer/spice/requirements.txt", "--with", "layer-spice"]
+      - id: poetry-export
+        name: export layer processing requirements.txt
+        args: [ "-f", "requirements.txt", "-o", "lambda_layer/processing/requirements.txt", "--with", "layer-processing"]
       - id: poetry-lock
         args: [--no-update]
-  - repo: local
-    hooks:
-      - id: generate-requirements-files
-        name: generate-requirements-files
-        entry: lambda_layer/generate_requirements_files.sh
-        language: script
-        pass_filenames: false
-        verbose: true
-

--- a/lambda_layer/database/requirements.txt
+++ b/lambda_layer/database/requirements.txt
@@ -72,9 +72,9 @@ greenlet==3.1.1 ; python_version < "3.14" and (platform_machine == "aarch64" or 
     --hash=sha256:f1d4aeb8891338e60d1ab6127af1fe45def5259def8094b9c7e34690c8858803 \
     --hash=sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79 \
     --hash=sha256:f6ff3b14f2df4c41660a7dec01045a045653998784bf8cfcb5a525bdffffbc8f
-imap-data-access==0.18.1 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:94edd7acccdb2d1eecb36b0d26be92769615e2dcd100867d998ec236b3268673 \
-    --hash=sha256:f9a54153b843158be7442321678c8df2185c52c8c9a4b15a6ebc6c0d722184eb
+imap-data-access==0.18.2 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:6f26970b2c162d8611dfa78eba9dc08bbdcec0a56828a1bc089b4525857636ad \
+    --hash=sha256:feda44b1523e3724d345d1f25fc942d8cc1b19f1a58eebd1330c0e99d63b617d
 psycopg2-binary==2.9.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:04392983d0bb89a8717772a193cfaac58871321e3ec69514e1c4e0d4957b5aff \
     --hash=sha256:056470c3dc57904bbf63d6f534988bafc4e970ffd50f6271fc4ee7daad9498a5 \

--- a/lambda_layer/processing/requirements.txt
+++ b/lambda_layer/processing/requirements.txt
@@ -43,9 +43,9 @@ astropy==6.1.7 ; python_version >= "3.10" and python_version < "4" \
 cdflib==1.3.3 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:16b0d1ed7f46f6e8c6011d70cf0168d89f022778d7591771337f7b1446553b2c \
     --hash=sha256:e41a15d36b7a00e516bd21a2ccb60e4ce4f1ab2639b80d82ff42e33820800f2f
-imap-data-access==0.18.1 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:94edd7acccdb2d1eecb36b0d26be92769615e2dcd100867d998ec236b3268673 \
-    --hash=sha256:f9a54153b843158be7442321678c8df2185c52c8c9a4b15a6ebc6c0d722184eb
+imap-data-access==0.18.2 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:6f26970b2c162d8611dfa78eba9dc08bbdcec0a56828a1bc089b4525857636ad \
+    --hash=sha256:feda44b1523e3724d345d1f25fc942d8cc1b19f1a58eebd1330c0e99d63b617d
 imap-processing==0.12.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:3ed372c08384e54f3fd36846ea47cad9c0c7a3619bf68f65c88b1f49cd5f239e \
     --hash=sha256:9c5bd9f1f3309c43b681cfaa6f6430df9169dbd21c2b07e26919e54eaf2d4992

--- a/lambda_layer/spice/requirements.txt
+++ b/lambda_layer/spice/requirements.txt
@@ -97,9 +97,9 @@ charset-normalizer==3.4.1 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.18.1 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:94edd7acccdb2d1eecb36b0d26be92769615e2dcd100867d998ec236b3268673 \
-    --hash=sha256:f9a54153b843158be7442321678c8df2185c52c8c9a4b15a6ebc6c0d722184eb
+imap-data-access==0.18.2 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:6f26970b2c162d8611dfa78eba9dc08bbdcec0a56828a1bc089b4525857636ad \
+    --hash=sha256:feda44b1523e3724d345d1f25fc942d8cc1b19f1a58eebd1330c0e99d63b617d
 numpy==2.2.4 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:05c076d531e9998e7e694c36e8b349969c56eadd2cdcd07242958489d79a7286 \
     --hash=sha256:0d54974f9cf14acf49c60f0f7f4084b6579d24d439453d5fc5805d46a165b542 \

--- a/poetry.lock
+++ b/poetry.lock
@@ -899,13 +899,13 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.18.1"
+version = "0.18.2"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap_data_access-0.18.1-py3-none-any.whl", hash = "sha256:94edd7acccdb2d1eecb36b0d26be92769615e2dcd100867d998ec236b3268673"},
-    {file = "imap_data_access-0.18.1.tar.gz", hash = "sha256:f9a54153b843158be7442321678c8df2185c52c8c9a4b15a6ebc6c0d722184eb"},
+    {file = "imap_data_access-0.18.2-py3-none-any.whl", hash = "sha256:feda44b1523e3724d345d1f25fc942d8cc1b19f1a58eebd1330c0e99d63b617d"},
+    {file = "imap_data_access-0.18.2.tar.gz", hash = "sha256:6f26970b2c162d8611dfa78eba9dc08bbdcec0a56828a1bc089b4525857636ad"},
 ]
 
 [package.extras]
@@ -2560,4 +2560,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "6b41fed46d95ac0df59083a60b64722c3e06961d6db511bb86fa929358ee61db"
+content-hash = "403c7a469bf7258d67b58c221dd31cd88a510ce3b0fda7c7e3e112c49f420d49"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ python = ">=3.10,<4"
 # WARNING - Please run this command when updateing `imap-data-access` to ensure that
 # the correct version and hash are used:
 #   poetry export -f requirements.txt -o lambda_layer/python/requirements.txt --with lambda-dev
-imap-data-access = ">=0.18.1"
+imap-data-access = ">=0.18.2"
 
 # Optional dependencies - install with `poetry install -E docs`
 sphinx = {version="^7.1.0", optional=true}

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
@@ -12,8 +12,9 @@ S3_CLIENT = boto3.client("s3")
 SECRETS_MANAGER = boto3.client("secretsmanager")
 
 # Logger setup
+# Set default logging level to INFO, to also capture INFO for the underlying downloaders
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 def get_two_most_recent_contact_times(bucket):


### PR DESCRIPTION
# Change Summary

## Overview

* Bumps the version of imap-data-access
* Adds more logs when downloading packet files from imap-data-access
* Reverts the pre-commit generate script updates from #520 as that doesn't work if a user doesn't have poetry installed locally (external to the venv).