### PR TITLE
ENH: Send SPICE Event from SPICE Indexer Lambda

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -13,6 +13,7 @@ from sqlalchemy.dialects.postgresql import insert
 
 from ..database import database as db
 from ..database import models
+from .lambda_custom_events import IMAPLambdaPutEvent
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -328,6 +329,63 @@ def write_data_to_efs(s3_key: str, s3_bucket: str, data_mount_path: Path) -> Pat
     return efs_spice_filename_and_path
 
 
+def send_spice_event(spice_obj: SPICEFilePath, s3_key: str):
+    """Send SPICE event to EventBridge.
+
+    Example of what PutEvent looks like:
+    {
+        "Source": "imap.lambda",
+        "DetailType": "Processed File",
+        "Detail": {
+            "object": {
+                "key": "imap/spice/spin/imap_2025_122_2025_122_02.spin.csv",
+                "instrument": "spacecraft",
+                }
+        }
+    }
+
+    Parameters
+    ----------
+    spice_obj : SPICEFilePath
+        SPICE of the file to determine the event type
+    s3_key : str
+        S3 object key to send to EventBridge
+    """
+    # If these kernels, send event to EventBridge
+    spice_events = [
+        "attitude_history",
+        "attitude_predict",
+        "ephemeris_reconstructed",
+        "ephemeris_nominal",
+        "ephemeris_predict",
+        "spin",
+        "thruster",
+    ]
+    if spice_obj.spice_metadata["type"] not in spice_events:
+        return None
+
+    logger.info(f"Sending SPICE event for {s3_key} to EventBridge")
+    eventbridge_client = boto3.client("events")
+
+    # Create event["detail"] and event inputs
+    detail = {
+        "object": {
+            "key": s3_key,
+            "instrument": "spacecraft",
+        }
+    }
+    event = IMAPLambdaPutEvent(
+        detail_type="Processed File",
+        detail=detail,
+    )
+    event_data = event.to_event()
+
+    # Send event to EventBridge
+    response = eventbridge_client.put_events(Entries=[event_data])
+    logger.info(f"Event sent to EventBridge: {response}")
+    return response
+
+
 def lambda_handler(event, context):
     """Lambda is triggered by eventbridge.
 
@@ -403,6 +461,8 @@ def lambda_handler(event, context):
         # Index the SPICE kerenels to the SPICE table
         logger.info(f"Indexing {s3_key} to SPICE table")
         index_spice_file(file_path)
+
+    send_spice_event(spice_obj, s3_key)
 
     return {
         "statusCode": 200,

--- a/tests/lambda_endpoints/test_spice_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_spice_indexer_lambda.py
@@ -5,6 +5,7 @@ import os
 from datetime import datetime
 
 import spiceypy
+from imap_data_access import SPICEFilePath
 from sqlalchemy import select
 
 from sds_data_manager.lambda_code.SDSCode.api_lambdas import (
@@ -191,3 +192,17 @@ def test_s3_spin_files(session, s3_client, events_client):
         temp_path + "/imap/spice/spin/imap_2026_267_2026_267_02.spin.csv"
     )
     assert spin_table_rows[1].version == "02"
+
+
+def test_send_spice_event(events_client):
+    """Test the ``send_spice_event`` function."""
+    s3_key = "imap/spice/lsk/naif0012.tls"
+    spice_obj = SPICEFilePath(s3_key)
+    result = spice_indexer.send_spice_event(spice_obj, s3_key)
+    assert result is None
+
+    # Now pass attitude kernel
+    s3_key = "imap/spice/ck/imap_2025_118_2025_120_001.ah.bc"
+    spice_obj = SPICEFilePath(s3_key)
+    result = spice_indexer.send_spice_event(spice_obj, s3_key)
+    assert result["ResponseMetadata"]["HTTPStatusCode"] == 200


### PR DESCRIPTION
# Change Summary
closes #610 

## Overview
Adding SPICE filter in SPICE indexer lambda and sending event to EventBridge those.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
   - Sending specific kernels or spin data to kickoff jobs that's dependent on it. I using knowledge from [this table](https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/228069149/SDC+SPICE+Dependency+Association+SPIKE#SDCSPICEDependencyAssociationSPIKE-Batchstarterlogics) to decide which ones to send to EventBridge as event.


## Testing
- tests/lambda_endpoints/test_spice_indexer_lambda.py
