### PR TITLE
Skip /spice folder in database synchronizer

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/database/synchronizer.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/synchronizer.py
@@ -49,7 +49,11 @@ def lambda_handler(event, context):
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         if "Contents" in page:
             s3_files_dict.update(
-                {obj["Key"]: obj["LastModified"] for obj in page["Contents"]}
+                {
+                    obj["Key"]: obj["LastModified"]
+                    for obj in page["Contents"]
+                    if "spice/" not in obj["Key"]
+                }
             )
 
     s3_files = set(s3_files_dict.keys())

--- a/sds_data_manager/lambda_code/SDSCode/database/synchronizer.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/synchronizer.py
@@ -48,6 +48,8 @@ def lambda_handler(event, context):
     # TODO search spice/ folder
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         if "Contents" in page:
+            # Add keys that do not have spice/ in them. This code does not have
+            # SPICE synchronization logic yet.
             s3_files_dict.update(
                 {
                     obj["Key"]: obj["LastModified"]


### PR DESCRIPTION
# Change Summary

## Overview
Since the /spice folder was moved to be under /imap, the db synchronizer code has not been working. This PR fixes that by skipping keys that contain "spice/". 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/database/synchronizer.py
   - Skip spice
