### PR TITLE
SWAPI: Adding SWAPI ancillary dependents for L2

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -111,7 +111,8 @@ swapi, l0, raw, swapi, l1, hk, HARD, DOWNSTREAM
 swapi, l0, raw, swapi, l1, sci, HARD, DOWNSTREAM
 swapi, l1, hk, swapi, l1, sci, HARD, DOWNSTREAM
 swapi, l1, sci, swapi, l2, sci, HARD, DOWNSTREAM
-
+swapi, ancillary, esa-unit-conversion, swapi, l2, sci, HARD, DOWNSTREAM
+swapi, ancillary, lut-notes, swapi, l2, sci, HARD, DOWNSTREAM
 # <---- TEST SWAPI L3 Dependencies ---->
 
 swapi, l2, sci, swapi, l3a, alpha-sw, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary
closes #528 

## Overview
Adding ancillary to dependency tree of l2

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - adding ancillary dependents

## Testing

