### PR TITLE
Improve error message for duplicate ancillary file uploads (#478)

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
@@ -12,11 +12,15 @@ import os
 import boto3
 import botocore
 import imap_data_access
+            
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 BUCKET_NAME = os.getenv("S3_BUCKET")
+
+
 REGION = os.getenv("REGION")
 # The default presigned url signature does not include the region information
 # within the signature and we should be hitting the actual s3 region endpoint
@@ -58,10 +62,16 @@ def _generate_signed_upload_response(s3_key_path, tags=None):
     """
     if _file_exists(s3_key_path):
         # We already have a file at this location, return a 409
-        return {
-            "statusCode": 409,
-            "body": json.dumps(f"{s3_key_path} already exists."),
-        }
+        return  {
+        "statusCode": 409,
+        "body": json.dumps({
+            "error": "FileAlreadyExists",
+            "message": (
+                f"The file '{s3_key_path}' already exists in the storage system. "
+                "Please check the filename or delete the existing file before uploading again."
+            )
+        }),
+    }
     # We know there isn't an object at this location, so
     # generate a pre-signed URL for the client to upload to
     url = S3_CLIENT.generate_presigned_url(
@@ -146,3 +156,7 @@ def lambda_handler(event, context):
     )
 
     return _generate_signed_upload_response(s3_key_path_str)
+
+
+
+

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
@@ -12,8 +12,6 @@ import os
 import boto3
 import botocore
 import imap_data_access
-            
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -62,16 +60,18 @@ def _generate_signed_upload_response(s3_key_path, tags=None):
     """
     if _file_exists(s3_key_path):
         # We already have a file at this location, return a 409
-        return  {
-        "statusCode": 409,
-        "body": json.dumps({
-            "error": "FileAlreadyExists",
-            "message": (
-                f"The file '{s3_key_path}' already exists. "
-                "Rename it or remove the existing file before uploading again."
-            )
-        }),
-    }
+        return {
+            "statusCode": 409,
+            "body": json.dumps(
+                {
+                    "error": "FileAlreadyExists",
+                    "message": (
+                        f"The file '{s3_key_path}' already exists. "
+                        "Rename it or remove the existing file before uploading again."
+                    ),
+                }
+            ),
+        }
     # We know there isn't an object at this location, so
     # generate a pre-signed URL for the client to upload to
     url = S3_CLIENT.generate_presigned_url(
@@ -156,7 +156,3 @@ def lambda_handler(event, context):
     )
 
     return _generate_signed_upload_response(s3_key_path_str)
-
-
-
-

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
@@ -17,8 +17,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 BUCKET_NAME = os.getenv("S3_BUCKET")
-
-
 REGION = os.getenv("REGION")
 # The default presigned url signature does not include the region information
 # within the signature and we should be hitting the actual s3 region endpoint

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
@@ -67,8 +67,8 @@ def _generate_signed_upload_response(s3_key_path, tags=None):
         "body": json.dumps({
             "error": "FileAlreadyExists",
             "message": (
-                f"The file '{s3_key_path}' already exists in the storage system. "
-                "Please check the filename or delete the existing file before uploading again."
+                f"The file '{s3_key_path}' already exists. "
+                "Rename it or remove the existing file before uploading again."
             )
         }),
     }


### PR DESCRIPTION
# Change Summary

## Overview
- Improved the error message returned when a user attempts to upload an ancillary file that already exists in the storage system.
- Updated the response to follow a structured JSON format, consistent with science file uploads, making the message more user-friendly and informative.

## New Dependencies
- None

## New Files
- None

## Deleted Files
- None

## Updated Files
## Updated Files
- `sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py`
  - Modified the `_generate_signed_upload_response()` function.
  - Enhanced the duplicate file detection logic to return a structured JSON object with an `"error"` code and a detailed `"message"` when a duplicate ancillary file is detected.

## Testing
- Manual test conducted by mocking `_file_exists()` to return `True`.
- Verified that the returned error follows the desired format:
  ```json
  {
    "statusCode": 409,
    "body": {
      "error": "FileAlreadyExists",
      "message": "The file 'imap/ancillary/...' already exists in the storage system. Please check the filename or delete the existing file before uploading again."
    }
  }