### PR TITLE
Fetch all upstream files for all relationship types

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -103,6 +103,7 @@ def _get_dependencies(dependency_events: dict):
         if response.status == 206:
             logger.info(f"Dependency API response: {dependency_response}")
             return None
+
         logger.debug(f"Received dependencies: {dependency_response}")
     # The API returns different output formats depending on the query parameters:
     # Without "start_date": Returns a list of dependency dictionaries.
@@ -329,45 +330,26 @@ def submit_all_jobs(
     None
     """
     # Find the files that this job depends on
-    base_event_msg = {
+    event_msg = {
         "data_source": job["data_source"],
         "data_type": job["data_type"],
         "descriptor": job["descriptor"],
         "dependency_type": "UPSTREAM",
-        "relationship": "HARD",
-    }
-    dependency_event_msg = base_event_msg | {
+        "relationship": "ALL",
         "start_date": start_date,
         "version": version,
         "trigger_type": trigger_type,
     }
-    if end_date:
-        dependency_event_msg["end_date"] = end_date
 
-    existing_hard_upstream_dependencies = _get_dependencies(dependency_event_msg)
-    if not existing_hard_upstream_dependencies:
-        logger.info(
-            f"Upstream dependency not found, or downstream dependency "
-            f"already exists for: {dependency_event_msg}"
-        )
+    if end_date:
+        event_msg["end_date"] = end_date
+
+    upstream_dependencies = _get_dependencies(event_msg)
+    if not upstream_dependencies:
         return
 
     logger.info(f"All required dependencies found for the job: {job}")
 
-    dependency_event_msg["relationship"] = "SOFT_TRIGGER"
-    existing_soft_trigger_upstream_dependencies = _get_dependencies(
-        dependency_event_msg
-    )
-    dependency_event_msg["relationship"] = "SOFT_NO_TRIGGER"
-    existing_soft_no_trigger_upstream_dependencies = _get_dependencies(
-        dependency_event_msg
-    )
-    # Combine soft and hard dependencies
-    upstream_dependencies = ProcessingInputCollection(
-        existing_soft_trigger_upstream_dependencies.processing_input,
-        existing_soft_no_trigger_upstream_dependencies.processing_input,
-        existing_hard_upstream_dependencies.processing_input,
-    )
     # Find science processingInputs that have the same source as the potential job
     for dep in upstream_dependencies.get_science_inputs():
         if job["data_source"] == dep.source:

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -326,7 +326,6 @@ def get_dependencies(node, dependency_type, relationship):
     dependency_type : str
         Whether it's UPSTREAM or DOWNSTREAM dependency.
     relationship : str
-        relationship : str
         Whether it's HARD, SOFT_TRIGGER, or SOFT_NO_TRIGGER dependency.
         HARD means data is required for pipeline and SOFT_TRIGGER and SOFT_NO_TRIGGER
         means data is optional for pipeline. A SOFT_TRIGGER file will trigger processing

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 import imap_data_access
 from imap_data_access import processing_input
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_
 
 from ..database import database as db
 from ..database import models
@@ -326,10 +326,12 @@ def get_dependencies(node, dependency_type, relationship):
     dependency_type : str
         Whether it's UPSTREAM or DOWNSTREAM dependency.
     relationship : str
+        relationship : str
         Whether it's HARD, SOFT_TRIGGER, or SOFT_NO_TRIGGER dependency.
         HARD means data is required for pipeline and SOFT_TRIGGER and SOFT_NO_TRIGGER
         means data is optional for pipeline. A SOFT_TRIGGER file will trigger processing
-        and reprocessing.
+        and reprocessing. If "ALL" is provided, dependencies for all valid relationships
+        (HARD, SOFT_TRIGGER, SOFT_NO_TRIGGER) will be returned.
 
     Returns
     -------
@@ -343,62 +345,28 @@ def get_dependencies(node, dependency_type, relationship):
         logger.error(f"Error loading dependencies: {e!s}")
         return None
 
-    dependencies = dependency_config.dependencies[relationship][dependency_type].get(
-        node, []
+    relationships = (
+        Relationship().valid_relationship if relationship == "ALL" else [relationship]
     )
-    # Add keys for a dict-like representation
-    dependencies = [
-        {"data_source": dep[0], "data_type": dep[1], "descriptor": dep[2]}
-        for dep in dependencies
-    ]
+
+    dependencies = []
+    for rel in relationships:
+        deps = dependency_config.dependencies[rel][dependency_type].get(node, [])
+
+        # Add keys for a dict-like representation
+        dependencies.extend(
+            [
+                {
+                    "data_source": dep[0],
+                    "data_type": dep[1],
+                    "descriptor": dep[2],
+                    "relationship": rel,
+                }
+                for dep in deps
+            ]
+        )
 
     return dependencies
-
-
-def filter_primary_science_dependencies(
-    session: db.Session, records: list, query_data_type: str, query_descriptor
-):
-    """Filter primary science dependencies for unprocessed downstream dependencies.
-
-    Parameters
-    ----------
-    session : orm session
-        Database session.
-    records : list[models.ScienceFiles]
-        Science file records.
-    query_data_type : str
-        The data_type of the dependency used to query the api.
-    query_descriptor
-        The descriptor of the dependency used to query the api.
-
-    Returns
-    -------
-    list[str]
-        Upstream primary source filenames that have downstream dependencies that need
-        to be processed.
-    """
-    # TODO create a downstream dependency instead of combining the query and records.
-    files = []
-    for record in records:
-        # check in the science table if the upstream primary source dependency
-        # already exists.
-        query = select(models.ScienceFiles.__table__).where(
-            models.ScienceFiles.instrument == record.instrument,
-            models.ScienceFiles.descriptor == query_descriptor,
-            # Use the query data type instead of the current record.
-            models.ScienceFiles.data_level == query_data_type,
-            models.ScienceFiles.start_date == record.start_date,
-            models.ScienceFiles.version == record.version,
-        )
-        # If the upstream primary source dependency does not exist, add it to the list
-        # of files to return.
-        # This indicates that the upstream primary source needs to be processed.
-        upstream_primary_source = session.execute(query).first()
-
-        if not upstream_primary_source:
-            files.append(basename(record.file_path))
-
-    return files
 
 
 def primary_science_dep(query_params: dict, dependency: dict) -> bool:
@@ -468,10 +436,10 @@ def get_dependency_processing_input(
     ProcessingInputCollection
         Dependency files that can include Ancillary, SPICE, or Science inputs.
     """
-    relationship = query_params["relationship"]
     dependency_inputs = processing_input.ProcessingInputCollection()
     with db.Session() as session:
         for dep in dependencies:
+            relationship = dep["relationship"]
             # Check if the dependency is a primary science dependency and if the file
             # source that triggered the batch stater is equal to the dependency source.
             # If true, we can find science files with the exact start date
@@ -488,13 +456,13 @@ def get_dependency_processing_input(
             else:
                 primary_sci_trigger = False
 
-            logger.info(
-                f"Searching for files matching dep={dep}\n"
-                f"start_date={start_date}\n"
-                f"end_date={end_date}\n"
-                f"primary_sci_trigger={primary_sci_trigger}\n"
-                f"primary_sci_dep={primary_sci_dep}"
+            dep_string = (
+                f"{dep=}\n{start_date=}\n{end_date=}\n"
+                f"{primary_sci_trigger=}\n{primary_sci_dep=}"
             )
+
+            logger.info(f"Searching for files matching dep={dep_string}")
+
             records = get_files(
                 session,
                 dep,
@@ -506,8 +474,10 @@ def get_dependency_processing_input(
             )
 
             if not records and relationship == Relationship.HARD:
-                logger.info("No records found for dependency. Returning None.")
-                return None
+                info = f"No records found for dependency: {dep_string}"
+                logger.info(dep_string)
+                return info
+
             elif not records:
                 continue
 
@@ -744,16 +714,19 @@ def lambda_handler(event, context):
                     "data_source": "hit",
                     "data_type": "l1a",
                     "descriptor": "all",
+                    "relationship": "HARD",
                 },
                 {
                     "data_source": "hit",
                     "data_type": "l1b",
                     "descriptor": "hk",
+                    "relationship": "HARD",
                 },
                 {
                     "data_source": "sc_attitude",
                     "data_type": "spice",
                     "descriptor": "historical",
+                    "relationship": "HARD",
                 },
             ]
         If "start_date" is supplied, "version" and "ancillary_trigger" are required and
@@ -831,8 +804,7 @@ def lambda_handler(event, context):
             if query_params.get("end_date")
             else None
         )
-        # TODO this only works for upstream deps right now. Do we need to ever get files
-        # for downstream?
+
         dependencies_output = get_dependency_processing_input(
             query_params=query_params,
             dependencies=dependencies,
@@ -841,10 +813,10 @@ def lambda_handler(event, context):
             trigger_type=trigger_type,
             end_date=end_date,
         )
-        if not dependencies_output:
+        if isinstance(dependencies_output, str):
             return {
                 "statusCode": 206,  # Partial content
-                "body": "At least one dependency is missing.",
+                "body": dependencies_output,
             }
         dependencies_output = dependencies_output.serialize()
     else:

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -409,10 +409,11 @@ def test_lambda_handler_missing_upstream_dependency(session, mock_urlopen, caplo
     with caplog.at_level(logging.DEBUG):
         lambda_handler(events, context)
         log_str = (
-            "Upstream dependency not found, or downstream dependency already exists "
-            "for: {'data_source': 'swe', 'data_type': 'l2', 'descriptor': 'sci', "
-            "'dependency_type': 'UPSTREAM', 'relationship': 'HARD', 'start_date': "
-            "'20000101', 'version': 'v001', 'trigger_type': 'l1b'"
+            "Dependency API response: No records found for dependency: "
+            "dep={'data_source': 'swe', 'data_type': 'l1b', 'descriptor': 'sci',"
+            " 'relationship': 'HARD'}\nstart_date=datetime.datetime(2000,"
+            " 1, 1, 0, 0)\nend_date=None\nprimary_sci_trigger"
+            "=True\nprimary_sci_dep=True"
         )
         # Verify the info statement was logged.
         assert log_str in caplog.text
@@ -585,7 +586,12 @@ def test_api_request_success(mock_urlopen: unittest.mock.MagicMock):
     }
     dependencies = _get_dependencies(dependency_event_msg)
     assert dependencies == [
-        {"data_source": "swe", "data_type": "l0", "descriptor": "raw"}
+        {
+            "data_source": "swe",
+            "data_type": "l0",
+            "descriptor": "raw",
+            "relationship": "HARD",
+        },
     ]
 
 

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -74,7 +74,7 @@ def test_missing_dependency(session):
     dependency_response = dependency.lambda_handler(event, None)
 
     assert dependency_response["statusCode"] == 206
-    assert dependency_response["body"] == "At least one dependency is missing."
+    assert "No records found for dependency:" in dependency_response["body"]
 
 
 def test_soft_dependencies(session):
@@ -183,6 +183,7 @@ def test_get_downstream_dependencies():
             "data_source": "hit",
             "data_type": "l1b",
             "descriptor": "all",
+            "relationship": "HARD",
         }
     ]
     assert len(dependents) == 1
@@ -199,14 +200,35 @@ def test_get_downstream_dependencies():
             "data_source": "swe",
             "data_type": "l1a",
             "descriptor": "sci",
+            "relationship": "HARD",
         },
         {
             "data_source": "swe",
             "data_type": "ancillary",
             "descriptor": "l1b-in-flight-cal",
+            "relationship": "HARD",
         },
     ]
     assert len(dependents) == 2
+    assert dependents == expected_complete_dependent
+
+
+def test_get_all_downstream_dependencies():
+    """Add test for getting back ancillary dependencies."""
+    event = create_dependency_api_event(
+        "mag", "l1b", descriptor="norm-mago", relationship="ALL"
+    )
+    dependency_response = dependency.lambda_handler(event, None)
+    dependents = json.loads(dependency_response["body"])
+
+    expected_complete_dependent = [
+        {
+            "data_source": "mag",
+            "data_type": "l1c",
+            "descriptor": "norm-mago",
+            "relationship": "SOFT_TRIGGER",
+        },
+    ]
     assert dependents == expected_complete_dependent
 
 


### PR DESCRIPTION
# Change Summary

## Overview
Instead of making three different API calls for each relationship type ("HARD", "SOFT_NO_TRIGGER", "SOFT_TRIGGER") add the capability of passing in "ALL" to the dependency query to handle every type in one call. 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Make only one call to fetch upstream deps.
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
   - Add handling for when "ALL" is passed in as the relationship type 
- tests/lambda_endpoints/test_batch_starter.py and tests/lambda_endpoints/test_dependency_api.py
  - Refactor tests to work with changes. 

