### PR TITLE
MNT: Fix for SIT-4 account URL for batch job

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -23,12 +23,17 @@
     },
     "dev": {
       "account": "449431850278",
-      "domain_name": "dev.imap-mission.com",
+      "domain_name": "api.dev.imap-mission.com",
       "region": "us-west-2"
     },
     "prod": {
       "account": "593025701104",
-      "domain_name": "imap-mission.com",
+      "domain_name": "api.prod.imap-mission.com",
+      "region": "us-west-2"
+    },
+    "sit4": {
+      "account": "038462760545",
+      "domain_name": "ak8fyo0zrb.execute-api.us-west-2.amazonaws.com",
       "region": "us-west-2"
     },
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -100,7 +100,7 @@ class ProcessingConstruct(Construct):
                 cpu=1,
                 environment={
                     "IMAP_DATA_DIR": "/mnt/data",
-                    "IMAP_DATA_ACCESS_URL": f"https://api.{self.node.get_context('account_name')}.imap-mission.com",
+                    "IMAP_DATA_ACCESS_URL": f"https://{self.node.get_context('account_name')['domain_name']}",
                 },
                 volumes=self.volumes,
                 # TODO: Do we need to explicitly specify architecture and OS family?

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -85,6 +85,9 @@ class ProcessingConstruct(Construct):
             removal_policy=cdk.RemovalPolicy.DESTROY,
         )
         # Create the job definition
+        account_name = self.node.get_context("account_name")
+        account_config = self.node.get_context(account_name)
+        domain_name = account_config["domain_name"]
         batch.EcsJobDefinition(
             self,
             f"ProcessingJob-{job_name}",
@@ -100,7 +103,7 @@ class ProcessingConstruct(Construct):
                 cpu=1,
                 environment={
                     "IMAP_DATA_DIR": "/mnt/data",
-                    "IMAP_DATA_ACCESS_URL": f"https://{self.node.get_context('account_name')['domain_name']}",
+                    "IMAP_DATA_ACCESS_URL": f"https://{domain_name}",
                 },
                 volumes=self.volumes,
                 # TODO: Do we need to explicitly specify architecture and OS family?


### PR DESCRIPTION
# Change Summary

## Overview
This is fixing being able to set different `DATA_ACCESS_URL` for SIT-4 and other cases.

## Updated Files
- cdk.json
   - add SIT-4 domain URL
- sds_data_manager/constructs/processing_construct.py
   - refactor code to read in cdk.json changes


