### PR TITLE
BUG: Fixed eventbridge's rule to match new path

### DIFF
--- a/sds_data_manager/constructs/indexer_lambda_construct.py
+++ b/sds_data_manager/constructs/indexer_lambda_construct.py
@@ -245,7 +245,7 @@ class SPICEIndexerLambda(Construct):
         # Define an EventBridge rule
         event_rule = events.Rule(
             self,
-            "EfsWriteLambdaS3EventRule",
+            "SPICEIndexerLambdaS3EventRule",
             event_pattern=events.EventPattern(
                 source=["aws.s3"],
                 detail_type=["Object Created"],
@@ -253,7 +253,7 @@ class SPICEIndexerLambda(Construct):
                     "bucket": {"name": [data_bucket.bucket_name]},
                     "object": {
                         "key": [
-                            {"prefix": "spice/"},
+                            {"prefix": "imap/spice/"},
                         ]
                     },
                 },


### PR DESCRIPTION
# Change Summary

## Overview
Fix EventBridge's rule to match new SPICE path


## Updated Files
- sds_data_manager/constructs/indexer_lambda_construct.py
   - update path


