### PR TITLE
MNT: Fixing some SPICE path to be able to work with upcoming change of DATA_DIR

### DIFF
--- a/sds_data_manager/constructs/efs_construct.py
+++ b/sds_data_manager/constructs/efs_construct.py
@@ -52,7 +52,6 @@ class EFSConstruct(Construct):
         # will need to access EFS or mount EFS.
         self.volume_name = "SPICE-EFS"
         self.efs_path = "/data"
-        self.efs_spice_path = "/data/spice"
 
         # Define EFS security group, ports are added in EC2 stack
         self.efs_security_group = ec2.SecurityGroup(
@@ -97,6 +96,6 @@ class EFSConstruct(Construct):
         self.spice_access_point = self.efs.add_access_point(
             "SpiceAccessPoint",
             create_acl=efs.Acl(owner_gid="1000", owner_uid="1000", permissions="750"),
-            path=self.efs_spice_path,
+            path=self.efs_path,
             posix_user=efs.PosixUser(gid="1000", uid="1000"),
         )

--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -217,13 +217,13 @@ class IalirtIngestLambda(Construct):
             vpc=self.vpc,
             security_groups=[self.efs_security_group],
             filesystem=lambda_.FileSystem.from_efs_access_point(
-                self.efs_access_point, "/mnt/spice"
+                self.efs_access_point, "/mnt/data"
             ),
             environment={
                 "INGEST_TABLE": packet_data_table.table_name,
                 "ALGORITHM_TABLE": algorithm_data_table.table_name,
                 "S3_BUCKET": ialirt_bucket.bucket_name,
-                "EFS_SPICE_MOUNT_PATH": "/mnt/spice",
+                "EFS_SPICE_MOUNT_PATH": "/mnt/data",
             },
         )
 

--- a/sds_data_manager/constructs/indexer_lambda_construct.py
+++ b/sds_data_manager/constructs/indexer_lambda_construct.py
@@ -211,7 +211,7 @@ class SPICEIndexerLambda(Construct):
         )
 
         # This access point is used by other resources to read from EFS
-        spice_mount_path = "/mnt/spice"
+        spice_mount_path = "/mnt/data"
 
         self.spice_ingest_lambda = lambda_.Function(
             self,

--- a/sds_data_manager/constructs/indexer_lambda_construct.py
+++ b/sds_data_manager/constructs/indexer_lambda_construct.py
@@ -237,7 +237,7 @@ class SPICEIndexerLambda(Construct):
             memory_size=1000,
             security_groups=[rds_security_group],
             environment={
-                "EFS_SPICE_MOUNT_PATH": spice_mount_path,
+                "DATA_DIR": spice_mount_path,
                 "SECRET_NAME": db_secret_name,
             },
         )

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -98,7 +98,7 @@ class ProcessingConstruct(Construct):
                 ),
                 memory=cdk.Size.mebibytes(4096),
                 cpu=1,
-                environment={"IMAP_SPICE_DIR": "/mnt/spice"},
+                environment={"DATA_DIR": "/mnt/data"},
                 volumes=self.volumes,
                 # TODO: Do we need to explicitly specify architecture and OS family?
                 #       We are building containers in GitHub Actions and need to

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import textwrap
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -46,16 +46,15 @@ class MetaKernel:
             self.spice_files[type] = []
             self.spice_gaps[type] = [[start_time, end_time]]
 
-        self.template_header = rf"""
+        self.template_header = f"""
+\\begintext
 
-       \begintext
+This is the most up to date Metakernel as of
+{datetime.now(timezone.utc)}.
 
-       This is the most up to date Metakernel as of
-       {datetime.now()}.
-
-       This attempts to cover data from
-       {self.start_time_j2000} to {self.end_time_j2000}
-       seconds since J2000.
+This attempts to cover data from
+{self.start_time_j2000} to {self.end_time_j2000}
+seconds since J2000.
 
         """
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -353,7 +353,7 @@ def lambda_handler(event, context):
 
     """
     # Define the paths
-    spice_mount_path = Path(os.getenv("EFS_SPICE_MOUNT_PATH"))  # Eg. /mnt/
+    spice_mount_path = Path(os.getenv("DATA_DIR"))  # Eg. /mnt/data
 
     # Retrieve the S3 bucket and key from the event
     s3_bucket = event["detail"]["bucket"]["name"]

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -382,5 +382,5 @@ def lambda_handler(event, context):
 
     return {
         "statusCode": 200,
-        "body": f"{s3_key} moved and index to table successfully",
+        "body": f"{s3_key} moved to EFS and indexed to table successfully",
     }

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -274,7 +274,7 @@ def write_data_to_efs(s3_key: str, s3_bucket: str, spice_mount_path: Path) -> Pa
     s3_bucket : str
         The S3 bucket
     spice_mount_path: Path
-        The path to the local SPICE directory
+        The path to the local SPICE directory. Eg. /mnt/
 
     Returns
     -------
@@ -285,23 +285,22 @@ def write_data_to_efs(s3_key: str, s3_bucket: str, spice_mount_path: Path) -> Pa
     # Create an S3 client
     s3_client = boto3.client("s3")
 
-    # Keep the base folder name and filename from the s3 key
-    # i.e. "ck/file.bc"
+    # Get directory structure from the S3 key
     dirname, filename = os.path.split(s3_key)
-    s3_folder_path = os.path.basename(dirname)
-    # Download path to EFS
-    efs_spice_path = spice_mount_path / s3_folder_path
-    efs_spice_filename_and_path = efs_spice_path / filename
+    # Prepend EFS path to the s3 directory structure
+    efs_spice_path = spice_mount_path / dirname
+    # Create the folder if it does not exist
+    efs_spice_path.mkdir(parents=True, exist_ok=True)
     try:
-        # Create the folder if it does not exist
-        efs_spice_path.mkdir(parents=True, exist_ok=True)
+        # Download path to the EFS path
+        efs_spice_filename_and_path = efs_spice_path / filename
         # Download file from S3 to the EFS path
         s3_client.download_file(s3_bucket, s3_key, efs_spice_filename_and_path)
         logger.info(f"{s3_key} file downloaded successfully")
     except Exception as e:
         logger.error(f"Error downloading file: {e!s}")
 
-    logger.info("File was written to EFS path: %s", efs_spice_path)
+    logger.info(f"{filename} was written to EFS path: {efs_spice_path}")
     return efs_spice_filename_and_path
 
 
@@ -354,7 +353,7 @@ def lambda_handler(event, context):
 
     """
     # Define the paths
-    spice_mount_path = Path(os.getenv("EFS_SPICE_MOUNT_PATH"))  # Eg. /mnt/spice
+    spice_mount_path = Path(os.getenv("EFS_SPICE_MOUNT_PATH"))  # Eg. /mnt/
 
     # Retrieve the S3 bucket and key from the event
     s3_bucket = event["detail"]["bucket"]["name"]

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -363,6 +363,24 @@ def lambda_handler(event, context):
     logger.info(event)
 
     file_path = write_data_to_efs(s3_key, s3_bucket, spice_mount_path)
-    index_spice_file(file_path)
+    logger.info(f"File {s3_key} moved to EFS successfully")
 
-    return {"statusCode": 200, "body": "File downloaded and moved successfully"}
+    spice_obj = SPICEFilePath(file_path)
+    # If file is of type 'spin' or 'repoint', don't index to SPICE table
+    if spice_obj.spice_metadata["type"] == "repoint":
+        return {
+            "statusCode": 200,
+            "body": f"{s3_key} file moved to EFS successfully",
+        }
+    elif spice_obj.spice_metadata["type"] == "spin":
+        # TODO: Write spin information to spin table
+        logger.info(f"Indexing {s3_key} spin table")
+    else:
+        # Index the SPICE kerenels to the SPICE table
+        logger.info(f"Indexing {s3_key} to SPICE table")
+        index_spice_file(file_path)
+
+    return {
+        "statusCode": 200,
+        "body": f"{s3_key} moved and index to table successfully",
+    }

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -1,5 +1,6 @@
 """Functions to write SPICE ingested files to EFS."""
 
+import json
 import logging
 import os
 from datetime import datetime
@@ -352,6 +353,7 @@ def lambda_handler(event, context):
         Response message
 
     """
+    logger.info("Received event: " + json.dumps(event, indent=2))
     # Define the paths
     spice_mount_path = Path(os.getenv("DATA_DIR"))  # Eg. /mnt/data
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -265,7 +265,7 @@ def index_spice_file(spice_file: Path):
     )
 
 
-def write_data_to_efs(s3_key: str, s3_bucket: str, spice_mount_path: Path) -> Path:
+def write_data_to_efs(s3_key: str, s3_bucket: str, data_mount_path: Path) -> Path:
     """Write data to EFS and create/update symlink.
 
     Parameters
@@ -274,8 +274,8 @@ def write_data_to_efs(s3_key: str, s3_bucket: str, spice_mount_path: Path) -> Pa
         S3 object key
     s3_bucket : str
         The S3 bucket
-    spice_mount_path: Path
-        The path to the local SPICE directory. Eg. /mnt/
+    data_mount_path: Path
+        The path to the local SPICE directory. Eg. /mnt/data
 
     Returns
     -------
@@ -289,7 +289,7 @@ def write_data_to_efs(s3_key: str, s3_bucket: str, spice_mount_path: Path) -> Pa
     # Get directory structure from the S3 key
     dirname, filename = os.path.split(s3_key)
     # Prepend EFS path to the s3 directory structure
-    efs_spice_path = spice_mount_path / dirname
+    efs_spice_path = data_mount_path / dirname
     # Create the folder if it does not exist
     efs_spice_path.mkdir(parents=True, exist_ok=True)
     try:
@@ -355,14 +355,14 @@ def lambda_handler(event, context):
     """
     logger.info("Received event: " + json.dumps(event, indent=2))
     # Define the paths
-    spice_mount_path = Path(os.getenv("DATA_DIR"))  # Eg. /mnt/data
+    data_mount_path = Path(os.getenv("DATA_DIR"))  # Eg. /mnt/data
 
     # Retrieve the S3 bucket and key from the event
     s3_bucket = event["detail"]["bucket"]["name"]
     s3_key = event["detail"]["object"]["key"]
     logger.info(event)
 
-    file_path = write_data_to_efs(s3_key, s3_bucket, spice_mount_path)
+    file_path = write_data_to_efs(s3_key, s3_bucket, data_mount_path)
     logger.info(f"File {s3_key} moved to EFS successfully")
 
     spice_obj = SPICEFilePath(file_path)

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -250,7 +250,7 @@ def build_sds(
             name=f"{efs_instance.volume_name}-ECS-mount",
             access_point_id=efs_instance.spice_access_point.access_point_id,
             file_system=efs_instance.efs,
-            container_path="/mnt/spice",
+            container_path="/mnt/data",
             enable_transit_encryption=True,
             transit_encryption_port=2049,
         )

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -33,7 +33,7 @@ def _set_env(monkeypatch, tmpdir):
     # Mock the api gateway url
     # This is used in batch_starter.py
     monkeypatch.setenv("IMAP_DATA_ACCESS_URL", "https://test.url")
-    monkeypatch.setenv("EFS_SPICE_MOUNT_PATH", str(tmpdir))
+    monkeypatch.setenv("DATA_DIR", str(tmpdir))
 
 
 @pytest.fixture(scope="module")

--- a/tests/lambda_endpoints/test_spice_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_spice_indexer_lambda.py
@@ -62,7 +62,7 @@ def test_s3_spice_files(session, s3_client, events_client):
     The files are located in the "test_spice_files" directory.
 
     """
-    temp_path = os.getenv("EFS_SPICE_MOUNT_PATH")
+    temp_path = os.getenv("DATA_DIR")
     current_path = os.path.dirname(os.path.abspath(__file__))
     one_level_up = os.path.abspath(os.path.join(current_path, ".."))
     test_spice_data_dir = os.path.join(one_level_up, "test-data", "test_spice_files")
@@ -93,7 +93,7 @@ def test_s3_spice_files(session, s3_client, events_client):
 
     # Verify that the file was moved to the temp_path directory. This move
     # happens in above lambda function when the file is written to the EFS
-    # path specified by EFS_SPICE_MOUNT_PATH environment variable.
+    # path specified by DATA_DIR environment variable.
     assert os.path.exists(temp_path + "/imap/spice/lsk/naif0012.tls")
     assert os.path.exists(temp_path + "/imap/spice/sclk/imap_sclk_0012.tsc")
     assert os.path.exists(temp_path + "/imap/spice/ck/imap_2025_118_2025_120_001.ah.bc")

--- a/tests/lambda_endpoints/test_spice_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_spice_indexer_lambda.py
@@ -70,7 +70,7 @@ def test_s3_spice_files(session, s3_client, events_client):
     # Insert leapsecond spice kernel
     leapsecond_event = put_local_file_in_bucket(
         s3_client,
-        "spice/lsk/naif0012.tls",
+        "imap/spice/lsk/naif0012.tls",
         os.path.join(test_spice_data_dir, "naif0012.tls"),
     )
     spice_indexer.lambda_handler(leapsecond_event, None)
@@ -78,7 +78,7 @@ def test_s3_spice_files(session, s3_client, events_client):
     # Insert spacecraft clock spice kernel
     clock_kernel_event = put_local_file_in_bucket(
         s3_client,
-        "spice/sclk/imap_sclk_0012.tsc",
+        "imap/spice/sclk/imap_sclk_0012.tsc",
         os.path.join(test_spice_data_dir, "imap_sclk_0012.tsc"),
     )
     spice_indexer.lambda_handler(clock_kernel_event, None)
@@ -86,15 +86,17 @@ def test_s3_spice_files(session, s3_client, events_client):
     # Insert a new attitude kernel
     attitude_kernel_event = put_local_file_in_bucket(
         s3_client,
-        "spice/ck/imap_2025_118_2025_120_001.ah.bc",
+        "imap/spice/ck/imap_2025_118_2025_120_001.ah.bc",
         os.path.join(test_spice_data_dir, "imap_2025_118_2025_120_001.ah.bc"),
     )
     spice_indexer.lambda_handler(attitude_kernel_event, None)
 
-    # Verify that the file was moved to the temp_path directory
-    assert os.path.exists(temp_path + "/lsk/naif0012.tls")
-    assert os.path.exists(temp_path + "/sclk/imap_sclk_0012.tsc")
-    assert os.path.exists(temp_path + "/ck/imap_2025_118_2025_120_001.ah.bc")
+    # Verify that the file was moved to the temp_path directory. This move
+    # happens in above lambda function when the file is written to the EFS
+    # path specified by EFS_SPICE_MOUNT_PATH environment variable.
+    assert os.path.exists(temp_path + "/imap/spice/lsk/naif0012.tls")
+    assert os.path.exists(temp_path + "/imap/spice/sclk/imap_sclk_0012.tsc")
+    assert os.path.exists(temp_path + "/imap/spice/ck/imap_2025_118_2025_120_001.ah.bc")
 
     # Verify that the database was populated appropriately
     # NOTE: This is also testing the spice_query_api, to help ensure compatibility
@@ -106,7 +108,6 @@ def test_s3_spice_files(session, s3_client, events_client):
     assert result[0]["kernel_type"] == "attitude_history"
     assert result[0]["version"] == 1
     assert len(result[0]["file_intervals_datetime"]) == 2  # 1 significant gap detected
-    print(result)
     result = spice_query_api.lambda_handler(
         {"queryStringParameters": {"type": "leapseconds"}}, None
     )
@@ -115,7 +116,7 @@ def test_s3_spice_files(session, s3_client, events_client):
     assert result[0]["kernel_type"] == "leapseconds"
     assert result[0]["version"] == 12
     assert len(result[0]["file_intervals_datetime"]) == 1  # Default time range
-    print(result)
+
     result = spice_query_api.lambda_handler(
         {"queryStringParameters": {"type": "spacecraft_clock"}}, None
     )
@@ -124,7 +125,6 @@ def test_s3_spice_files(session, s3_client, events_client):
     assert result[0]["kernel_type"] == "spacecraft_clock"
     assert result[0]["version"] == 12
     assert len(result[0]["file_intervals_datetime"]) == 1  # Default time range
-    print(result)
 
     # Checking metakernel API here as well!
     result = spice_metakernel_api.lambda_handler(
@@ -132,7 +132,7 @@ def test_s3_spice_files(session, s3_client, events_client):
             "queryStringParameters": {
                 "start_time": 0,
                 "end_time": 1000000000,
-                "spice_path": temp_path,
+                "spice_path": temp_path + "/imap/spice/",
             }
         },
         None,

--- a/tests/lambda_endpoints/test_spice_metakernel_api.py
+++ b/tests/lambda_endpoints/test_spice_metakernel_api.py
@@ -198,3 +198,21 @@ def test_metakernel(session):
     assert len(results) == 2
     assert results[0]["file_name"] == "ck/imap_1000_065_1000_090_003.ap.bc"
     assert results[1]["file_name"] == "ck/imap_1000_060_1000_070_003.ap.bc"
+
+    """
+    Metakernel generation tests
+    """
+    response = spice_metakernel_api.lambda_handler(
+        {
+            "queryStringParameters": {
+                "start_time": 65,
+                "end_time": 75,
+                "spice_path": "",
+                "list_files": "False",
+            }
+        },
+        None,
+    )
+    assert response["statusCode"] == 200
+    assert "KERNELS_TO_LOAD" in response["body"]
+    assert "ck/imap_1000_065_1000_090_003.ap.bc" in response["body"]


### PR DESCRIPTION
# Change Summary
closes #550 #565

## Overview
This PR updates SPICE query API to return filename without prefix of path. Instead, it moves adding S3 path prefix in metakernel API code. This code changes help line up with future work. Future work is mounting S3 to batch job. For that, it needs to know about s3 folder path of SPICE. Then when user or batch starter passes `spice_path` parameter to metakernel API, it will line nicely with DATA_DIR thinking and download API. If user pass in `DATA_DIR` as `/mnt/`, then the path in SPICE metakernel would result in `/mnt/spice/ck/<filename>`.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
   - Format fixes and adding S3 folder path
- sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
   - Removed adding folder prefix

## Testing
- tests/lambda_endpoints/test_spice_metakernel_api.py
- tests/lambda_endpoints/test_spice_query_api.py
