### PR TITLE
Ultra - add ultra dependency info

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -135,13 +135,52 @@ ultra, l0, raw, ultra, l1a, all, HARD, DOWNSTREAM
 
 # Ultra-45 products
 ultra, l1a, 45sensor-de, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
+ultra, l1a, 45sensor-params, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-rates, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-hk,ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-aux,ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-de,ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+
+ultra, ancillary, 45sensor-leftslit-lookup, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 45sensor-rightslit-lookup, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, egynorm-lookup, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 45sensor-imgparams-lookup, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 45sensor-back-pos-lookup, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 45sensor-tdc-norm-lookup, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 45sensor-logistic-interpolation, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 90sensor-dps-exposure, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 
 ultra, l1b, 45sensor-de, ultra, l1c, 45sensor-pset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-extendedspin, ultra, l1c, 45sensor-pset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-cullingmask, ultra, l1c, 45sensor-pset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-histogram, ultra, l1c, 45sensor-histogram, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-cullingmask, ultra, l1c, 45sensor-histogram, HARD, DOWNSTREAM
+
+ultra, ancillary, 90sensor-gf, ultra, l1c, 45sensor-pset, HARD, DOWNSTREAM
+ultra, ancillary, 90sensor-efficiencies, ultra, l1c, 45sensor-pset, HARD, DOWNSTREAM
+
+# Ultra-90 products
+ultra, l1a, 90sensor-de, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
+ultra, l1a, 90sensor-params, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, l1a, 90sensor-rates, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, l1a, 90sensor-hk,ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, l1a, 90sensor-aux,ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, l1b, 90sensor-de,ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+
+ultra, ancillary, 90sensor-leftslit-lookup, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 90sensor-rightslit-lookup, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, egynorm-lookup, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 90sensor-imgparams-lookup, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 90sensor-back-pos-lookup, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 90sensor-tdc-norm-lookup, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 45sensor-logistic-interpolation, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, 90sensor-dps-exposure, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+
+ultra, l1b, 90sensor-de, ultra, l1c, 90sensor-pset, HARD, DOWNSTREAM
+ultra, l1b, 90sensor-extendedspin, ultra, l1c, 90sensor-pset, HARD, DOWNSTREAM
+ultra, l1b, 90sensor-cullingmask, ultra, l1c, 90sensor-pset, HARD, DOWNSTREAM
+ultra, l1a, 90sensor-histogram, ultra, l1c, 90sensor-histogram, HARD, DOWNSTREAM
+ultra, l1b, 90sensor-cullingmask, ultra, l1c, 90sensor-histogram, HARD, DOWNSTREAM
+
+ultra, ancillary, 90sensor-gf, ultra, l1c, 90sensor-pset, HARD, DOWNSTREAM
+ultra, ancillary, 90sensor-efficiencies, ultra, l1c, 90sensor-pset, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview
Added (almost) all of the Ultra dependencies. There are still a couple of lookup tables that they will give to me. Based on this Galaxy page:
https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/256944034/Ultra+lookup+table+names

Note that some 45 or 90 luts are missing. In those cases I use the other instrument. 

## Updated Files
- dependency_config.csv
   - Added Ultra dependency info
