### PR TITLE
Revert back to using v001 for initial file version

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -172,8 +172,8 @@ def determine_job_version(
                 *filter_conditions(models.ScienceFiles)
             )
         ).scalar()
-    # Bump the version number. "V000" will be returned if max_version is None.
-    return f"v{int(max_version[1:]) + 1:03d}" if max_version else "v000"
+    # Bump the version number. "V001" will be returned if max_version is None.
+    return f"v{int(max_version[1:]) + 1:03d}" if max_version else "v001"
 
 
 def try_to_submit_job(

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -145,7 +145,7 @@ def test_lambda_handler(
                     "--start-date",
                     "20240110",
                     "--version",
-                    "v000",
+                    "v001",
                     "--dependency",
                     serialized_processing_input,
                     "--upload-to-sdc",
@@ -293,7 +293,7 @@ def test_lambda_handler_mag_l1c_case(session, mock_urlopen):
                     "--start-date",
                     "20240101",
                     "--version",
-                    "v000",
+                    "v001",
                     "--dependency",
                     expected_processing_input.serialize(),
                     "--upload-to-sdc",
@@ -360,7 +360,7 @@ def test_lambda_handler_mag_l1c_case(session, mock_urlopen):
                     "--start-date",
                     "20240101",
                     "--version",
-                    "v001",
+                    "v002",
                     "--dependency",
                     expected_processing_input.serialize(),
                     "--upload-to-sdc",
@@ -476,7 +476,7 @@ def test_determine_max_version(session):
         start_date=datetime(2010, 1, 1),
     )
     assert result == "v002"
-    # Assert that the version returned is "v000" when the job has not been processed.
+    # Assert that the version returned is "v001" when the job has not been processed.
     result = determine_job_version(
         session=session,
         instrument="swapi",
@@ -484,7 +484,7 @@ def test_determine_max_version(session):
         descriptor="sci",
         start_date=datetime(2010, 1, 1),
     )
-    assert result == "v000"
+    assert result == "v001"
 
 
 def test_determine_max_version_missing_processing_job(session):


### PR DESCRIPTION
# Change Summary

## Overview
Revert back to using v001 for initial file version. I changed the initial version to use "v000" after Gregs message in slack but after more clarification, it should be v001. 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   -Use v001 for initial versino

## Testing
Fixed test in respect to v000 - > v001 
