### PR TITLE
MNT/FIX: removed EFS mount volume from batch. HIT L1B dep fix

### DIFF
--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -66,8 +66,6 @@ class ProcessingConstruct(Construct):
             ],
         )
 
-        self.volumes = volumes
-
     def add_job(self, job_name: str):
         """Create an ECR repo and a job definition for the given job.
 
@@ -99,10 +97,8 @@ class ProcessingConstruct(Construct):
                 memory=cdk.Size.mebibytes(4096),
                 cpu=1,
                 environment={
-                    "IMAP_DATA_DIR": "/mnt/data",
                     "IMAP_DATA_ACCESS_URL": f"https://api.{self.node.get_context('account_name')}.imap-mission.com",
                 },
-                volumes=self.volumes,
                 # TODO: Do we need to explicitly specify architecture and OS family?
                 #       We are building containers in GitHub Actions and need to
                 #       make sure these are aligned.

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -395,8 +395,8 @@ leapseconds, spice, historical, hit, l1a, all, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, hit, l1a, all, HARD_NO_TRIGGER, DOWNSTREAM
 
 hit, l0, raw, hit, l1b, hk, HARD, DOWNSTREAM
-leapseconds, spice, historical, hit, l1a, hk, HARD_NO_TRIGGER, DOWNSTREAM
-spacecraft_clock, spice, historical, hit, l1a, hk, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, hit, l1b, hk, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, hit, l1b, hk, HARD_NO_TRIGGER, DOWNSTREAM
 
 hit, l1a, counts, hit, l1b, all, HARD, DOWNSTREAM
 

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import imap_data_access
 from aws_cdk import App, Environment, Stack
-from aws_cdk import aws_batch as batch
 from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_lambda as lambda_
@@ -232,18 +231,8 @@ def build_sds(
     )
 
     # This valid instrument list is from imap-data-access package
-    processing_volumes = [
-        batch.EfsVolume(
-            name=f"{efs_instance.volume_name}-ECS-mount",
-            access_point_id=efs_instance.spice_access_point.access_point_id,
-            file_system=efs_instance.efs,
-            container_path="/mnt/data",
-            enable_transit_encryption=True,
-            transit_encryption_port=2049,
-        )
-    ]
     processing = processing_construct.ProcessingConstruct(
-        sdc_stack, "ProcessingConstruct", vpc=networking.vpc, volumes=processing_volumes
+        sdc_stack, "ProcessingConstruct", vpc=networking.vpc
     )
     for instrument in imap_data_access.VALID_INSTRUMENTS:
         for step in ["", "-l3"]:


### PR DESCRIPTION
# Change Summary

## Overview
This removes EFS volume from batch job. Because IMAP_DATA_DIR is EFS path, it was causing to download sci/anc into EFS volume. And in addition, some processing code was removing SPICE files from EFS as clean up, we think. Therefore, we removed EFS mount and let batch job download from API and load kernels that way. And we tested that it works in AWS and it worked even after removing EFS mount volume.

## Updated Files
- sds_data_manager/constructs/processing_construct.py
- sds_data_manager/utils/stackbuilder.py
   - remove volume from batch job construct
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - update HIT depedency

