### PR TITLE
MNT: Use region-specific endpoint for presigned urls

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/download_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/download_api.py
@@ -91,6 +91,7 @@ def lambda_handler(event, context):
         "s3",
         region_name=region,
         config=botocore.client.Config(signature_version="s3v4"),
+        endpoint_url=f"https://s3.{region}.amazonaws.com",
     )
 
     # check if object exists

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
@@ -23,7 +23,10 @@ REGION = os.getenv("REGION")
 # to avoid any 307 redirects. (Generally only an issue on newly created buckets
 # where the DNS records haven't propagated yet)
 S3_CLIENT = boto3.client(
-    "s3", region_name=REGION, config=botocore.client.Config(signature_version="s3v4")
+    "s3",
+    region_name=REGION,
+    config=botocore.client.Config(signature_version="s3v4"),
+    endpoint_url=f"https://s3.{REGION}.amazonaws.com",
 )
 
 


### PR DESCRIPTION
# Change Summary

## Overview

With new data buckets, we get a 307 redirect (for up to 24-hours) which then causes the presigned url's to fail because the default endpoint doesn't exist yet and therefore the signatures don't match.

This change causes the pre-signed url that is returned to the users to contain the region specific endpoint of s3. So it looks like: `s3.us-west-2.aws.com` instead of the bare `s3.aws.com`.