### PR TITLE
SQS decrease retry count 

### DIFF
--- a/sds_data_manager/constructs/sqs_construct.py
+++ b/sds_data_manager/constructs/sqs_construct.py
@@ -54,9 +54,9 @@ class SqsConstruct(Construct):
             # This is required. It removes messages with identical content. Since
             # the event includes a filename each event should be totally unique.
             content_based_deduplication=True,
-            # The dead letter queue will take messages that failed retry 20 times.
+            # The dead letter queue will take messages that failed retry.
             dead_letter_queue=aws_sqs.DeadLetterQueue(
-                max_receive_count=3, queue=self.dead_letter_queue
+                max_receive_count=1, queue=self.dead_letter_queue
             ),
         )
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -448,8 +448,8 @@ idex, l1a, sci-1week, idex, l1b, sci-1week, HARD, DOWNSTREAM
 spin, spin, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 leapseconds, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
-ephemeris_reconstructed, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
+ephemeris_reconstructed, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
+attitude_history, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 
@@ -650,7 +650,7 @@ ultra, l1b, 45sensor-extendedspin,ultra, l1b, 45sensor-cullingmask, HARD, DOWNST
 ultra, l1b, 45sensor-extendedspin,ultra, l1b, 45sensor-badtimes, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-cullingmask,ultra, l1b, 45sensor-badtimes, HARD, DOWNSTREAM
 
-ultra, ancillary, 45sensor-logistic-interpolation, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
+ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
 
 spacecraft_clock, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1063,6 +1063,18 @@ def test_dependency_success():
             "descriptor": "historical",
             "relationship": "HARD",
         },
+        {
+            "data_source": "ephemeris_reconstructed",
+            "data_type": "spice",
+            "descriptor": "historical",
+            "relationship": "HARD",
+        },
+        {
+            "data_source": "attitude_history",
+            "data_type": "spice",
+            "descriptor": "historical",
+            "relationship": "HARD",
+        },
     ]
 
 


### PR DESCRIPTION
# Change Summary

## Overview
Reduce sqs retry count to 1. We want failed events to move directly into the dead letter queue. 

## Updated Files
- sds_data_manager/constructs/sqs_construct.py
   - Reduce retry count. 
