### PR TITLE
SWAPI: updating HK l1b dependency

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -302,7 +302,7 @@ leapseconds, spice, historical, swapi, l1, hk, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, swapi, l1, hk, HARD_NO_TRIGGER, DOWNSTREAM
 
 swapi, l0, raw, swapi, l1, sci, HARD, DOWNSTREAM
-swapi, l1, hk, swapi, l1, sci, HARD, DOWNSTREAM
+swapi, l1b, hk, swapi, l1, sci, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l1, sci, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, swapi, l1, sci, HARD_NO_TRIGGER, DOWNSTREAM
 


### PR DESCRIPTION
# Change Summary

## Overview
This small change is support changes coming from `imap_processing`.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - update HK dependency to l1b now.

