### PR TITLE
Fix end_time when making a call to the metakernel api 

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -616,6 +616,7 @@ def get_latest_repoint_file(end_date: datetime) -> Optional[str]:
     return basename(latest[2])
 
 
+# ruff: noqa: PLR0915
 def get_upstream_dependency_inputs(
     dependencies: list,
     start_date: datetime,
@@ -682,13 +683,11 @@ def get_upstream_dependency_inputs(
             # convert start_date and end_date in seconds after j2000.
             # TODO: remove this once Bryan changes takes in 'yyyymmdd' format
             def yyyymmdd_to_seconds_since_j2000(
-                date_str: str, end_date_input=False
+                date_str: str, add_24_hrs=False
             ) -> float:
                 # Parse input date string
                 dt = datetime.strptime(date_str, "%Y%m%d").replace(tzinfo=timezone.utc)
-                # If the input date is the end date, add 24 hours so files through that
-                # date are included.
-                if end_date_input:
+                if add_24_hrs:
                     dt += timedelta(hours=24)
                 # Define J2000 epoch: 2000-01-01T12:00:00 UTC
                 j2000 = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
@@ -699,8 +698,9 @@ def get_upstream_dependency_inputs(
 
             start_time = yyyymmdd_to_seconds_since_j2000(start_date.strftime("%Y%m%d"))
             # TODO revisit setting end_time after SIT-4. This should be handled upstream
+            add_24_hrs = True if end_date == start_date else False
             end_time = yyyymmdd_to_seconds_since_j2000(
-                end_date.strftime("%Y%m%d"), True
+                end_date.strftime("%Y%m%d"), add_24_hrs
             )
             metakernel_response = spice_metakernel_api.lambda_handler(
                 {

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -698,6 +698,7 @@ def get_upstream_dependency_inputs(
                 return delta.total_seconds()
 
             start_time = yyyymmdd_to_seconds_since_j2000(start_date.strftime("%Y%m%d"))
+            # TODO revisit setting end_time after SIT-4. This should be handled upstream
             end_time = yyyymmdd_to_seconds_since_j2000(
                 end_date.strftime("%Y%m%d"), True
             )

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from os.path import basename
 from pathlib import Path
 from typing import Optional
@@ -681,10 +681,15 @@ def get_upstream_dependency_inputs(
 
             # convert start_date and end_date in seconds after j2000.
             # TODO: remove this once Bryan changes takes in 'yyyymmdd' format
-            def yyyymmdd_to_seconds_since_j2000(date_str: str) -> float:
+            def yyyymmdd_to_seconds_since_j2000(
+                date_str: str, end_date_input=False
+            ) -> float:
                 # Parse input date string
                 dt = datetime.strptime(date_str, "%Y%m%d").replace(tzinfo=timezone.utc)
-
+                # If the input date is the end date, add 24 hours to it because files
+                # through that day are valid.
+                if end_date_input:
+                    dt += timedelta(hours=24)
                 # Define J2000 epoch: 2000-01-01T12:00:00 UTC
                 j2000 = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
@@ -693,7 +698,9 @@ def get_upstream_dependency_inputs(
                 return delta.total_seconds()
 
             start_time = yyyymmdd_to_seconds_since_j2000(start_date.strftime("%Y%m%d"))
-            end_time = yyyymmdd_to_seconds_since_j2000(end_date.strftime("%Y%m%d"))
+            end_time = yyyymmdd_to_seconds_since_j2000(
+                end_date.strftime("%Y%m%d"), True
+            )
             metakernel_response = spice_metakernel_api.lambda_handler(
                 {
                     "queryStringParameters": {

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -686,8 +686,8 @@ def get_upstream_dependency_inputs(
             ) -> float:
                 # Parse input date string
                 dt = datetime.strptime(date_str, "%Y%m%d").replace(tzinfo=timezone.utc)
-                # If the input date is the end date, add 24 hours to it because files
-                # through that day are valid.
+                # If the input date is the end date, add 24 hours so files through that
+                # date are included.
                 if end_date_input:
                     dt += timedelta(hours=24)
                 # Define J2000 epoch: 2000-01-01T12:00:00 UTC


### PR DESCRIPTION
# Change Summary

## Overview
@subagonsouth and I noticed that the start/ end_date query parameters to the metakernel api, were being set to that date at 00:00. When start date == end, ( as is the case for many jobs during normal processing/ reprocessing) It was only querying for files at that exact day/hour/minute. See log below from the metakernel API:

logger:INFO Attempting to find file to cover 813931200 to 813931200

This resulted in some files not being returned. To fix this Tim proposed adding 24 hours to the end date. This will still need to be revisited after SIT-4 because there are still issues for instruments that have data for a Pointing rather than a Day.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
   - After parsing end_date into a string, add 24 hours to that value so the metakernel API returns files through that date. 
