### PR TITLE
ENH: Add authorization to the API

### DIFF
--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -10,13 +10,16 @@ https://ialirt.prod.imap-mission.com/ialirt-log-query
 from typing import Optional
 
 from aws_cdk import Duration, aws_sns
-from aws_cdk import aws_apigateway as apigw
+from aws_cdk import aws_apigatewayv2 as apigwv2
+from aws_cdk import aws_apigatewayv2_authorizers as apigwv2_authorizers
+from aws_cdk import aws_apigatewayv2_integrations as apigwv2_integrations
 from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_cloudwatch as cloudwatch
 from aws_cdk import aws_cloudwatch_actions as cloudwatch_actions
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_route53 as route53
 from aws_cdk import aws_route53_targets as targets
+from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
 from sds_data_manager.constructs.route53_hosted_zone import DomainConstruct
@@ -50,7 +53,6 @@ class ApiGateway(Construct):
             Prefix for ialirt domain, Optional
         kwargs : dict
             Keyword arguments
-
         """
         super().__init__(scope, construct_id, **kwargs)
 
@@ -61,13 +63,34 @@ class ApiGateway(Construct):
             self.prefix = ""
             self.lowercase_prefix = "api"
 
-        # Create a single API Gateway
-        self.api = apigw.RestApi(
-            self,
-            f"{self.prefix}RestApi",
-            rest_api_name=f"{self.prefix}RestApi",
-            description="API Gateway for lambda function endpoints.",
-            endpoint_types=[apigw.EndpointType.REGIONAL],
+        # Start with an empty domain name mapping and fill it in within
+        # the domain construct if necessary within the lower if-block
+        domain_mapping = None
+
+        # NOTE: We look these up from the account parameter store. To update
+        # these values, run the following command:
+        #
+        # aws ssm put-parameter --name lasp-auth-issuer --value <issuer> --type String
+        #
+        # where <issuer>, <audience>, and <scope> are values retrieved from the
+        # LASP Web Team.
+
+        self.auth_issuer = ssm.StringParameter.from_string_parameter_name(
+            scope=scope, id="SSMAuthIssuer", string_parameter_name="lasp-auth-issuer"
+        ).string_value
+        self.auth_audience = ssm.StringParameter.from_string_parameter_name(
+            scope=scope,
+            id="SSMAuthAudience",
+            string_parameter_name="lasp-auth-audience",
+        ).string_value
+        self.auth_scope = ssm.StringParameter.from_string_parameter_name(
+            scope=scope, id="SSMAuthScope", string_parameter_name="lasp-auth-scope"
+        ).string_value
+
+        self.authorizer = apigwv2_authorizers.HttpJwtAuthorizer(
+            id=f"{self.lowercase_prefix}JwtAuthorizer",
+            jwt_issuer=self.auth_issuer,
+            jwt_audience=[self.auth_audience],
         )
 
         # Add a custom domain to the API if we have one
@@ -76,32 +99,46 @@ class ApiGateway(Construct):
                 f"{self.lowercase_prefix}.{domain_construct.domain_name}"
             )
 
-            custom_domain = apigw.DomainName(
+            custom_domain = apigwv2.DomainName(
                 self,
-                f"{self.prefix}RestAPI-DomainName",
+                f"{self.lowercase_prefix}HttpAPI-DomainName",
                 domain_name=self.api_domain_name,
                 certificate=certificate,
-                endpoint_type=apigw.EndpointType.REGIONAL,
             )
-
-            # Route domain to api gateway
-            apigw.BasePathMapping(
-                self,
-                f"{self.prefix}RestAPI-BasePathMapping",
-                domain_name=custom_domain,
-                rest_api=self.api,
-            )
+            # Create a domain mapping for the API that can be used later for the
+            # custom domain mapping in the default stage
+            domain_mapping = {"domain_name": custom_domain}
 
             # Add record to Route53
             route53.ARecord(
                 self,
-                f"{self.prefix}RestAPI-AliasRecord",
+                f"{self.prefix}HttpAPI-AliasRecord",
                 zone=domain_construct.hosted_zone,
                 record_name=self.api_domain_name,
                 target=route53.RecordTarget.from_alias(
-                    targets.ApiGatewayDomain(custom_domain)
+                    targets.ApiGatewayv2DomainProperties(
+                        regional_domain_name=custom_domain.regional_domain_name,
+                        regional_hosted_zone_id=custom_domain.regional_hosted_zone_id,
+                    )
                 ),
             )
+
+        # Create a single HTTP API Gateway
+        self.api = apigwv2.HttpApi(
+            self,
+            f"{self.lowercase_prefix}HttpApi",
+            api_name=f"{self.prefix}HttpApi",
+            default_domain_mapping=domain_mapping,
+            description="HTTP API Gateway for lambda function endpoints.",
+            cors_preflight={
+                "allow_origins": ["*"],
+                "allow_methods": [
+                    apigwv2.CorsHttpMethod.GET,
+                    apigwv2.CorsHttpMethod.POST,
+                    apigwv2.CorsHttpMethod.OPTIONS,
+                ],
+            },
+        )
 
     def deliver_to_sns(self, sns_topic: aws_sns.Topic):
         """Deliver API Gateway alerts to an SNS topic.
@@ -118,12 +155,10 @@ class ApiGateway(Construct):
         # Define the metric the alarm is based on
         # List of Metric options for API Gateway:
         # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html
-        metric = cloudwatch.Metric(
-            namespace="AWS/ApiGateway",
-            metric_name="Latency",
-            dimensions_map={"ApiName": self.api.rest_api_name},
+        metric = self.api.metric_latency(
             period=Duration.minutes(1),
             statistic="Maximum",
+            label="API Gateway Latency",
         )
 
         # Define the alarm
@@ -152,9 +187,8 @@ class ApiGateway(Construct):
         route: str,
         http_method: str,
         lambda_function: lambda_.Function,
-        use_path_params: bool = False,
     ):
-        """Add a route to the API Gateway.
+        """Add a route to the HTTP API Gateway.
 
         Parameters
         ----------
@@ -164,16 +198,17 @@ class ApiGateway(Construct):
             HTTP method. Eg. GET, POST, etc.
         lambda_function : lambda_.Function
             Lambda function to trigger when this route is hit.
-        use_path_params : bool, optional
-            Whether or not to use path parameters, by default False
-            This allows for ``/download/{filename}`` style routes.
-
         """
-        # Define the API Gateway Resources
-        resource = self.api.root.add_resource(route)
-        if use_path_params:
-            # Need to add a proxy resource to allow path parameters
-            resource = resource.add_proxy(any_method=False)
-
-        # Create a new method that is linked to the Lambda function
-        resource.add_method(http_method, apigw.LambdaIntegration(lambda_function))
+        # Add the authorizer to the route if it is a route that requires authentication
+        authorizer = self.authorizer if route.startswith("/auth") else None
+        authorization_scopes = [self.auth_scope] if route.startswith("/auth") else None
+        # Add the route to the HTTP API
+        self.api.add_routes(
+            path=route,
+            methods=[apigwv2.HttpMethod[http_method]],
+            integration=apigwv2_integrations.HttpLambdaIntegration(
+                f"{self.prefix}-{route}-Integration", lambda_function
+            ),
+            authorizer=authorizer,
+            authorization_scopes=authorization_scopes,
+        )

--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -83,7 +83,7 @@ class IalirtApiManager(Construct):
         query_api_lambda.add_to_role_policy(s3_read_policy)
 
         api.add_route(
-            route="ialirt-log-query",
+            route="/ialirt-log-query",
             http_method="GET",
             lambda_function=query_api_lambda,
         )
@@ -107,10 +107,9 @@ class IalirtApiManager(Construct):
         download_api.add_to_role_policy(s3_read_policy)
 
         api.add_route(
-            route="ialirt-download",
+            route="/ialirt-download",
             http_method="GET",
             lambda_function=download_api,
-            use_path_params=True,
         )
 
         # catalog API lambda
@@ -133,7 +132,7 @@ class IalirtApiManager(Construct):
         catalog_api.add_to_role_policy(s3_read_policy)
 
         api.add_route(
-            route="ialirt-catalog",
+            route="/ialirt-catalog",
             http_method="GET",
             lambda_function=catalog_api,
         )
@@ -158,8 +157,7 @@ class IalirtApiManager(Construct):
         algorithm_table.grant_read_write_data(ialirt_db_query_handler)
 
         api.add_route(
-            route="ialirt-db-query",
+            route="/ialirt-db-query",
             http_method="GET",
             lambda_function=ialirt_db_query_handler,
-            use_path_params=True,
         )

--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -94,11 +94,16 @@ class SdsApiManager(Construct):
         upload_api_lambda.add_to_role_policy(s3_read_policy)
         upload_api_lambda.apply_removal_policy(cdk.RemovalPolicy.DESTROY)
 
+        # {proxy+} is used to allow for any pathParams after /upload/
         api.add_route(
-            route="upload",
+            route="/upload/{proxy+}",
             http_method="GET",
             lambda_function=upload_api_lambda,
-            use_path_params=True,
+        )
+        api.add_route(
+            route="/authorized/upload/{proxy+}",
+            http_method="GET",
+            lambda_function=upload_api_lambda,
         )
 
         # query API lambda
@@ -122,7 +127,12 @@ class SdsApiManager(Construct):
         )
 
         api.add_route(
-            route="query",
+            route="/query",
+            http_method="GET",
+            lambda_function=query_api_lambda,
+        )
+        api.add_route(
+            route="/authorized/query",
             http_method="GET",
             lambda_function=query_api_lambda,
         )
@@ -148,7 +158,7 @@ class SdsApiManager(Construct):
         )
 
         api.add_route(
-            route="spice-query",
+            route="/spice-query",
             http_method="GET",
             lambda_function=spice_query_api_lambda,
         )
@@ -174,7 +184,7 @@ class SdsApiManager(Construct):
         )
 
         api.add_route(
-            route="metakernel",
+            route="/metakernel",
             http_method="GET",
             lambda_function=spice_metakernel_api_lambda,
         )
@@ -197,11 +207,16 @@ class SdsApiManager(Construct):
 
         download_api.add_to_role_policy(s3_read_policy)
 
+        # {proxy+} is used to allow for any pathParams after /download/
         api.add_route(
-            route="download",
+            route="/download/{proxy+}",
             http_method="GET",
             lambda_function=download_api,
-            use_path_params=True,
+        )
+        api.add_route(
+            route="/authorized/download/{proxy+}",
+            http_method="GET",
+            lambda_function=download_api,
         )
 
         universal_spin_table_handler = lambda_.Function(
@@ -241,7 +256,7 @@ class SdsApiManager(Construct):
             layers=layers,
         )
         api.add_route(
-            route="batch-job",
+            route="/batch-job",
             http_method="GET",
             lambda_function=batch_job_query_api_lambda,
         )
@@ -256,7 +271,7 @@ class SdsApiManager(Construct):
         rds_secret.grant_read(grantee=batch_job_query_api_lambda)
 
         api.add_route(
-            route="spin_table",
+            route="/spin_table",
             http_method="GET",
             lambda_function=universal_spin_table_handler,
         )

--- a/tests/infrastructure/test_apigateway.py
+++ b/tests/infrastructure/test_apigateway.py
@@ -23,26 +23,43 @@ def template(stack, code):
         construct_id="ApigwTest",
     )
     apigw.deliver_to_sns(sns_topic=test_sns_topic)
-    apigw.add_route("test-route", "GET", test_func)
+    apigw.add_route("/test-route", "GET", test_func)
+    # Add a route with an authorizer
+    apigw.add_route("/authorized/test-route", "GET", test_func)
     template = Template.from_stack(stack)
     return template
 
 
 def test_apigw_routes(template):
     """Ensure that the template has the appropriate routes."""
-    template.resource_count_is("AWS::ApiGateway::RestApi", 1)
-    # One path resource
-    template.resource_count_is("AWS::ApiGateway::Resource", 1)
+    template.resource_count_is("AWS::ApiGatewayV2::Api", 1)
+    # Test that CORS is configured
     template.has_resource_properties(
-        "AWS::ApiGateway::Resource",
-        props={"PathPart": "test-route"},
+        "AWS::ApiGatewayV2::Api",
+        props={
+            "CorsConfiguration": {
+                "AllowMethods": ["GET", "POST", "OPTIONS"],
+                "AllowOrigins": ["*"],
+            },
+        },
+    )
+    # Test that we have an authorizer
+    template.resource_count_is("AWS::ApiGatewayV2::Authorizer", 1)
+    template.has_resource_properties(
+        "AWS::ApiGatewayV2::Authorizer",
+        props={"AuthorizerType": "JWT"},
     )
 
-    # One GET method on that resource
-    template.resource_count_is("AWS::ApiGateway::Method", 1)
+    template.resource_count_is("AWS::ApiGatewayV2::Route", 2)
+    # No authorizer
     template.has_resource_properties(
-        "AWS::ApiGateway::Method",
-        props={"HttpMethod": "GET"},
+        "AWS::ApiGatewayV2::Route",
+        props={"AuthorizationType": "NONE", "RouteKey": "GET /test-route"},
+    )
+    # JWT authorizer
+    template.has_resource_properties(
+        "AWS::ApiGatewayV2::Route",
+        props={"AuthorizationType": "JWT", "RouteKey": "GET /authorized/test-route"},
     )
 
 
@@ -59,11 +76,6 @@ def test_cloudwatch_alarm(template):
                 {"Fn::ImportValue": None, "Ref": Match.string_like_regexp("sns")}
             ],
             "DatapointsToAlarm": 1,
-            "Dimensions": [{"Name": "ApiName", "Value": Match.any_value()}],
-            "MetricName": "Latency",
-            "Namespace": "AWS/ApiGateway",
-            "Period": 60,
-            "Statistic": "Maximum",
             "Threshold": 10000,
             "TreatMissingData": "notBreaching",
         },

--- a/tests/infrastructure/test_sds_api_manager_construct.py
+++ b/tests/infrastructure/test_sds_api_manager_construct.py
@@ -42,6 +42,6 @@ def template(stack, env):
 
 def test_indexer_role(template):
     """Ensure that the template has appropriate IAM roles."""
-    template.resource_count_is("AWS::IAM::Role", 10)
+    template.resource_count_is("AWS::IAM::Role", 9)
     # Ensure that the template has appropriate lambda count
     template.resource_count_is("AWS::Lambda::Function", 8)


### PR DESCRIPTION
# Change Summary

## Overview

This adds a JWT authorizer that is managed internally. It only adds the authorization to specific endpoints that are located under `auth` to maintain the public endpoints.

This required a change to HttpApi from RestApi to more easily add an authorizer and CORS handling.

For testing information, reach out to me and I can give you auth flows.