### PR TITLE
Add ancillary end date handling back to batch starter

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -292,7 +292,10 @@ def s3_processing_event(session, events):
             start_date = file_obj.start_date
             # Ancillary files can have an end date.
             end_date = getattr(file_obj, "end_date", None)
-
+            # If there is no end date for the ancillary file, then it is implicitly
+            # valid through today.
+            if not end_date:
+                end_date = datetime.today().strftime("%Y%m%d")
         # Potential jobs are the instruments that depend on the current file,
         # which are the downstream dependencies.
         potential_jobs = dependency.get_jobs(


### PR DESCRIPTION
# Change Summary

## Overview
Somehow in all the shuffling of batch starter last week, the logic that sets the end_date of an ancillary file to datetime.today(), if it is None was removed. This PR adds it back in and should fix at least some of the problems (if not all) that menlo was having.

## Updated Files
-sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Add ancillary end_date handling back in 