### PR TITLE
IDEX dependency fixes

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -167,7 +167,7 @@ attitude_history, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 
 idex, l1b, sci-1week, idex, l2a, sci-1week, HARD, DOWNSTREAM
 idex, l2a, sci-1week, idex, l2b, sci-1week, HARD, DOWNSTREAM
-idex, l1b, evt, idex, l2b, sci-1week, HARD, DOWNSTREAM
+idex, l1b, evt, idex, l2b, sci-1week, SOFT_NO_TRIGGER, DOWNSTREAM
 idex, l2b, sci-1week, idex, l2c, sci-1week, HARD, DOWNSTREAM
 
 # <---- LO Dependencies ---->

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -157,8 +157,8 @@ hit, ancillary, hit-event-type-lookup, hit, l3, direct-events, HARD, DOWNSTREAM
 # <---- IDEX Dependencies ---->
 
 idex, l0, raw, idex, l1a, all, HARD, DOWNSTREAM
-leapseconds, spice, historical, idex, l1a, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
-spacecraft_clock, spice, historical, idex, l1a, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, idex, l1a, all, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, idex, l1a, all, HARD_NO_TRIGGER, DOWNSTREAM
 
 idex, l1a, sci-1week, idex, l1b, sci-1week, HARD, DOWNSTREAM
 spin, spin, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview
Fix idex SPICE dependency descriptors


## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - use descriptor "all" for spice l1a deps