### PR TITLE
IDEX l2 and MAG ancillary dependencies 

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -261,7 +261,7 @@ def s3_processing_event(session, events):
             )
 
             if not upstream_dependencies:
-                return
+                continue
 
             logger.info(f"All required dependencies found for the job: {job}")
             # Find the first science processingInput that has the same source as the

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -147,6 +147,8 @@ repoint, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 attitude_history, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 idex, l1b, sci-1week, idex, l2a, sci-1week, HARD, DOWNSTREAM
+idex, l2a, sci-1week, idex, l2b, sci-1week, HARD, DOWNSTREAM
+idex, l2b, sci-1week, idex, l2c, sci-1week, HARD, DOWNSTREAM
 
 # <---- LO Dependencies ---->
 lo, l0, raw, lo, l1a, all, HARD, DOWNSTREAM
@@ -175,7 +177,10 @@ mag, l1a, norm-mago, mag, l1b, norm-mago, HARD, DOWNSTREAM
 mag, l1a, norm-magi, mag, l1b, norm-magi, HARD, DOWNSTREAM
 mag, l1a, burst-mago, mag, l1b, burst-mago, HARD, DOWNSTREAM
 mag, l1a, burst-magi, mag, l1b, burst-magi, HARD, DOWNSTREAM
-mag, ancillary, l1b-calibration, mag, l1b, all, HARD, DOWNSTREAM
+mag, ancillary, l1b-calibration, mag, l1b, norm-mago, HARD, DOWNSTREAM
+mag, ancillary, l1b-calibration, mag, l1b, norm-magi, HARD, DOWNSTREAM
+mag, ancillary, l1b-calibration, mag, l1b, burst-mago, HARD, DOWNSTREAM
+mag, ancillary, l1b-calibration, mag, l1b, burst-magi, HARD, DOWNSTREAM
 
 # For L1C, we want to trigger on either burst or norm or both.
 mag, l1b, norm-mago, mag, l1c, norm-mago, SOFT_TRIGGER, DOWNSTREAM
@@ -187,7 +192,8 @@ mag, l1c, norm-mago, mag, l1d, norm, HARD, DOWNSTREAM
 mag, l1c, norm-magi, mag, l1d, norm, HARD, DOWNSTREAM
 mag, l1b, burst-mago, mag, l1d, burst, HARD, DOWNSTREAM
 mag, l1b, burst-magi, mag, l1d, burst, HARD, DOWNSTREAM
-mag, ancillary, l1d-calibration, mag, l1d, all, HARD, DOWNSTREAM
+mag, ancillary, l1d-calibration, mag, l1d, burst, HARD, DOWNSTREAM
+mag, ancillary, l1d-calibration, mag, l1d, norm, HARD, DOWNSTREAM
 
 # <---- Spacecraft Dependencies ---->
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -174,12 +174,12 @@ lo, l1b, de, lo, l1c, pset, HARD, DOWNSTREAM
 mag, l0, raw, mag, l1a, all, HARD, DOWNSTREAM
 
 mag, l1a, norm-mago, mag, l1b, norm-mago, HARD, DOWNSTREAM
-mag, l1a, norm-magi, mag, l1b, norm-magi, HARD, DOWNSTREAM
-mag, l1a, burst-mago, mag, l1b, burst-mago, HARD, DOWNSTREAM
-mag, l1a, burst-magi, mag, l1b, burst-magi, HARD, DOWNSTREAM
 mag, ancillary, l1b-calibration, mag, l1b, norm-mago, HARD, DOWNSTREAM
+mag, l1a, norm-magi, mag, l1b, norm-magi, HARD, DOWNSTREAM
 mag, ancillary, l1b-calibration, mag, l1b, norm-magi, HARD, DOWNSTREAM
+mag, l1a, burst-mago, mag, l1b, burst-mago, HARD, DOWNSTREAM
 mag, ancillary, l1b-calibration, mag, l1b, burst-mago, HARD, DOWNSTREAM
+mag, l1a, burst-magi, mag, l1b, burst-magi, HARD, DOWNSTREAM
 mag, ancillary, l1b-calibration, mag, l1b, burst-magi, HARD, DOWNSTREAM
 
 # For L1C, we want to trigger on either burst or norm or both.
@@ -190,9 +190,9 @@ mag, l1b, burst-magi, mag, l1c, norm-magi, SOFT_TRIGGER, DOWNSTREAM
 
 mag, l1c, norm-mago, mag, l1d, norm, HARD, DOWNSTREAM
 mag, l1c, norm-magi, mag, l1d, norm, HARD, DOWNSTREAM
+mag, ancillary, l1d-calibration, mag, l1d, burst, HARD, DOWNSTREAM
 mag, l1b, burst-mago, mag, l1d, burst, HARD, DOWNSTREAM
 mag, l1b, burst-magi, mag, l1d, burst, HARD, DOWNSTREAM
-mag, ancillary, l1d-calibration, mag, l1d, burst, HARD, DOWNSTREAM
 mag, ancillary, l1d-calibration, mag, l1d, norm, HARD, DOWNSTREAM
 
 # <---- Spacecraft Dependencies ---->

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -281,7 +281,7 @@ def test_lambda_handler_mag_l1c_case(session):
         lambda_handler(events, context)
         # Verify the function was called
         mock_batch_client.submit_job.assert_called_with(
-            jobName="mag-l1c-norm-mago-job-3",
+            jobName="mag-l1c-norm-mago-job-2",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-mag",
             containerOverrides={


### PR DESCRIPTION
# Change Summary

## Overview
Add IDEX l2 dependencies. 
Update MAG ancillary dependencies to not use "all"

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - Add / fix dependencies
