### PR TITLE
Update batch starter version bumping 

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -175,20 +175,20 @@ def determine_job_version(
             conditions.append(table.status == models.Status.INPROGRESS)
         return conditions
 
-    # Get the max version for any jobs in progress
+    # First check to see if there are any jobs in progress and get the max version
     max_version = (
         session.query(func.max(models.ProcessingJob.version)).filter(
             *filter_conditions(models.ProcessingJob)
         )
     ).scalar()
-
+    # If no jobs are in progress, check the science files table for the max version.
     if not max_version:
         max_version = (
             session.query(func.max(models.ScienceFiles.version)).filter(
                 *filter_conditions(models.ScienceFiles)
             )
         ).scalar()
-
+    # Bump the version number. "V001" will be returned if max_version is None.
     return bump_version_number(max_version)
 
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -130,9 +130,9 @@ def bump_version_number(version: str):
     Returns
     -------
     str
-        Version increased by 1.
+        Version increased by 1. If the input version is None, return "v001".
     """
-    return f"v{int(version[1:]) + 1:03d}"
+    return f"v{int(version[1:]) + 1:03d}" if version else "v001"
 
 
 def determine_job_version(
@@ -141,8 +141,8 @@ def determine_job_version(
     data_level: str,
     descriptor: str,
     start_date: datetime,
-):
-    """Return the version of the job to run.
+) -> str:
+    """Return the maximum existing file version in the pipeline increased by one.
 
     Parameters
     ----------
@@ -160,29 +160,36 @@ def determine_job_version(
     Returns
     -------
      str
-        The highest version number bumped by 1 if the file has been already processed,
-        otherwise "v001".
+        The highest version number.
     """
-    # TODO should I be making a separate call to the scienceFilesTable for the
-    # latest version?
-    filter_conditions = [
-        models.ProcessingJob.instrument == instrument,
-        models.ProcessingJob.data_level == data_level,
-        models.ProcessingJob.descriptor == descriptor,
-        models.ProcessingJob.start_date == start_date,
-        models.ProcessingJob.status.in_(
-            [models.Status.INPROGRESS.value, models.Status.SUCCEEDED.value]
-        ),
-    ]
-    # Determine the maximum version for the file if any
+
+    def filter_conditions(table):
+        # Filter conditions for the query
+        conditions = [
+            table.instrument == instrument,
+            table.data_level == data_level,
+            table.descriptor == descriptor,
+            table.start_date == start_date,
+        ]
+        if table == models.ProcessingJob:
+            conditions.append(table.status == models.Status.INPROGRESS)
+        return conditions
+
+    # Get the max version for any jobs in progress
     max_version = (
-        session.query(
-            func.max(models.ProcessingJob.version).label("latest_version")
-        ).filter(*filter_conditions)
+        session.query(func.max(models.ProcessingJob.version)).filter(
+            *filter_conditions(models.ProcessingJob)
+        )
     ).scalar()
 
-    job_version = bump_version_number(max_version) if max_version else "v001"
-    return job_version
+    if not max_version:
+        max_version = (
+            session.query(func.max(models.ScienceFiles.version)).filter(
+                *filter_conditions(models.ScienceFiles)
+            )
+        ).scalar()
+
+    return bump_version_number(max_version)
 
 
 def try_to_submit_job(

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -444,7 +444,7 @@ def test_spice_file():
 
 
 def test_determine_max_version(session):
-    """Test the ``is_job_in_status_table`` function."""
+    """Test the ``determine_job_version`` function."""
     _populate_processing_table(session)
     # query the processing table and get the bumped version
     result = determine_job_version(
@@ -454,10 +454,8 @@ def test_determine_max_version(session):
         descriptor="de",
         start_date=datetime(2010, 1, 1),
     )
-
     assert result == "v002"
-
-    # Assert that the version returned is "v000" when the job has not been processed.
+    # Assert that the version returned is "v001" when the job has not been processed.
     result = determine_job_version(
         session=session,
         instrument="swapi",
@@ -466,6 +464,22 @@ def test_determine_max_version(session):
         start_date=datetime(2010, 1, 1),
     )
     assert result == "v001"
+
+
+def test_determine_max_version_missing_processing_job(session):
+    """Test that determine_job_version returns the correct version."""
+    _populate_processing_table(session)
+    _populate_file_catalog(session)
+    # Test when processingJob table is not updated, the function checks
+    # science_files table to get version
+    result = determine_job_version(
+        session=session,
+        instrument="swe",
+        data_level="l1a",
+        descriptor="sci",
+        start_date=datetime(2024, 1, 1),
+    )
+    assert result == "v011"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# Change Summary

closes #560 

## Overview
Update batch starter to check the science files table for the max version as well as the processing table. This will help fix cases where the processingJob table is not up to date. 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Updates to versioning. 

## Testing
Add test to check that function returns the max version found in the science files table if no jobs are processing. 
