### PR TITLE
Ultra l2 spice requirements

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -503,45 +503,44 @@ ultra, l1c, 45sensor-pset, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD, 
 
 
 # Ultra L2 depends on the following Spice products:
-# spacecraft clock kernel, leap seconds kernel, general frame kernel, pointing attitude kernel
-# science frame kernel - TODO: this is not yet available through the system
-# Specify frames kernel for all Ultra L2 ENA Maps
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# spacecraft clock kernel, leap seconds kernel, imap frame kernel, pointing attitude kernel, science frame kernel
+# Specify science_frames kernel for all Ultra L2 ENA Maps
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
 # Specify spacecraft_clock kernel for all Ultra L2 ENA Maps
 spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
@@ -653,43 +652,43 @@ pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-
 pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
 pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
 pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# Specify sci-frames kernel for all Ultra L2 ENA Maps (TODO:)
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# Specify imap frames kernel for all Ultra L2 ENA Maps
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
 
 # Ultra L3 survival probability map Dependencies:
 glows, l3e, ulc-sp, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -502,14 +502,6 @@ ultra, l1c, 45sensor-pset, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD, 
 ultra, l1c, 45sensor-pset, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD, DOWNSTREAM
 
 
-# Ultra L3 survival probability map Dependencies:
-glows, l3e, ulc-sp, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD, DOWNSTREAM
-ultra, l2, u90-ena-h-sf-full-hae-nside8-3mo, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD, DOWNSTREAM
-ephemeris_reconstructed, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-spacecraft_clock, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-leapseconds, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM
-
-
 # Ultra L2 depends on the following Spice products:
 # spacecraft clock kernel, leap seconds kernel, general frame kernel, pointing attitude kernel
 # science frame kernel - TODO: this is not yet available through the system
@@ -698,3 +690,10 @@ pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-
 # sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
 # sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
 # sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+
+# Ultra L3 survival probability map Dependencies:
+glows, l3e, ulc-sp, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD, DOWNSTREAM
+ultra, l2, u90-ena-h-sf-full-hae-nside8-3mo, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD, DOWNSTREAM
+ephemeris_reconstructed, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -508,3 +508,13 @@ ultra, l2, u90-ena-h-sf-full-hae-nside8-3mo, ultra, l3, u90-spx-hsf-sp-full-hae-
 ephemeris_reconstructed, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+
+
+# Ultra L2 depends on the following Spice products:
+# spacecraft clock kernel, leap seconds kernel, general frame kernel pointing attitude kernel
+# science frame kernel - TODO: this is not yet available through the system
+frames, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -511,10 +511,190 @@ leapseconds, spice, historical, ultra, l3, u90-spx-hsf-sp-full-hae-nside8-3mo, H
 
 
 # Ultra L2 depends on the following Spice products:
-# spacecraft clock kernel, leap seconds kernel, general frame kernel pointing attitude kernel
+# spacecraft clock kernel, leap seconds kernel, general frame kernel, pointing attitude kernel
 # science frame kernel - TODO: this is not yet available through the system
-frames, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
-spacecraft_clock, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
-leapseconds, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
-# sci-frames, spice, historical, ultra, l2, all, HARD_NO_TRIGGER, DOWNSTREAM
+# Specify frames kernel for all Ultra L2 ENA Maps
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# Specify spacecraft_clock kernel for all Ultra L2 ENA Maps
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# Specify leapseconds kernel for all Ultra L2 ENA Maps
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# Specify pointing_attitude kernel for all Ultra L2 ENA Maps
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# Specify sci-frames kernel for all Ultra L2 ENA Maps (TODO:)
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo, HARD_NO_TRIGGER, DOWNSTREAM
+# sci-frames, spice, historical, ultra, l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo, HARD_NO_TRIGGER, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview
Add the L2 Spice requirements for Ultra. 

Closes #622 

Ultra L2 needs the following kernels:
1. spacecraft clock
2. leapseconds
3. pointing_attitude
4. frames
5. **TODO: science frames kernel**

The science frames kernel is not yet available in the system - I will wait to merge this PR until it is. 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- dependency_config.csv
   - Add kernels as Ultra dependencies

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
None