### PR TITLE
BUG: Fix SPICE Indexer lambda handler path

### DIFF
--- a/sds_data_manager/constructs/indexer_lambda_construct.py
+++ b/sds_data_manager/constructs/indexer_lambda_construct.py
@@ -221,7 +221,7 @@ class SPICEIndexerLambda(Construct):
             # allow_all_outbound=True,
             runtime=lambda_.Runtime.PYTHON_3_12,
             code=code,
-            handler="pipeline_lambdas.spice_indexer.lambda_handler",
+            handler="SDSCode.pipeline_lambdas.spice_indexer.lambda_handler",
             role=efs_lambda_role,
             description="""Lambda that writes SPICE files to the EFS and indexes
                            them in our database.""",


### PR DESCRIPTION
# Change Summary

## Overview
Small fix to fix the SPICE indexer lambda handler path

## Updated Files
- sds_data_manager/constructs/indexer_lambda_construct.py
   - updated handler path

