### PR TITLE
ENH: Adding SPICE to batch starter and dependency tree

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
 from typing import Optional
@@ -108,16 +109,38 @@ class PointingAttitudeKernels(Enum):
         return "pointing_attitude_category"
 
 
-IMAP_SPICE_LOAD_ORDER = [
-    LeapsecondKernels,
-    PlanetaryConstantsKernels,
-    FramesKernels,
-    SpacecraftClockKernels,
-    PlanetaryEphemerisKernels,
-    SpacecraftEphemerisKernels,
-    SpacecraftAttitudeKernels,
-    PointingAttitudeKernels,
-]
+@dataclass
+class KernelCollection:
+    """Collection of SPICE kernel types for IMAP."""
+
+    imap_spice_load_order: list = field(
+        default_factory=lambda: [
+            LeapsecondKernels,
+            PlanetaryConstantsKernels,
+            FramesKernels,
+            SpacecraftClockKernels,
+            PlanetaryEphemerisKernels,
+            SpacecraftEphemerisKernels,
+            SpacecraftAttitudeKernels,
+            PointingAttitudeKernels,
+        ]
+    )
+
+    @property
+    def file_types(self):
+        """Return all kernel members in lowercase."""
+        members = []
+        for kernel_class in self.imap_spice_load_order:
+            members.extend([member.name.lower() for member in kernel_class])
+        return members
+
+    @property
+    def category_types(self):
+        """Collect all kernel category type strings."""
+        return [
+            kernel_class.spice_category_name()
+            for kernel_class in self.imap_spice_load_order
+        ]
 
 
 def lambda_handler(event, context):
@@ -190,10 +213,10 @@ def _metakernel_builder(
     metakernel = MetaKernel(
         start_time,
         end_time,
-        allowed_spice_types=[c.spice_category_name() for c in IMAP_SPICE_LOAD_ORDER],
+        allowed_spice_types=KernelCollection().category_types,
     )
 
-    for spice_category in IMAP_SPICE_LOAD_ORDER:
+    for spice_category in KernelCollection().imap_spice_load_order:
         for spice_subtype in spice_category:
             if file_types and spice_subtype.name not in file_types:
                 continue  # Skip over the file if not in requested list

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -13,6 +13,7 @@ import imap_data_access
 from imap_data_access import processing_input
 from sqlalchemy import and_, func, or_
 
+from ..api_lambdas import spice_metakernel_api
 from ..database import database as db
 from ..database import models
 
@@ -29,15 +30,6 @@ class DataSource:
     from imap_data_access and other data sources related to SPICE.
     """
 
-    SC_ATTITUDE: str = "sc_attitude"
-    SC_EPHEMERIS: str = "sc_ephemeris"
-    PLANET_EPHEMERIS: str = "planet_ephemeris"
-    TIME_KERNEL: str = "time_kernel"
-    THRUSTER_FIRE_KERNEL: str = "thruster_fire_kernel"
-    SC_SPIN: str = "sc_spin"
-    SC_REPOINT: str = "sc_repoint"
-    SC_POINTING_FRAME: str = "sc_pointing_frame"
-
     @property
     def valid_source(self) -> list[str]:
         """Add data sources.
@@ -47,15 +39,11 @@ class DataSource:
         list[str]
             list of valid data sources.
         """
+        # TODO: import this from imap_data_access once it's defined.
         return [
-            self.SC_ATTITUDE,
-            self.SC_EPHEMERIS,
-            self.PLANET_EPHEMERIS,
-            self.TIME_KERNEL,
-            self.THRUSTER_FIRE_KERNEL,
-            self.SC_SPIN,
-            self.SC_REPOINT,
-            self.SC_POINTING_FRAME,
+            "spin",
+            "repoint",
+            *spice_metakernel_api.KernelCollection().file_types,
             *imap_data_access.VALID_INSTRUMENTS,
         ]
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -125,6 +125,10 @@ hit, ancillary, hit-event-type-lookup, hit, l3, direct-events, HARD, DOWNSTREAM
 
 idex, l0, raw, idex, l1a, sci-1week, HARD, DOWNSTREAM
 idex, l1a, sci-1week, idex, l1b, sci-1week, HARD, DOWNSTREAM
+spin, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
+repoint, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
+ephemeris_reconstructed, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
+attitude_history, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 idex, l1b, sci-1week, idex, l2a, sci-1week, HARD, DOWNSTREAM
 
 # <---- LO Dependencies ---->
@@ -171,6 +175,8 @@ mag, ancillary, l1d-calibration, mag, l1d, all, HARD, DOWNSTREAM
 # <---- Spacecraft Dependencies ---->
 
 spacecraft, l0, raw, spacecraft, l1a, quaternions, HARD, DOWNSTREAM
+attitude_history, spice, historical, spacecraft, l1a, pointing_attitude, HARD, DOWNSTREAM
+repoint, spice, historical, spacecraft, l1a, pointing_attitude, HARD, DOWNSTREAM
 
 # <---- SWAPI Dependencies ---->
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -644,6 +644,72 @@ def test_api_request_success(mock_urlopen: unittest.mock.MagicMock):
         },
     ]
 
+    # Check for SPICE upstream dependencies
+    idex_l1b = {
+        "data_source": "idex",
+        "data_type": "l1b",
+        "descriptor": "sci-1week",
+        "relationship": "HARD",
+        "dependency_type": "UPSTREAM",
+    }
+
+    dependencies = _get_dependencies(idex_l1b)
+    assert dependencies == [
+        {
+            "data_source": "idex",
+            "data_type": "l1a",
+            "descriptor": "sci-1week",
+            "relationship": "HARD",
+        },
+        {
+            "data_source": "spin",
+            "data_type": "spice",
+            "descriptor": "historical",
+            "relationship": "HARD",
+        },
+        {
+            "data_source": "repoint",
+            "data_type": "spice",
+            "descriptor": "historical",
+            "relationship": "HARD",
+        },
+        {
+            "data_source": "ephemeris_reconstructed",
+            "data_type": "spice",
+            "descriptor": "historical",
+            "relationship": "HARD",
+        },
+        {
+            "data_source": "attitude_history",
+            "data_type": "spice",
+            "descriptor": "historical",
+            "relationship": "HARD",
+        },
+    ]
+
+    pointing_attitude = {
+        "data_source": "spacecraft",
+        "data_type": "l1a",
+        "descriptor": "pointing_attitude",
+        "relationship": "HARD",
+        "dependency_type": "UPSTREAM",
+    }
+    dependencies = _get_dependencies(pointing_attitude)
+    assert dependencies == [
+        {
+            "data_source": "attitude_history",
+            "data_type": "spice",
+            "descriptor": "historical",
+            "relationship": "HARD",
+        },
+        {
+            "data_source": "repoint",
+            "data_type": "spice",
+            "descriptor": "historical",
+            "relationship": "HARD",
+        },
+    ]
+
 
 def test_api_request_success_empty(session, mock_urlopen: unittest.mock.MagicMock):
     """Test that _get_dependencies() returns the expected dependency result.


### PR DESCRIPTION
# Change Summary
closes #585 

## Overview
Initial steps of adding spice to dependency tree and added dataclasses to store kernels information

## Updated Files
- sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
   - Added new class to store kernels informations
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
   - uses new class to validate dependency tree inputs
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - adding new SPICE dependency to use for upcoming task

## Testing
- tests/lambda_endpoints/test_batch_starter.py
