### PR TITLE
ENH: Adding SPICE logics to batch starter and dependency

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -212,7 +212,8 @@ def s3_processing_event(session, events):
         if isinstance(file_obj, SPICEFilePath):
             # Add source, data_type, and descriptor to the downstream event message
             spice_input = SPICEInput(filename)
-            data_source = spice_input.source
+            # TODO: fix this in future release of imap_data_access
+            data_source = file_obj.spice_metadata["type"]
             descriptor = spice_input.descriptor
             data_type = spice_input.data_type
             # Set the start and end dates for the upstream event message.
@@ -262,6 +263,10 @@ def s3_processing_event(session, events):
             dependency_type="DOWNSTREAM",
             relationship="SOFT_TRIGGER",
         )
+        logger.info(
+            f"Potential jobs: {potential_jobs} and potential soft jobs: "
+            f"{potential_soft_jobs}"
+        )
 
         for job in potential_jobs + potential_soft_jobs:
             # Submit downstream jobs for each upstream primary science dependency file.
@@ -278,9 +283,35 @@ def s3_processing_event(session, events):
             )
 
             if not upstream_dependencies:
-                return
+                continue
 
             logger.info(f"All required dependencies found for the job: {job}")
+            # data_source -> spacecraft and pointing kernel is a unqiue case
+            # where we need to kick off with what's in upstream dependencies
+            # without filtering.
+            if (
+                job["data_source"] == "spacecraft"
+                and job["descriptor"] == "pointing_attitude"
+            ):
+                # Convert to datetime object
+                job_start_date = datetime.strptime(start_date, "%Y%m%d")
+                job_version = determine_job_version(
+                    session=session,
+                    instrument=job["data_source"],
+                    descriptor=job["descriptor"],
+                    start_date=job_start_date,
+                    data_level=job["data_type"],
+                )
+                # submit the job
+                try_to_submit_job(
+                    session,
+                    job,
+                    job_start_date,
+                    job_version,
+                    upstream_dependencies,
+                )
+                continue
+
             # Find the first science processingInput that has the same source as the
             # potential job. Use this to determine the start date.
             primary_science = upstream_dependencies.get_science_inputs(

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -242,7 +242,7 @@ def s3_processing_event(session, events):
             # Set the start and end dates for the upstream event message
             start_date = file_obj.start_date
             # Ancillary files can have an end date.
-            end_date = file_obj.end_date if hasattr(file_obj, "end_date") else None
+            end_date = getattr(file_obj, "end_date", None)
 
         # Potential jobs are the instruments that depend on the current file,
         # which are the downstream dependencies.

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -217,11 +217,8 @@ def s3_processing_event(session, events):
             descriptor = spice_input.descriptor
             data_type = spice_input.data_type
             # Set the start and end dates for the upstream event message.
-            # TODO: fix date range if file was repoint file.
-            if file_obj.spice_metadata["type"] == "repoint":
-                # Repoint file doesn't have a start date.
-                # TODO: So set start date to be what?
-                start_date = file_obj.spice_metadata["start_date"]
+            # TODO: fix date range if/when repoint file ingestion event is
+            # passed to batch starter to kickoff HARD or SOFT_TRIGGER downstream jobs.
             # Convert datetime object to string of format YYYYMMDD
             start_date = file_obj.spice_metadata["start_date"].strftime("%Y%m%d")
             end_date = file_obj.spice_metadata["end_date"].strftime("%Y%m%d")
@@ -286,31 +283,6 @@ def s3_processing_event(session, events):
                 continue
 
             logger.info(f"All required dependencies found for the job: {job}")
-            # data_source -> spacecraft and pointing kernel is a unqiue case
-            # where we need to kick off with what's in upstream dependencies
-            # without filtering.
-            if (
-                job["data_source"] == "spacecraft"
-                and job["descriptor"] == "pointing_attitude"
-            ):
-                # Convert to datetime object
-                job_start_date = datetime.strptime(start_date, "%Y%m%d")
-                job_version = determine_job_version(
-                    session=session,
-                    instrument=job["data_source"],
-                    descriptor=job["descriptor"],
-                    start_date=job_start_date,
-                    data_level=job["data_type"],
-                )
-                # submit the job
-                try_to_submit_job(
-                    session,
-                    job,
-                    job_start_date,
-                    job_version,
-                    upstream_dependencies,
-                )
-                continue
 
             # Find the first science processingInput that has the same source as the
             # potential job. Use this to determine the start date.

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -7,10 +7,15 @@ from datetime import datetime
 import boto3
 import imap_data_access
 from imap_data_access import (
+    AncillaryFilePath,
     ScienceFilePath,
     SPICEFilePath,
 )
-from imap_data_access.processing_input import ProcessingInputCollection
+from imap_data_access.processing_input import (
+    ProcessingInputCollection,
+    ProcessingInputType,
+    SPICEInput,
+)
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
@@ -204,43 +209,55 @@ def s3_processing_event(session, events):
         logger.info(f"Retrieved filename: {filename}")
 
         file_obj = imap_data_access.file_validation.generate_imap_file_path(filename)
-
         if isinstance(file_obj, SPICEFilePath):
-            raise ValueError(
-                f"Batch starter handling for spice file: {filename} is not "
-                f"implemented yet"
-            )
-
-        # TODO: How to handle repointing
-        start_date = file_obj.start_date
-        end_date = file_obj.end_date if hasattr(file_obj, "end_date") else None
-
-        if not end_date:
-            if isinstance(file_obj, ScienceFilePath):
-                # Set end_date to start_date for science files
-                end_date = file_obj.start_date
-            else:
-                # Set end_date to today's date for ancillary or SPICE files
-                end_date = datetime.today().strftime("%Y%m%d")
-
-        # TODO: handle spice once implemented
-        data_type = (
-            file_obj.data_level if hasattr(file_obj, "data_level") else "ancillary"
-        )
+            # Add source, data_type, and descriptor to the downstream event message
+            spice_input = SPICEInput(filename)
+            data_source = spice_input.source
+            descriptor = spice_input.descriptor
+            data_type = spice_input.data_type
+            # Set the start and end dates for the upstream event message.
+            # TODO: fix date range if file was repoint file.
+            if file_obj.spice_metadata["type"] == "repoint":
+                # Repoint file doesn't have a start date.
+                # TODO: So set start date to be what?
+                start_date = file_obj.spice_metadata["start_date"]
+            # Convert datetime object to string of format YYYYMMDD
+            start_date = file_obj.spice_metadata["start_date"].strftime("%Y%m%d")
+            end_date = file_obj.spice_metadata["end_date"].strftime("%Y%m%d")
+        elif isinstance(file_obj, ScienceFilePath):
+            # Add source, data_type, and descriptor to the downstream event message
+            data_source = file_obj.instrument
+            descriptor = file_obj.descriptor
+            data_type = file_obj.data_level
+            # Set the start and end dates for the upstream event message
+            # TODO: if ENA or glows instrument, then get repoint number from filename
+            # and set start date and end date differently.
+            start_date = end_date = file_obj.start_date
+        elif isinstance(file_obj, AncillaryFilePath):
+            # Add source, data_type, and descriptor to the downstream event message
+            data_source = file_obj.instrument
+            descriptor = file_obj.descriptor
+            # data_type ==> "ancillary"
+            data_type = ProcessingInputType.ANCILLARY_FILE.value
+            # Set the start and end dates for the upstream event message
+            start_date = file_obj.start_date
+            # Ancillary files can have an end date.
+            end_date = file_obj.end_date if hasattr(file_obj, "end_date") else None
 
         # Potential jobs are the instruments that depend on the current file,
         # which are the downstream dependencies.
         potential_jobs = dependency.get_jobs(
-            data_source=file_obj.instrument,
-            descriptor=file_obj.descriptor,
+            data_source=data_source,
+            descriptor=descriptor,
             data_type=data_type,
             dependency_type="DOWNSTREAM",
             relationship="HARD",
         )
+
         # SOFT_TRIGGER dependencies will try to set off processing
         potential_soft_jobs = dependency.get_jobs(
-            data_source=file_obj.instrument,
-            descriptor=file_obj.descriptor,
+            data_source=data_source,
+            descriptor=descriptor,
             data_type=data_type,
             dependency_type="DOWNSTREAM",
             relationship="SOFT_TRIGGER",

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -409,11 +409,7 @@ def combine_kernel_sources(dependency: dict) -> str:
     """
     file_types = []
     for dep in dependency:
-        if (
-            dep["data_source"] != processing_input.SPICESource.REPOINT.value
-            and dep["data_source"] != processing_input.SPICESource.SPIN.value
-            and dep["data_source"] in spice_metakernel_api.KernelCollection().file_types
-        ):
+        if dep["data_source"] in spice_metakernel_api.KernelCollection().file_types:
             file_types.append(dep["data_source"])
     return ",".join(file_types)
 
@@ -544,7 +540,7 @@ def get_upstream_dependency_inputs(
         # Check for SPICE dependencies
         # -----------------------------
         # If spin is a dependency, query spin table for given date range
-        has_spin_dep = [dep for dep in dependencies if dep["data_source"] == "spin"]
+        has_spin_dep = any(dep["data_source"] == "spin" for dep in dependencies)
         if has_spin_dep:
             logger.info("Looking for spin files")
             spin_files = get_spin_files(session, start_date, end_date)
@@ -555,9 +551,7 @@ def get_upstream_dependency_inputs(
             dependency_inputs.add(processing_input.SPICEInput(*spin_files))
 
         # If repoint is a dependency, query s3 for latest repoint file
-        has_repoint_dep = [
-            dep for dep in dependencies if dep["data_source"] == "repoint"
-        ]
+        has_repoint_dep = any(dep["data_source"] == "repoint" for dep in dependencies)
         if has_repoint_dep:
             latest_repoint_file = get_latest_repoint_file(end_date)
             if latest_repoint_file is None:
@@ -570,13 +564,12 @@ def get_upstream_dependency_inputs(
 
         # Otherwise, combine rest of kernels types and query metakernel lambda
         # for given date range
-        has_kernel_dep = [
-            dep
-            for dep in dependencies
-            if dep["data_source"] != "spin"
+        has_kernel_dep = any(
+            dep["data_source"] != "spin"
             and dep["data_source"] != "repoint"
             and dep["data_type"] == "spice"
-        ]
+            for dep in dependencies
+        )
         if has_kernel_dep:
             combined_kernel_sources = combine_kernel_sources(dependencies)
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -405,7 +405,7 @@ def combine_kernel_sources(dependency: dict) -> str:
     -------
     str
         Combined kernel sources separated by commans. Eg.
-        "attitude_history, attitude_predict,..."
+        "attitude_history,attitude_predict,..."
     """
     file_types = []
     for dep in dependency:
@@ -509,7 +509,7 @@ def get_latest_repoint_file(end_date: datetime) -> Optional[str]:
         return None
 
     # Otherwise, return the latest repoint file without the path prefix
-    return latest[2].split("/")[-1]
+    return basename(latest[2])
 
 
 def get_upstream_dependency_inputs(

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -493,7 +493,7 @@ def get_latest_repoint_file(end_date: datetime) -> Optional[str]:
         return None
 
     # Sort by end_date and version
-    latest = max(repoint_files, key=lambda x: (x[0], x[1]))
+    latest = sorted(repoint_files, key=lambda x: (x[0], x[1]))[-1]
     latest_file_date = latest[0]
 
     # Check that input end is within latest repoint file end date

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -1,13 +1,16 @@
 """Dependency tracking module."""
 
+import json
 import logging
+import os
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from os.path import basename
 from pathlib import Path
 from typing import Optional
 
+import boto3
 import imap_data_access
 from imap_data_access import processing_input
 from imap_data_access.processing_input import ProcessingInputCollection
@@ -387,10 +390,132 @@ def primary_science_dep(query_params: dict, dependency: dict) -> bool:
     )
 
 
+def combine_kernel_sources(dependency: dict) -> str:
+    """Combine kernel sources.
+
+    Combine the kernel sources to form a single string separated by commas.
+    This is used in metakernel API calls to get kernels in order list.
+
+    Parameters
+    ----------
+    dependency : dict
+        Dependency dictionary containing the data source and data type.
+
+    Returns
+    -------
+    str
+        Combined kernel sources separated by commans. Eg.
+        "attitude_history, attitude_predict,..."
+    """
+    file_types = []
+    for dep in dependency:
+        if (
+            dep["data_source"] != processing_input.SPICESource.REPOINT.value
+            and dep["data_source"] != processing_input.SPICESource.SPIN.value
+            and dep["data_source"] in spice_metakernel_api.KernelCollection().file_types
+        ):
+            file_types.append(dep["data_source"])
+    return ",".join(file_types)
+
+
+def get_spin_files(
+    session,
+    start_date: datetime,
+    end_date: datetime,
+) -> list:
+    """Get spin input.
+
+    Query the spin table for the given date range.
+
+    Parameters
+    ----------
+    session : orm session
+        Database session.
+    spice_denpendencies : list
+        Dependency list containing dictionary of SPICE dependencies.
+    start_date : datetime
+        Start date to find dependent files with.
+    end_date : datetime
+        End date to find dependent files with.
+
+    Returns
+    -------
+    list
+        List of spin files.
+    """
+    # Query the spin table for the given date range
+    records = (
+        session.query(models.SpinTable)
+        .filter(
+            models.SpinTable.start_date <= end_date,
+            models.SpinTable.end_date >= start_date,
+        )
+        .all()
+    )
+
+    spin_files = [basename(record.file_path) for record in records]
+    return spin_files
+
+
+def get_latest_repoint_file(end_date: datetime) -> Optional[str]:
+    """Get latest repoint file.
+
+    Query S3 bucket for the latest repoint file.
+
+    Parameters
+    ----------
+    end_date : datetime
+        End date to find dependent files with.
+
+    Returns
+    -------
+    str
+        Latest repoint file name.
+    """
+    bucket_name = os.getenv("S3_BUCKET")
+    prefix = "imap/spice/repoint/"
+
+    s3 = boto3.client("s3")
+    paginator = s3.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket_name, Prefix=prefix)
+
+    repoint_files = []
+
+    for page in pages:
+        for obj in page.get("Contents", []):
+            filename = obj["Key"]
+            file_obj = processing_input.SPICEFilePath(filename)
+            repoint_files.append(
+                (
+                    file_obj.spice_metadata["end_date"],
+                    file_obj.spice_metadata["version"],
+                    filename,
+                )
+            )
+
+    if not repoint_files:
+        return None
+
+    # Sort by end_date and version
+    latest = max(repoint_files, key=lambda x: (x[0], x[1]))
+    latest_file_date = latest[0]
+
+    # Check that input end is within latest repoint file end date
+    if latest_file_date < end_date:
+        logger.info(
+            f"Latest repoint file end date {latest_file_date} "
+            f"is before input end date {end_date}"
+        )
+        return None
+
+    # Otherwise, return the latest repoint file without the path prefix
+    return latest[2].split("/")[-1]
+
+
 def get_upstream_dependency_inputs(
     dependencies: list,
     start_date: datetime,
-    end_date: Optional[datetime] = None,
+    end_date: datetime,
 ):
     """Construct a ProcessingInputCollection of dependency files.
 
@@ -405,7 +530,7 @@ def get_upstream_dependency_inputs(
         dependency in the query parameters.
     start_date : datetime
         Start date to find dependent files with.
-    end_date : datetime, optional
+    end_date : datetime
         End date to find dependent files with.
 
     Returns
@@ -415,7 +540,91 @@ def get_upstream_dependency_inputs(
     """
     dependency_inputs = processing_input.ProcessingInputCollection()
     with db.Session() as session:
-        for dep in dependencies:
+        # -----------------------------
+        # Check for SPICE dependencies
+        # -----------------------------
+        # If spin is a dependency, query spin table for given date range
+        has_spin_dep = [dep for dep in dependencies if dep["data_source"] == "spin"]
+        if has_spin_dep:
+            logger.info("Looking for spin files")
+            spin_files = get_spin_files(session, start_date, end_date)
+            if not spin_files:
+                logger.info(f"No spin files found for {start_date} to {end_date}")
+                return None
+            logger.info(f"Found spin files: {spin_files}. Adding to collection.")
+            dependency_inputs.add(processing_input.SPICEInput(*spin_files))
+
+        # If repoint is a dependency, query s3 for latest repoint file
+        has_repoint_dep = [
+            dep for dep in dependencies if dep["data_source"] == "repoint"
+        ]
+        if has_repoint_dep:
+            latest_repoint_file = get_latest_repoint_file(end_date)
+            if latest_repoint_file is None:
+                logger.info(f"No repoint file found for {start_date} to {end_date}")
+                return None
+            logger.info(
+                f"Found repoint file: {latest_repoint_file}. Adding to collection."
+            )
+            dependency_inputs.add(processing_input.SPICEInput(latest_repoint_file))
+
+        # Otherwise, combine rest of kernels types and query metakernel lambda
+        # for given date range
+        has_kernel_dep = [
+            dep
+            for dep in dependencies
+            if dep["data_source"] != "spin"
+            and dep["data_source"] != "repoint"
+            and dep["data_type"] == "spice"
+        ]
+        if has_kernel_dep:
+            combined_kernel_sources = combine_kernel_sources(dependencies)
+
+            # convert start_date and end_date in seconds after j2000.
+            # TODO: remove this once Bryan changes takes in 'yyyymmdd' format
+            def yyyymmdd_to_seconds_since_j2000(date_str: str) -> float:
+                # Parse input date string
+                dt = datetime.strptime(date_str, "%Y%m%d").replace(tzinfo=timezone.utc)
+
+                # Define J2000 epoch: 2000-01-01T12:00:00 UTC
+                j2000 = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+                # Compute seconds difference
+                delta = dt - j2000
+                return delta.total_seconds()
+
+            start_time = yyyymmdd_to_seconds_since_j2000(start_date.strftime("%Y%m%d"))
+            end_time = yyyymmdd_to_seconds_since_j2000(end_date.strftime("%Y%m%d"))
+            metakernel_response = spice_metakernel_api.lambda_handler(
+                {
+                    "queryStringParameters": {
+                        "start_time": start_time,
+                        "end_time": end_time,
+                        "list_files": "True",
+                        "file_types": combined_kernel_sources,
+                        # "require_coverage": "True",
+                    }
+                },
+                None,
+            )
+            if metakernel_response["statusCode"] != 200:
+                logger.info(
+                    f"Error querying metakernel lambda: {metakernel_response['body']}"
+                )
+                return None
+            metakernel_files = json.loads(metakernel_response["body"])
+            logger.info(
+                f"Found metakernel files: {metakernel_files}. Adding to collection."
+            )
+            dependency_inputs.add(processing_input.SPICEInput(*metakernel_files))
+
+        # ---------------------------------
+        # Check for non-spice dependencies
+        # ---------------------------------
+        non_spice_dependencies = [
+            dep for dep in dependencies if dep["data_type"] != "spice"
+        ]
+        for dep in non_spice_dependencies:
             relationship = dep["relationship"]
 
             dep_string = f"{dep=}\n{start_date=}\n{end_date=}"

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -595,6 +595,7 @@ def get_upstream_dependency_inputs(
                         "end_time": end_time,
                         "list_files": "True",
                         "file_types": combined_kernel_sources,
+                        # TODO: revisit this after SIT-4
                         # "require_coverage": "True",
                     }
                 },

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -143,7 +143,6 @@ hit, ancillary, hit-event-type-lookup, hit, l3, direct-events, HARD, DOWNSTREAM
 idex, l0, raw, idex, l1a, sci-1week, HARD, DOWNSTREAM
 idex, l1a, sci-1week, idex, l1b, sci-1week, HARD, DOWNSTREAM
 spin, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
-repoint, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 attitude_history, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 idex, l1b, sci-1week, idex, l2a, sci-1week, HARD, DOWNSTREAM
@@ -192,8 +191,6 @@ mag, ancillary, l1d-calibration, mag, l1d, all, HARD, DOWNSTREAM
 # <---- Spacecraft Dependencies ---->
 
 spacecraft, l0, raw, spacecraft, l1a, quaternions, HARD, DOWNSTREAM
-attitude_history, spice, historical, spacecraft, l1a, pointing_attitude, HARD, DOWNSTREAM
-repoint, spice, historical, spacecraft, l1a, pointing_attitude, HARD, DOWNSTREAM
 
 # <---- SWAPI Dependencies ---->
 

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -202,6 +202,18 @@ def _populate_file_catalog(session):
                 "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
             ),
         ),
+        ScienceFiles(
+            file_path="/path/to/imap_swe_l1a_sci_20240106_v001.cdf",
+            instrument="swe",
+            data_level="l1a",
+            descriptor="sci",
+            start_date=datetime(2024, 1, 6),
+            version="v001",
+            extension="pkts",
+            ingestion_date=datetime.strptime(
+                "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+            ),
+        ),
         # Adding a downstream swe l1b file that depends on the science file above
         ScienceFiles(
             file_path="/path/to/imap_swe_l1b_sci_20240102_v001.cdf",

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -545,12 +545,6 @@ def test_dependency_success():
             "relationship": "HARD",
         },
         {
-            "data_source": "repoint",
-            "data_type": "spice",
-            "descriptor": "historical",
-            "relationship": "HARD",
-        },
-        {
             "data_source": "ephemeris_reconstructed",
             "data_type": "spice",
             "descriptor": "historical",
@@ -558,28 +552,6 @@ def test_dependency_success():
         },
         {
             "data_source": "attitude_history",
-            "data_type": "spice",
-            "descriptor": "historical",
-            "relationship": "HARD",
-        },
-    ]
-
-    dependencies = dependency.get_jobs(
-        data_source="spacecraft",
-        data_type="l1a",
-        descriptor="pointing_attitude",
-        relationship="HARD",
-        dependency_type="UPSTREAM",
-    )
-    assert dependencies == [
-        {
-            "data_source": "attitude_history",
-            "data_type": "spice",
-            "descriptor": "historical",
-            "relationship": "HARD",
-        },
-        {
-            "data_source": "repoint",
             "data_type": "spice",
             "descriptor": "historical",
             "relationship": "HARD",
@@ -699,10 +671,6 @@ def test_spice_event(session, s3_client):
             "files": ["imap_2025_118_2025_120_01.spin.csv"],
         },
         {
-            "type": "repoint",
-            "files": ["imap_2025_120_01.repoint.csv"],
-        },
-        {
             "type": "spice",
             "files": [
                 "imap_recon_20250428_20250430_v02.bsp",
@@ -742,20 +710,3 @@ def test_spice_event(session, s3_client):
                 ]
             },
         )
-
-    # Attitude kernel event should trigger both IDEX L1B and spacecraft L1A jobs
-    events = {
-        "Records": [
-            {
-                "body": '{"detail": '
-                '{"object": {"key": "imap_2025_118_2025_120_02.ah.bc"}}'
-                "}"
-            }
-        ]
-    }
-
-    with patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client:
-        lambda_handler(events, None)
-        mock_batch_client.submit_job.assert_called()
-        # Check that the function was called twice
-        assert mock_batch_client.submit_job.call_count == 2

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -742,3 +742,20 @@ def test_spice_event(session, s3_client):
                 ]
             },
         )
+
+    # Attitude kernel event should trigger both IDEX L1B and spacecraft L1A jobs
+    events = {
+        "Records": [
+            {
+                "body": '{"detail": '
+                '{"object": {"key": "imap_2025_118_2025_120_02.ah.bc"}}'
+                "}"
+            }
+        ]
+    }
+
+    with patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client:
+        lambda_handler(events, None)
+        mock_batch_client.submit_job.assert_called()
+        # Check that the function was called twice
+        assert mock_batch_client.submit_job.call_count == 2

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1,5 +1,6 @@
 """Tests the batch starter."""
 
+import json
 import logging
 from datetime import datetime
 from unittest.mock import Mock, patch
@@ -16,6 +17,8 @@ from sds_data_manager.lambda_code.SDSCode.database import models
 from sds_data_manager.lambda_code.SDSCode.database.models import (
     ProcessingJob,
     ScienceFiles,
+    SPICEFiles,
+    SpinTable,
 )
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import (
     batch_starter,
@@ -375,30 +378,6 @@ def test_lambda_handler_missing_upstream_dependency(session, caplog):
         assert log_str in caplog.text
 
 
-def test_spice_file(session):
-    """Tests ``lambda_handler`` function with spice file."""
-    events = {
-        "Records": [
-            {
-                "body": '{"detail": '
-                '{"object": {"key": "imap_1000_100_1000_100_10.spin.csv"}}'
-                "}"
-            }
-        ]
-    }
-
-    context = {"context": "sample_context"}
-
-    # Test that value error is raised for SPICE file right now.
-    # TODO: undo this and add correct tests when it's implemented.
-    with pytest.raises(
-        ValueError,
-        match="Batch starter handling for spice file: "
-        "imap_1000_100_1000_100_10.spin.csv is not implemented yet",
-    ):
-        lambda_handler(events, context)
-
-
 def test_determine_max_version(session):
     """Test the ``determine_job_version`` function."""
     _populate_processing_table(session)
@@ -626,3 +605,140 @@ def test_dependency_success_empty(session):
         end_date="20000101",
     )
     assert not dependencies
+
+
+def test_spice_event(session, s3_client):
+    """Test spice dependencies."""
+    # Write repoint file to s3 that batch starter can query
+    # for dependencies
+    filepath = "imap/spice/repoint/imap_2025_120_01.repoint.csv"
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key=filepath,
+        Body=b"test",
+    )
+    # Write data to the database that batch starter can query
+    # for dependencies
+    session.add_all(
+        [
+            # Data to test the SPICE dependency using IDEX L1B and pointing_attitude
+            ScienceFiles(
+                file_path="/path/to/imap_idex_l1a_sci-1week_20250429_v001.cdf",
+                instrument="idex",
+                data_level="l1a",
+                descriptor="sci-1week",
+                start_date=datetime(2025, 4, 29),
+                version="v001",
+                extension="cdf",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),
+            SPICEFiles(
+                # 2025028 to 2025030
+                file_name="imap_2025_118_2025_120_02.ah.bc",
+                ingestion_date=datetime.now(),
+                file_root="imap_2025_118_2025_120_.ah.bc",
+                kernel_type="attitude_history",
+                min_date_j2000=799070400.1854936,
+                max_date_j2000=799243200.185493,
+                file_intervals_j2000=[[799070400, 799243200]],
+                min_date_datetime=datetime(2025, 4, 28),
+                max_date_datetime=datetime(2025, 4, 30),
+                file_intervals_datetime=[["0", "0"]],
+                min_date_sclk="",
+                max_date_sclk="",
+                file_intervals_sclk=[["0", "0"]],
+                sclk_kernel="imap_sclk_0001.tsc",
+                lsk_kernel="naif0012.tls",
+                version=2,
+            ),
+            SPICEFiles(
+                file_name="imap_recon_20250428_20250430_v02.bsp",
+                ingestion_date=datetime.now(),
+                file_root="imap_recon_20250428_20250430_v.bsp",
+                kernel_type="ephemeris_reconstructed",
+                min_date_j2000=799070400.1854936,
+                max_date_j2000=799243200.185493,
+                file_intervals_j2000=[[799070400, 799243200]],
+                min_date_datetime=datetime(2025, 4, 28),
+                max_date_datetime=datetime(2025, 4, 30),
+                file_intervals_datetime=[["0", "0"]],
+                min_date_sclk="",
+                max_date_sclk="",
+                file_intervals_sclk=[["0", "0"]],
+                sclk_kernel="imap_sclk_0001.tsc",
+                lsk_kernel="naif0012.tls",
+                version=2,
+            ),
+            SpinTable(
+                # 2025028 to 2025030
+                file_path="/mnt/data/imap/spice/spin/imap_2025_118_2025_120_01.spin.csv",
+                start_date=datetime(2025, 4, 28),
+                end_date=datetime(2025, 4, 30),
+                version="01",
+                ingestion_date=datetime.now(),
+            ),
+        ]
+    )
+    session.commit()
+    # Event of spin file should trigger IDEX L1B sci-1week job
+    events = {
+        "Records": [
+            {
+                "body": '{"detail": '
+                '{"object": '
+                '{"key": "imap/spice/spin/imap_2025_118_2025_120_01.spin.csv"}}'
+                "}"
+            }
+        ]
+    }
+    expected_dependency_input = [
+        {
+            "type": "spin",
+            "files": ["imap_2025_118_2025_120_01.spin.csv"],
+        },
+        {
+            "type": "repoint",
+            "files": ["imap_2025_120_01.repoint.csv"],
+        },
+        {
+            "type": "spice",
+            "files": [
+                "imap_recon_20250428_20250430_v02.bsp",
+                "imap_2025_118_2025_120_02.ah.bc",
+            ],
+        },
+        {
+            "type": "science",
+            "files": [
+                "imap_idex_l1a_sci-1week_20250429_v001.cdf",
+            ],
+        },
+    ]
+
+    with patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client:
+        lambda_handler(events, None)
+        mock_batch_client.submit_job.assert_called_once()
+        mock_batch_client.submit_job.assert_called_with(
+            jobName="idex-l1b-sci-1week-job-1",
+            jobQueue="ProcessingJobQueue",
+            jobDefinition="ProcessingJob-idex",
+            containerOverrides={
+                "command": [
+                    "--instrument",
+                    "idex",
+                    "--data-level",
+                    "l1b",
+                    "--descriptor",
+                    "sci-1week",
+                    "--start-date",
+                    "20250429",
+                    "--version",
+                    "v001",
+                    "--dependency",
+                    json.dumps(expected_dependency_input),
+                    "--upload-to-sdc",
+                ]
+            },
+        )

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -1,5 +1,7 @@
 """Test data dependency functions."""
 
+import json
+import os
 from datetime import datetime
 from unittest.mock import patch
 
@@ -12,6 +14,7 @@ from imap_data_access.processing_input import (
 
 from sds_data_manager.lambda_code.SDSCode.database.models import (
     ScienceFiles,
+    SpinTable,
 )
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import dependency
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.dependency import get_files
@@ -318,6 +321,24 @@ def test_get_primary_science_files(session):
     )
     assert record == []
 
+    # Query for file that falls in middle date of range
+    dep = {
+        "data_source": "swe",
+        "data_type": "l1a",
+        "descriptor": "sci",
+    }
+    record = get_files(
+        session,
+        dependency=dep,
+        start_date=datetime(2024, 1, 4),
+        end_date=datetime(2024, 1, 7),
+    )
+    assert len(record) == 1
+    assert record[0].instrument == "swe"
+    assert record[0].data_level == "l1a"
+    assert record[0].descriptor == "sci"
+    assert record[0].start_date == datetime(2024, 1, 6)
+
 
 def test_get_science_files_date_range(session):
     """Tests the get_file function for science files dependent on start_date."""
@@ -392,3 +413,182 @@ def test_get_files_max_version(session):
 
     assert records[2].start_date == datetime(2024, 1, 3)
     assert records[2].version == "v001"
+
+
+# #####################################
+# TESTS SPICE logics
+# #####################################
+
+
+def test_get_latest_repoint_file(s3_client):
+    """Test get_latest_repoint_file function."""
+    # Write repoint files to the S3 bucket
+    bucket_name = "test-data-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+    os.environ["S3_BUCKET"] = bucket_name
+
+    s3_client.put_object(
+        Bucket=bucket_name,
+        Key="imap/spice/repoint/imap_2025_120_01.repoint.csv",  # 20250430
+        Body=b"test",
+    )
+
+    # Test with date of the file
+    end_date = datetime(2025, 4, 30)
+    latest_file = dependency.get_latest_repoint_file(end_date)
+    assert latest_file == "imap/spice/repoint/imap_2025_120_01.repoint.csv"
+
+    # Add more files to the bucket
+    s3_client.put_object(
+        Bucket=bucket_name,
+        Key="imap/spice/repoint/imap_2025_121_01.repoint.csv",  # 20250501
+        Body=b"test",
+    )
+    s3_client.put_object(
+        Bucket=bucket_name,
+        Key="imap/spice/repoint/imap_2025_121_02.repoint.csv",  # 20250501
+        Body=b"test",
+    )
+
+    # Test with date before the first file
+    end_date = datetime(2025, 3, 1)
+    latest_file = dependency.get_latest_repoint_file(end_date)
+    assert latest_file == "imap/spice/repoint/imap_2025_121_02.repoint.csv"
+
+    # Test with a date after the latest file
+    end_date = datetime(2025, 6, 30)
+    latest_file = dependency.get_latest_repoint_file(end_date)
+    assert latest_file is None
+
+
+def test_get_spin_files(session):
+    """Test get_spin_files function."""
+    # Add spin files to the database
+    session.add_all(
+        [
+            SpinTable(
+                file_path="/imap/spice/spin/imap_2025_119_2025_120_01.spin.csv",
+                start_date=datetime(2025, 4, 29),
+                end_date=datetime(2025, 4, 30),
+                version="01",
+                ingestion_date=datetime.now(),
+            ),
+            SpinTable(
+                file_path="/imap/spice/spin/imap_2025_120_2025_121_01.spin.csv",
+                start_date=datetime(2025, 4, 30),
+                end_date=datetime(2025, 5, 1),
+                version="01",
+                ingestion_date=datetime.now(),
+            ),
+        ]
+    )
+    session.commit()
+
+    # Test with overlapping date range
+    start_date = datetime(2025, 4, 29)
+    end_date = datetime(2025, 4, 30)
+    spin_files = dependency.get_spin_files(session, start_date, end_date)
+    assert spin_files == [
+        "imap_2025_119_2025_120_01.spin.csv",
+        "imap_2025_120_2025_121_01.spin.csv",
+    ]
+
+    # Test with a date range that does not overlap
+    start_date = datetime(2025, 5, 2)
+    end_date = datetime(2025, 5, 3)
+    spin_files = dependency.get_spin_files(session, start_date, end_date)
+    assert spin_files == []
+
+    # Test with one day date range
+    start_date = datetime(2025, 4, 29)
+    end_date = datetime(2025, 4, 29)
+    spin_files = dependency.get_spin_files(session, start_date, end_date)
+    assert spin_files == [
+        "imap_2025_119_2025_120_01.spin.csv",
+    ]
+
+
+def test_combine_kernel_sources():
+    """Test combine_kernel_sources function."""
+    # Test with valid SPICE dependencies excluding REPOINT and SPIN
+    dependencies = [
+        {
+            "data_source": "attitude_history",
+            "data_type": "spice",
+            "descriptor": "historical",
+        },
+        {
+            "data_source": "ephemeris_reconstructed",
+            "data_type": "spice",
+            "descriptor": "historical",
+        },
+    ]
+    result = dependency.combine_kernel_sources(dependencies)
+    assert result == "attitude_history,ephemeris_reconstructed"
+
+    # Test with REPOINT and SPIN dependencies
+    dependencies = [
+        {"data_source": "repoint", "data_type": "spice", "descriptor": "historical"},
+        {"data_source": "spin", "data_type": "spice", "descriptor": "historical"},
+        {
+            "data_source": "attitude_history",
+            "data_type": "spice",
+            "descriptor": "historical",
+        },
+    ]
+    result = dependency.combine_kernel_sources(dependencies)
+    assert result == "attitude_history"
+
+    # Test with an empty dependency list
+    dependencies = []
+    result = dependency.combine_kernel_sources(dependencies)
+    assert result == ""
+
+    # Test with only REPOINT and SPIN dependencies
+    dependencies = [
+        {"data_source": "repoint", "data_type": "spice", "descriptor": "historical"},
+        {"data_source": "spin", "data_type": "spice", "descriptor": "historical"},
+    ]
+    result = dependency.combine_kernel_sources(dependencies)
+    assert result == ""
+
+    # Test with only REPOINT dependency
+    dependencies = [
+        {"data_source": "repoint", "data_type": "spice", "descriptor": "historical"},
+        {
+            "data_source": "attitude_history",
+            "data_type": "spice",
+            "descriptor": "historical",
+        },
+    ]
+    result = dependency.combine_kernel_sources(dependencies)
+    assert result == "attitude_history"
+
+    # Test with only SPIN dependency
+    dependencies = [
+        {"data_source": "spin", "data_type": "spice", "descriptor": "historical"},
+        {
+            "data_source": "attitude_history",
+            "data_type": "spice",
+            "descriptor": "historical",
+        },
+    ]
+    result = dependency.combine_kernel_sources(dependencies)
+    assert result == "attitude_history"
+
+    # Pass invalid SPICE file types
+    dependencies = [
+        {
+            "data_source": "invalid_file_type",
+            "data_type": "spice",
+            "descriptor": "historical",
+        },
+    ]
+    result = dependency.combine_kernel_sources(dependencies)
+    assert result == ""
+    # Pass instrument name as data_source
+    dependencies = [
+        {"data_source": "idex", "data_type": "spice", "descriptor": "historical"},
+    ]
+    result = dependency.combine_kernel_sources(dependencies)
+    assert result == ""

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -1,6 +1,5 @@
 """Test data dependency functions."""
 
-import json
 import os
 from datetime import datetime
 from unittest.mock import patch
@@ -436,7 +435,7 @@ def test_get_latest_repoint_file(s3_client):
     # Test with date of the file
     end_date = datetime(2025, 4, 30)
     latest_file = dependency.get_latest_repoint_file(end_date)
-    assert latest_file == "imap/spice/repoint/imap_2025_120_01.repoint.csv"
+    assert latest_file == "imap_2025_120_01.repoint.csv"
 
     # Add more files to the bucket
     s3_client.put_object(
@@ -453,7 +452,7 @@ def test_get_latest_repoint_file(s3_client):
     # Test with date before the first file
     end_date = datetime(2025, 3, 1)
     latest_file = dependency.get_latest_repoint_file(end_date)
-    assert latest_file == "imap/spice/repoint/imap_2025_121_02.repoint.csv"
+    assert latest_file == "imap_2025_121_02.repoint.csv"
 
     # Test with a date after the latest file
     end_date = datetime(2025, 6, 30)


### PR DESCRIPTION
# Change Summary
closes #586

## Overview
Main changes for adding SPICE dependency.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - updated how inputs to dependency are constructed based on what file type it is.
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
   - main changes. Added logics to query and build spice dependencies
   - added handling for spin, repoint, and kernels.

## Testing
updated tests to test above cases
- tests/lambda_endpoints/conftest.py
- tests/lambda_endpoints/test_batch_starter.py
- tests/lambda_endpoints/test_dependency_api.py
