### PR TITLE
Harrison L3 2569 - Update CoDICE L3a dependency config

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -45,16 +45,16 @@ mag, l1d, norm-mago, codice, l3b, hi-pitch-angle, HARD, DOWNSTREAM
 codice, l2, hi-sectored, codice, l3b, hi-pitch-angle, HARD, DOWNSTREAM
 
 codice, l3a, lo-direct-events, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
-codice, l1a, lo-sw-priority, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
-codice, l1a, lo-nsw-priority, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
+codice, l1a, lo-sw-priority, codice, l3a, lo-hplus-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
+codice, l1a, lo-nsw-priority, codice, l3a, lo-hplus-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-geometric-factors, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-energy-per-charge, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-hplus-efficiency, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
 
 codice, l3a, lo-direct-events, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
-codice, l1a, lo-sw-priority, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
-codice, l1a, lo-nsw-priority, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
+codice, l1a, lo-sw-priority, codice, l3a, lo-heplus2-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
+codice, l1a, lo-nsw-priority, codice, l3a, lo-heplus2-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-geometric-factors, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-energy-per-charge, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
@@ -62,16 +62,16 @@ codice, ancillary, lo-heplus2-efficiency, codice, l3a, lo-heplus2-3d-distributio
 
 
 codice, l3a, lo-direct-events, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
-codice, l1a, lo-sw-priority, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
-codice, l1a, lo-nsw-priority, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
+codice, l1a, lo-sw-priority, codice, l3a, lo-oplus6-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
+codice, l1a, lo-nsw-priority, codice, l3a, lo-oplus6-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-geometric-factors, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-energy-per-charge, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-oplus6-efficiency, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 
 codice, l3a, lo-direct-events, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
-codice, l1a, lo-sw-priority, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
-codice, l1a, lo-nsw-priority, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
+codice, l1a, lo-sw-priority, codice, l3a, lo-heplus-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
+codice, l1a, lo-nsw-priority, codice, l3a, lo-heplus-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-geometric-factors, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-energy-per-charge, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -32,7 +32,7 @@ codice, ancillary, mass-per-charge, codice, l3a, lo-partial-densities, HARD, DOW
 codice, l1a, lo-sw-priority, codice, l3a, lo-direct-events, HARD, DOWNSTREAM
 codice, l1a, lo-nsw-priority, codice, l3a, lo-direct-events, HARD, DOWNSTREAM
 codice, l2, lo-direct-events, codice, l3a, lo-direct-events, HARD, DOWNSTREAM
-codice, ancillary, lo-energy-per-charge, codice, l3a,  lo-direct-events, HARD, DOWNSTREAM
+codice, ancillary, lo-energy-per-charge, codice, l3a, lo-direct-events, HARD, DOWNSTREAM
 codice, ancillary, mass-coefficient-lookup, codice, l3a, lo-direct-events, HARD, DOWNSTREAM
 
 codice, l3a, lo-partial-densities, codice, l3a, lo-sw-ratios, HARD, DOWNSTREAM
@@ -55,9 +55,9 @@ codice, ancillary, lo-hplus-efficiency, codice, l3a, lo-hplus-3d-distribution, H
 codice, l3a, lo-direct-events, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 codice, l1a, lo-sw-priority, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 codice, l1a, lo-nsw-priority, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-mass-species-bin-lookup, codice, l3a,  lo-heplus2-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-geometric-factors, codice, l3a,  lo-heplus2-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-energy-per-charge, codice, l3a,  lo-heplus2-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, lo-geometric-factors, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, lo-energy-per-charge, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-heplus2-efficiency, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 
 
@@ -65,16 +65,16 @@ codice, l3a, lo-direct-events, codice, l3a, lo-oplus6-3d-distribution, HARD, DOW
 codice, l1a, lo-sw-priority, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 codice, l1a, lo-nsw-priority, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-geometric-factors, codice, l3a,  lo-oplus6-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-energy-per-charge, codice, l3a,  lo-oplus6-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, lo-geometric-factors, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, lo-energy-per-charge, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-oplus6-efficiency, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 
 codice, l3a, lo-direct-events, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 codice, l1a, lo-sw-priority, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 codice, l1a, lo-nsw-priority, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-geometric-factors, codice, l3a,  lo-heplus-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-energy-per-charge, codice, l3a,  lo-heplus-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, lo-geometric-factors, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, lo-energy-per-charge, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-heplus-efficiency, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 
 # <---- `GLOWS` Dependencies ---->


### PR DESCRIPTION
# Change Summary

## Overview
Some of our dependency config lines had 2 spaces in front of the output descriptor which we believe was causing them to be
read incorrectly. 

## Updated Files
dependency_config.csv
 - removed whitespaces on CoDICE 3d distribution lines
