### PR TITLE
BUG FIX for niche case with multiple dependent ancillary files

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -437,7 +437,8 @@ def submit_all_jobs(session, job_node, start_date, end_date, filter_dependencies
     )
     if not upstream_dependencies:
         logger.info(
-            f"Skiping job submission for {job_node} because no upstream dependencies."
+            f"Skipping job submission for {job_node} because of a missing upstream "
+            f"dependency."
         )
         return
 
@@ -473,6 +474,12 @@ def submit_all_jobs(session, job_node, start_date, end_date, filter_dependencies
                 start_date=filepath.start_date,
                 end_date=filepath.start_date,
             )
+            if not upstream_deps_for_job:
+                logger.info(
+                    f"Skipping job submission for {job_node} with start_date: "
+                    f"{start_date} because of a missing upstream dependency."
+                )
+                continue
         else:
             upstream_deps_for_job = upstream_dependencies
         try_to_submit_job(

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import IntegrityError
 
 from sds_data_manager.lambda_code.SDSCode.database import models
 from sds_data_manager.lambda_code.SDSCode.database.models import (
+    AncillaryFiles,
     ProcessingJob,
     ScienceFiles,
     SPICEFiles,
@@ -267,6 +268,75 @@ def test_lambda_handler_missing_upstream_dependency(session, caplog):
         )
         # Verify the info statement was logged.
         assert log_str in caplog.text
+
+
+def test_lambda_handler_missing_dependency_for_start_date(session, caplog):
+    """Tests ``lambda_handler`` function for a specific case."""
+    # This test covers a rare scenario: when a new ancillary file is uploaded, the
+    # dependency handler might find jobs to run where the uploaded file is valid for the
+    # job's start_date, but another required ancillary file is not. The test ensures
+    # that in these cases, the job is skipped.
+
+    session.add_all(
+        [
+            ScienceFiles(
+                file_path="/path/to/imap_mag_l1c_norm-mago_20250418_v004.cdf",
+                instrument="mag",
+                data_level="l1c",
+                descriptor="norm-mago",
+                start_date=datetime(2025, 4, 18),
+                version="v004",
+                extension="cdf",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),
+            AncillaryFiles(
+                file_path="/path/to/imap_mag_l2-calibration_20250117_v001.cdf",
+                instrument="mag",
+                descriptor="l2-calibration",
+                start_date=datetime(2025, 1, 17),
+                version="v001",
+                extension="cdf",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),
+            AncillaryFiles(
+                file_path="/path/to/imap_mag_l2-norm-offsets_20250421_v001.cdf",
+                instrument="mag",
+                descriptor="l2-norm-offsets",
+                start_date=datetime(2025, 4, 21),
+                version="v001",
+                extension="cdf",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),
+        ]
+    )
+    multiple_events = {
+        "Records": [
+            {
+                "body": '{"detail": '
+                '{"object": {"key": "imap_mag_l2-calibration_20250117_v001.cdf"}}'
+                "}"
+            },
+        ]
+    }
+    caplog.set_level("INFO")
+    context = {"context": "sample_context"}
+    with patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client:
+        lambda_handler(multiple_events, context)
+        assert mock_batch_client.submit_job.call_count == 0
+
+    # Check that the expected message was logged.
+    expected_log = (
+        "Skipping job submission for {'data_source': 'mag', 'data_type': "
+        "'l2', 'descriptor': 'norm-srf'} with start_date: 20250117 because"
+        " of a missing upstream dependency."
+    )
+    assert expected_log in caplog.text
 
 
 ###### BULK REPROCESSING TESTS #######


### PR DESCRIPTION
# Change Summary

## Overview
This PR fixes a bug that was caused by a rare scenario: 

When a new ancillary file is uploaded, the dependency handler might find jobs to run where the uploaded file is valid for the job's start_date, but another required ancillary file is not. 

We recently updated the batch starter to check for upstream dependencies twice, once to get the start dates for the jobs to run and then second to get the dependencies for that specific start date. The first request checks if the value returned was None (meaning missing dependency) but the second request did not check this and caused an error when submitting the job with None type as the processingInputCollection. In the specific scenario above, the second request would determine that there was no valid file for the second required ancillary dependency, and return None, causing an error. 


## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Check if the second upstream dependency request returned None
   - If it did return none, log a message and continue with the next job. 