### PR TITLE
MNT: Removing unused usernames field

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -16,7 +16,6 @@
   },
   "context": {
     "account_name": "dev",
-    "usernames": ["sandoval"],
     "backup": {
       "account": "012345678901",
       "source_account": "dev"

--- a/docs/source/cdk/cdk-deployment-personal-aws.rst
+++ b/docs/source/cdk/cdk-deployment-personal-aws.rst
@@ -31,8 +31,7 @@ For example::
 
 *Do not put a domain field for your personal context*
 
-8. In ``cdk.json``, replace the usernames in the list so that it only contains the username from your personal AWS account (the user created in step 2).
-9. In your local terminal, go to the top of the ``sds-data-manager`` repository and run the following:
+8. In your local terminal, go to the top of the ``sds-data-manager`` repository and run the following:
     a. ``cdk bootstrap --profile my_profile --context account_name=my_context``
     b. ``cdk synth --profile my_profile --context account_name=my_context``
     c. ``cdk deploy --profile my_profile --context account_name=my_context``
@@ -47,4 +46,4 @@ For example::
             29143fef993fc62aeb3447a224679eafa9e60eaba00aa3bfaa60f0de9f9815bb: digest: sha256:e3c8f122ade7a0c1f598b3c7bbc08488c694aa9b7279e1367227ed0d0fba6c33 size: 2628
 
         there's no prompt and it hangs there forever. However, if I hit ``Enter``, a ``y/n`` prompt appears asking if I want to deploy. So if it gets stuck at that point, hit ``Enter``, then you can select ``y``.
-10. Before committing any changes, make sure to revert your ``cdk.json`` file to its original state.
+9. Before committing any changes, make sure to revert your ``cdk.json`` file to its original state.

--- a/sds_data_manager/constructs/ecr_construct.py
+++ b/sds_data_manager/constructs/ecr_construct.py
@@ -39,26 +39,4 @@ class EcrConstruct(Construct):
             image_scan_on_push=True,
         )
 
-        # TODO: remove these lines or find replacement. This is causing an error.
-        # # Grant access to developers to push ECR Images to be used by the batch job
-        # ecr_authenticators = iam.Group(self, "EcrAuthenticators")
-
-        # # Allows members of this group to get the auth token for `docker login`
-        # ecr.AuthorizationToken.grant_read(ecr_authenticators)
-
-        # # Grant permissions to the group to pull and push images
-        # self.container_repo.grant_pull_push(ecr_authenticators)
-
-        # Add each of the SDC devs to the newly created group
-        # TODO: should we remove this?
-        # Error from this line:
-        # The stack named loEcr failed creation, it may need to
-        # be manually deleted from the AWS console: ROLLBACK_COMPLETE:
-        # The maximum number of groups per user is exceeded for user: sandoval.
-        # (Service: AmazonIdentityManagement; Status Code: 409; Error Code:
-        # LimitExceeded; Request ID: 71ba3c0c-2be1-45e8-87cd-f1645fa49a94; Proxy: null)
-        # for username in self.node.try_get_context("usernames"):
-        #     user = iam.User.from_user_name(self, username, user_name=username)
-        #     ecr_authenticators.add_user(user)
-
         self.container_repo.apply_removal_policy(RemovalPolicy.RETAIN)


### PR DESCRIPTION
# Change Summary

## Overview

This cleans up the cdk.json file to remove the usernames which we aren't using and the associated commented out code. If we do go that direction we can add it back in later, but I don't think we should use this to control access to the ECRs.