### PR TITLE
Bug fix for batch starter version calculation 

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -152,11 +152,19 @@ def determine_job_version(
         conditions = [
             table.instrument == instrument,
             table.data_level == data_level,
-            table.descriptor == descriptor,
             table.start_date == start_date,
         ]
         if table == models.ProcessingJob:
-            conditions.append(table.status == models.Status.INPROGRESS)
+            conditions.append(
+                table.status.in_(
+                    [models.Status.INPROGRESS.value, models.Status.SUCCEEDED.value]
+                )
+            )
+        elif descriptor != "all":
+            # If the descriptor is not "all", filter by descriptor otherwise, look at
+            # all descriptors
+            conditions.append(table.descriptor == descriptor)
+
         return conditions
 
     # First check to see if there are any jobs in progress and get the max version

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -160,10 +160,9 @@ def determine_job_version(
                     [models.Status.INPROGRESS.value, models.Status.SUCCEEDED.value]
                 )
             )
-            if descriptor != "all":
-                # If the descriptor is not "all", filter by descriptor otherwise, look
-                # at all descriptors
-                conditions.append(table.descriptor == descriptor)
+        if descriptor != "all":
+            # If the descriptor is all we want to check for all descriptors
+            conditions.append(table.descriptor == descriptor)
 
         return conditions
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -160,10 +160,10 @@ def determine_job_version(
                     [models.Status.INPROGRESS.value, models.Status.SUCCEEDED.value]
                 )
             )
-        elif descriptor != "all":
-            # If the descriptor is not "all", filter by descriptor otherwise, look at
-            # all descriptors
-            conditions.append(table.descriptor == descriptor)
+            if descriptor != "all":
+                # If the descriptor is not "all", filter by descriptor otherwise, look
+                # at all descriptors
+                conditions.append(table.descriptor == descriptor)
 
         return conditions
 

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -153,12 +153,12 @@ def _populate_file_catalog(session):
     # Setup: Add records to the database
     test_records = [
         ScienceFiles(
-            file_path="/path/to/imap_mag_l1b_norm-mago_20240101_v001.cdf",
+            file_path="/path/to/imap_mag_l1b_norm-mago_20240101_v002.cdf",
             instrument="mag",
             data_level="l1b",
             descriptor="norm-mago",
             start_date=datetime(2024, 1, 1),
-            version="v001",
+            version="v002",
             extension="cdf",
             ingestion_date=datetime.strptime(
                 "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -487,6 +487,21 @@ def test_determine_max_version(session):
     assert result == "v001"
 
 
+def test_determine_job_version_descriptor_is_all(session):
+    """Test the ``determine_job_version`` function."""
+    _populate_file_catalog(session)
+    # With the descriptor set to "all", the function should return the max version
+    # bumped of ALL of the files matching "mag" and "l1b" in the database.
+    result = determine_job_version(
+        session=session,
+        instrument="mag",
+        data_level="l1b",
+        descriptor="all",
+        start_date=datetime(2024, 1, 1),
+    )
+    assert result == "v003"
+
+
 def test_determine_max_version_missing_processing_job(session):
     """Test that determine_job_version returns the correct version."""
     _populate_processing_table(session)

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -98,7 +98,7 @@ def test_soft_dependencies(session):
     # mag_l1b_norm-mago
     # Expect ancillary dependencies and science dependencies
     expected_processing_input = ProcessingInputCollection(
-        ScienceInput("imap_mag_l1b_norm-mago_20240101_v001.cdf"),
+        ScienceInput("imap_mag_l1b_norm-mago_20240101_v002.cdf"),
         ScienceInput("imap_mag_l1b_burst-mago_20240101_v001.cdf"),
     )
     assert dependencies == expected_processing_input.serialize()


### PR DESCRIPTION
# Change Summary

## Overview
The version calculation in the batch starter code contained two bugs: 
1. It only checked for jobs in progress in the processing table. It should get for both in progress and succeeded. 
2. If the descriptor is "all" batch starter only was checking for the max version for any "all" jobs but it should be looking for the max version of all of the jobs - meaning "all" plus any descriptor that falls under that all umbrella. 


## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Bug fixes

