### PR TITLE
MNT: update imap-data-access to v0.21.0

### DIFF
--- a/lambda_layer/database/requirements.txt
+++ b/lambda_layer/database/requirements.txt
@@ -153,9 +153,9 @@ greenlet==3.2.0 ; python_version < "3.14" and (platform_machine == "aarch64" or 
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.20.1 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:6997033ede624bb59a68e2c39a2fd540b285009143a1b753d70f788fb34ad930 \
-    --hash=sha256:b42765e3104e4f55894f8a2c2e6c4ba8d41630279ee8694373d85dc01c44904a
+imap-data-access==0.21.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:9193c48d91476149d76834efb83a6463f0296456b8a434a1467ffee587de7c99 \
+    --hash=sha256:a2308f73be95cd66fdb7a02e70df049755c77d1d9246d4692b6d669217d7974f
 psycopg2-binary==2.9.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:04392983d0bb89a8717772a193cfaac58871321e3ec69514e1c4e0d4957b5aff \
     --hash=sha256:056470c3dc57904bbf63d6f534988bafc4e970ffd50f6271fc4ee7daad9498a5 \

--- a/lambda_layer/spice/requirements.txt
+++ b/lambda_layer/spice/requirements.txt
@@ -97,9 +97,9 @@ charset-normalizer==3.4.1 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.20.1 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:6997033ede624bb59a68e2c39a2fd540b285009143a1b753d70f788fb34ad930 \
-    --hash=sha256:b42765e3104e4f55894f8a2c2e6c4ba8d41630279ee8694373d85dc01c44904a
+imap-data-access==0.21.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:9193c48d91476149d76834efb83a6463f0296456b8a434a1467ffee587de7c99 \
+    --hash=sha256:a2308f73be95cd66fdb7a02e70df049755c77d1d9246d4692b6d669217d7974f
 numpy==2.2.5 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:0255732338c4fdd00996c0421884ea8a3651eea555c3a56b84892b66f696eb70 \
     --hash=sha256:02f226baeefa68f7d579e213d0f3493496397d8f1cff5e2b222af274c86a552a \

--- a/poetry.lock
+++ b/poetry.lock
@@ -881,13 +881,13 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.20.1"
+version = "0.21.0"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap_data_access-0.20.1-py3-none-any.whl", hash = "sha256:6997033ede624bb59a68e2c39a2fd540b285009143a1b753d70f788fb34ad930"},
-    {file = "imap_data_access-0.20.1.tar.gz", hash = "sha256:b42765e3104e4f55894f8a2c2e6c4ba8d41630279ee8694373d85dc01c44904a"},
+    {file = "imap_data_access-0.21.0-py3-none-any.whl", hash = "sha256:9193c48d91476149d76834efb83a6463f0296456b8a434a1467ffee587de7c99"},
+    {file = "imap_data_access-0.21.0.tar.gz", hash = "sha256:a2308f73be95cd66fdb7a02e70df049755c77d1d9246d4692b6d669217d7974f"},
 ]
 
 [package.dependencies]
@@ -1026,7 +1026,7 @@ files = [
     {file = "lxml-5.3.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:aa837e6ee9534de8d63bc4c1249e83882a7ac22bd24523f83fad68e6ffdf41ae"},
     {file = "lxml-5.3.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:da4c9223319400b97a2acdfb10926b807e51b69eb7eb80aad4942c0516934858"},
     {file = "lxml-5.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:dc0e9bdb3aa4d1de703a437576007d366b54f52c9897cae1a3716bb44fc1fc85"},
-    {file = "lxml-5.3.2-cp310-cp310-win32.whl", hash = "sha256:5f94909a1022c8ea12711db7e08752ca7cf83e5b57a87b59e8a583c5f35016ad"},
+    {file = "lxml-5.3.2-cp310-cp310-win32.win32.whl", hash = "sha256:dd755a0a78dd0b2c43f972e7b51a43be518ebc130c9f1a7c4480cf08b4385486"},
     {file = "lxml-5.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:d64ea1686474074b38da13ae218d9fde0d1dc6525266976808f41ac98d9d7980"},
     {file = "lxml-5.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9d61a7d0d208ace43986a92b111e035881c4ed45b1f5b7a270070acae8b0bfb4"},
     {file = "lxml-5.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:856dfd7eda0b75c29ac80a31a6411ca12209183e866c33faf46e77ace3ce8a79"},
@@ -2545,4 +2545,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "49188a967457388dc56aaaf16e5aeb7b344d5b2ed0c08c0ac1c208aae590a49e"
+content-hash = "4592711586b6640896a8dfc54802b58847a4df02650265f8971220f8f60e83db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ python = ">=3.10,<4"
 # WARNING - Please run this command when updateing `imap-data-access` to ensure that
 # the correct version and hash are used:
 #   poetry export -f requirements.txt -o lambda_layer/database/requirements.txt --with layer-database
-imap-data-access = ">=0.20.1"
+imap-data-access = ">=0.21.0"
 
 # Optional dependencies - install with `poetry install -E docs`
 sphinx = {version="^7.1.0", optional=true}

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -142,9 +142,9 @@ charset-normalizer==3.4.1 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.20.1 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:6997033ede624bb59a68e2c39a2fd540b285009143a1b753d70f788fb34ad930 \
-    --hash=sha256:b42765e3104e4f55894f8a2c2e6c4ba8d41630279ee8694373d85dc01c44904a
+imap-data-access==0.21.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:9193c48d91476149d76834efb83a6463f0296456b8a434a1467ffee587de7c99 \
+    --hash=sha256:a2308f73be95cd66fdb7a02e70df049755c77d1d9246d4692b6d669217d7974f
 imap-processing==0.12.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:3ed372c08384e54f3fd36846ea47cad9c0c7a3619bf68f65c88b1f49cd5f239e \
     --hash=sha256:9c5bd9f1f3309c43b681cfaa6f6430df9169dbd21c2b07e26919e54eaf2d4992
@@ -207,7 +207,6 @@ lxml==5.3.2 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:58e8c9b9ed3c15c2d96943c14efc324b69be6352fe5585733a7db2bf94d97841 \
     --hash=sha256:59d437cc8a7f838282df5a199cf26f97ef08f1c0fbec6e84bd6f5cc2b7913f6e \
     --hash=sha256:5bb304f67cbf5dfa07edad904732782cbf693286b9cd85af27059c5779131050 \
-    --hash=sha256:5f94909a1022c8ea12711db7e08752ca7cf83e5b57a87b59e8a583c5f35016ad \
     --hash=sha256:617ecaccd565cbf1ac82ffcaa410e7da5bd3a4b892bb3543fb2fe19bd1c4467d \
     --hash=sha256:638d06b4e1d34d1a074fa87deed5fb55c18485fa0dab97abc5604aad84c12031 \
     --hash=sha256:661feadde89159fd5f7d7639a81ccae36eec46974c4a4d5ccce533e2488949c8 \
@@ -277,6 +276,7 @@ lxml==5.3.2 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:da4c9223319400b97a2acdfb10926b807e51b69eb7eb80aad4942c0516934858 \
     --hash=sha256:dae97d9435dc90590f119d056d233c33006b2fd235dd990d5564992261ee7ae8 \
     --hash=sha256:dc0e9bdb3aa4d1de703a437576007d366b54f52c9897cae1a3716bb44fc1fc85 \
+    --hash=sha256:dd755a0a78dd0b2c43f972e7b51a43be518ebc130c9f1a7c4480cf08b4385486 \
     --hash=sha256:e3bef90af21d31c4544bc917f51e04f94ae11b43156356aff243cdd84802cbf2 \
     --hash=sha256:e5dea998c891f082fe204dec6565dbc2f9304478f2fc97bd4d7a940fec16c873 \
     --hash=sha256:e70ad4c9658beeff99856926fd3ee5fde8b519b92c693f856007177c36eb2e30 \

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -51,7 +51,7 @@ def science_file():
 @pytest.fixture(scope="module")
 def spice_file():
     """Path to a valid spice file."""
-    return "spice/ck/imap_2025_032_2025_034_003.ah.bc"
+    return "imap/spice/ck/imap_2025_032_2025_034_003.ah.bc"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
# Change Summary

## Overview
version update to update SPICE path to be `imap/spice`.

## Updated Files
- pyproject.toml
   - version update and other files update related to this.
