### PR TITLE
Version bumping fix with descriptor "all"

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -152,6 +152,7 @@ def determine_job_version(
         conditions = [
             table.instrument == instrument,
             table.data_level == data_level,
+            table.descriptor == descriptor,
             table.start_date == start_date,
         ]
         if table == models.ProcessingJob:
@@ -160,10 +161,6 @@ def determine_job_version(
                     [models.Status.INPROGRESS.value, models.Status.SUCCEEDED.value]
                 )
             )
-        if descriptor != "all":
-            # If the descriptor is all we want to check for all descriptors
-            conditions.append(table.descriptor == descriptor)
-
         return conditions
 
     # First check to see if there are any jobs in progress and get the max version
@@ -172,6 +169,11 @@ def determine_job_version(
             *filter_conditions(models.ProcessingJob)
         )
     ).scalar()
+    # If the descriptor is "all", we should only check the processing job table. The
+    # ScienceFiles table does not have descriptors of "all" since the products
+    # produced will have their own specific descriptors.
+    if descriptor == "all":
+        return f"v{int(max_version[1:]) + 1:03d}" if max_version else "v001"
     # If no jobs are in progress, check the science files table for the max version.
     if not max_version:
         max_version = (

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -491,7 +491,7 @@ def test_determine_job_version_descriptor_is_all(session):
     """Test the ``determine_job_version`` function."""
     _populate_file_catalog(session)
     # With the descriptor set to "all", the function should return the max version
-    # bumped of ALL of the files matching "mag" and "l1b" in the database.
+    # found in the processing job table and not the science files table.
     result = determine_job_version(
         session=session,
         instrument="mag",
@@ -499,7 +499,7 @@ def test_determine_job_version_descriptor_is_all(session):
         descriptor="all",
         start_date=datetime(2024, 1, 1),
     )
-    assert result == "v003"
+    assert result == "v001"
 
 
 def test_determine_max_version_missing_processing_job(session):


### PR DESCRIPTION
# Change Summary

## Overview
Fix version bumping when the descriptor is "all" 

Veronica reported this bug: 

"The first set of files shown in the screenshot below is from a query I ran for HIT files from 20251017. I had just uploaded an L0 file with the same date but a version bump to 8.
The second set of files shown is the processing result from that new file being added to the bucket. The generated L1B file versions don't make sense to me. I would expect standard-rates and summed-rates to have v002 and sectored-rates to have v001 but they have v003."

This was due to batch starter determining the version by checking for the max version of that instrument and level. With Hit (and potentially others), this is incorrect behavior because there is an l1b housekeeping file that is not produced in the "all" job. That is why the version is v003 because it found that the max version of all l1b  jobs for that date was v002.

To fix this we should only check the processingJob table to find the version if the descriptor is "all". This will now function correctly because those jobs produced by an "all" job are highly coupled now and they should always all have the same version. This is thanks to Maxine's fix in imap_processing where post processing checks to make sure all files can be created and uploaded successfully before trying each one where one product might fail to upload but another succeeds. 

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- new file 1
   - description of new file 1's purpose


## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Add descriptor "all" check
- updated file 2
   - descipriton of change 1 in file 2
