### PR TITLE
MNT/ENH: Add bucket replication configuration to the CDK

### DIFF
--- a/docs/source/cdk/backup-deploy.rst
+++ b/docs/source/cdk/backup-deploy.rst
@@ -12,7 +12,6 @@ Steps for deploying
 #. Set your ``AWS_PROFILE`` environment variable to the backup account profile
 #. Set the ``source_account`` variable in the "backup" section of the cdk.json file to the account number for the _source_ bucket (where the backed up items originate)
 #. Update the ``account_name`` variable in the ``cdk.json`` file to "backup"
-#. Finally, you will need to copy the Role arn deployed in SdsDataManager into :file:`sds_data_manager/stacks/backup_bucket_construct.py`. This arn can be found by going to the IAM console in the source account and searching for "BackupRole".
 #. Run your ``cdk bootstrap`` command if you haven't already done so for the backup account.
 #. Run ``cdk synth --context account_name=backup`` and check to confirm that the only stack being deployed is the "BackupBucket" stack
 #. Run ``cdk deploy --context account_name=backup`` to deploy!

--- a/docs/source/cdk/s3-replication.rst
+++ b/docs/source/cdk/s3-replication.rst
@@ -1,31 +1,21 @@
 S3 Replication
 ==============
 
-Once you have finished :doc:`backup-deploy`, you can set up replication in the source bucket.
-
-Create a replication rule
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-#. Open your source S3 bucket in the AWS console
-#. Under the "Management" tab, find the "Replication Rules" section
-#. Click "Create replication rule" to create a new rule
-#. Enter an ID. If this is a developer bucket, include your initials. Preferably, it should be clear this is a backup rule.
-#. Under "Source Bucket", select "Apply to all objects in this bucket"
-#. Under "Destination" select "Specify a bucket in another account" and enter the account number and bucket name
-#. Under "IAM role", select the "SdsDataManager-{account_name}-BackupRole"
-#. Then, save the rule, and select "Do not replicate existing objects" in the popup
-
-Now, items placed in the source bucket will be automatically replicated to the backup bucket!
+Once you have finished :doc:`backup-deploy`, the new items are automatically replicated
+from the source bucket to the backup bucket.
 
 Copying items back into source account bucket
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To restore files from the backup bucket into the main account bucket, we are going to [assume the role](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-role-prereqs) created by SdsDataManager stack in the source account. Here, "source account" refers to the account with SdsDataManager deployed into it (i.e. dev or prod).
+To restore files from the backup bucket into the main account bucket, we are going to
+[assume the role](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-role-prereqs)
+created by SdsDataManager stack in the source account. Here, "source account" refers to
+the account with SdsDataManager deployed into it (i.e. dev or prod).
 
 #. Update ``~/.aws/config`` to include a new profile for this role. Here, ``source_profile`` should be the source account profile
 ```
 [profile backup-role]
-role_arn = arn:aws:iam::<source account number>:role/<role name>
+role_arn = arn:aws:iam::<source account number>:role/BackupRole
 source_profile = imap
 ```
 #. Update the role in the dev account to include a new principal:

--- a/docs/source/cdk/s3-replication.rst
+++ b/docs/source/cdk/s3-replication.rst
@@ -9,8 +9,8 @@ Copying items back into source account bucket
 
 To restore files from the backup bucket into the main account bucket, we are going to
 [assume the role](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-role-prereqs)
-created by SdsDataManager stack in the source account. Here, "source account" refers to
-the account with SdsDataManager deployed into it (i.e. dev or prod).
+created by SDCStack stack in the source account. Here, "source account" refers to
+the account with SDCStack deployed into it (i.e. dev or prod).
 
 #. Update ``~/.aws/config`` to include a new profile for this role. Here, ``source_profile`` should be the source account profile
 ```

--- a/sds_data_manager/constructs/backup_bucket_construct.py
+++ b/sds_data_manager/constructs/backup_bucket_construct.py
@@ -14,15 +14,7 @@ class BackupBucket(Construct):
     should be the AWS account for the source bucket.
 
     For replication to work, you also need to deploy SdsDataManager and create
-    the source bucket and replication role. Then, you need to manually update
-    the role_arn variable with the replication role created.
-
-    Finally, you need to set up the replication rule in the **source** account.
-    To do this, go to the source bucket and click the "Management" tab.
-    Under the "Replication Rules" section, create a replication rule. Specify
-    your bucket, select the IAM Role "BackupRole" created in SdsDataManager, and
-    save the rule. This rule can be set up after both source and destination
-    stacks are deployed.
+    the source bucket and replication role.
     """
 
     def __init__(
@@ -48,13 +40,10 @@ class BackupBucket(Construct):
         """
         super().__init__(scope, construct_id, **kwargs)
 
-        # FOR NOW: Deploy other stack, update this name with the created role.
-        role_arn = (
-            "arn:aws:iam::449431850278:"
-            "role/SdsDataManager-mh-dev-BackupRoleF43CFD90-FXUPB8TEP0P0"
-        )
+        # NOTE: This requires the source account to have this specific BackupRole
+        #       which we create in the data_bucket_construct
+        role_arn = f"arn:aws:iam::{source_account}:role/BackupRole"
 
-        # This is the S3 bucket used by upload_api_lambda
         backup_bucket = s3.Bucket(
             self,
             "BackupDataBucket",

--- a/sds_data_manager/constructs/backup_bucket_construct.py
+++ b/sds_data_manager/constructs/backup_bucket_construct.py
@@ -13,7 +13,7 @@ class BackupBucket(Construct):
     account. The source_account is a required parameter. This source account
     should be the AWS account for the source bucket.
 
-    For replication to work, you also need to deploy SdsDataManager and create
+    For replication to work, you also need to deploy SDCStack and create
     the source bucket and replication role.
     """
 

--- a/sds_data_manager/constructs/data_bucket_construct.py
+++ b/sds_data_manager/constructs/data_bucket_construct.py
@@ -109,3 +109,28 @@ class DataBucketConstruct(Construct):
         backup_role.add_to_policy(s3_backup_bucket_items_policy)
         backup_role.add_to_policy(s3_backup_bucket_policy)
         backup_role.add_to_policy(s3_write_policy)
+
+        # Add replication configuration to the data bucket
+        # accesses the raw cloudformation L1 constructs which is necessary
+        # because the l2 constructs do not support replication configuration
+        bucket_cf: s3.CfnBucket = self.data_bucket.node.default_child
+        bucket_cf.replication_configuration = s3.CfnBucket.ReplicationConfigurationProperty(  # noqa: E501
+            role=backup_role.role_arn,
+            rules=[
+                s3.CfnBucket.ReplicationRuleProperty(
+                    id="ReplicateToBackup",
+                    status="Enabled",
+                    priority=1,
+                    delete_marker_replication=s3.CfnBucket.DeleteMarkerReplicationProperty(
+                        status="Disabled"
+                    ),
+                    destination=s3.CfnBucket.ReplicationDestinationProperty(
+                        bucket=f"arn:aws:s3:::{backup_bucket_name}",
+                        # TODO: Enable deep archive storage class for backups that
+                        #       are accessed infrequently.
+                        # storage_class="DEEP_ARCHIVE",
+                    ),
+                    filter=s3.CfnBucket.ReplicationRuleFilterProperty(prefix=""),
+                )
+            ],
+        )

--- a/sds_data_manager/constructs/data_bucket_construct.py
+++ b/sds_data_manager/constructs/data_bucket_construct.py
@@ -33,13 +33,13 @@ class DataBucketConstruct(Construct):
         """
         super().__init__(scope, construct_id, **kwargs)
         # Get the current account number so we can use it in the bucket names
-        account = env.account
+        self.account = env.account
 
         # This is the S3 bucket used by upload_api_lambda
         self.data_bucket = s3.Bucket(
             self,
             "DataBucket",
-            bucket_name=f"sds-data-{account}",
+            bucket_name=f"sds-data-{self.account}",
             versioned=True,
             event_bridge_enabled=True,
             removal_policy=RemovalPolicy.RETAIN,
@@ -47,6 +47,15 @@ class DataBucketConstruct(Construct):
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
         )
 
+    def setup_backup_replication(self) -> None:
+        """Add the backup replication to the data bucket.
+
+        This sets up the replication configuration for the data bucket to
+        replicate data to a backup bucket in another account. The backup bucket
+        is assumed to already exist and is named based on the source account
+        number and "backup". The replication role is created in the source account
+        and is assumed by the S3 service to perform the replication.
+        """
         s3_write_policy = iam.PolicyStatement(
             effect=iam.Effect.ALLOW,
             actions=["s3:PutObject"],
@@ -74,7 +83,7 @@ class DataBucketConstruct(Construct):
         # Rather than depending on the deploy in another account through CDK,
         # we can assume the backup bucket already exists and go from here.
         # Consisting of the source account number (this account) and "backup"
-        backup_bucket_name = f"sds-data-{account}-backup"
+        backup_bucket_name = f"sds-data-{self.account}-backup"
 
         s3_backup_bucket_items_policy = iam.PolicyStatement(
             effect=iam.Effect.ALLOW,

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -124,6 +124,11 @@ def build_sds(
     data_bucket = data_bucket_construct.DataBucketConstruct(
         scope=sdc_stack, construct_id="DataBucket", env=env
     )
+    # Only setup replication for the production account
+    # XXX: Temporarily also for SIT-4 to test replication
+    #       This should be removed once SIT-4 is no longer used
+    if account_config["account_name"] in ("prod", "sit-4"):
+        data_bucket.setup_backup_replication()
 
     monitoring = monitoring_construct.MonitoringConstruct(
         scope=sdc_stack,

--- a/tests/infrastructure/test_backup_bucket_stack.py
+++ b/tests/infrastructure/test_backup_bucket_stack.py
@@ -114,7 +114,7 @@ def test_s3_data_bucket_policy_resource_properties(template):
                         ],
                         "Effect": "Allow",
                         "Principal": {
-                            "AWS": Match.string_like_regexp(".*SdsDataManager.*")
+                            "AWS": Match.string_like_regexp(".*BackupRole.*")
                         },
                         "Resource": {
                             "Fn::Join": [
@@ -141,7 +141,7 @@ def test_s3_data_bucket_policy_resource_properties(template):
                         ],
                         "Effect": "Allow",
                         "Principal": {
-                            "AWS": Match.string_like_regexp(".*SdsDataManager.*")
+                            "AWS": Match.string_like_regexp(".*BackupRole.*")
                         },
                         "Resource": {
                             "Fn::GetAtt": [

--- a/tests/infrastructure/test_data_bucket.py
+++ b/tests/infrastructure/test_data_bucket.py
@@ -9,7 +9,8 @@ from sds_data_manager.constructs.data_bucket_construct import DataBucketConstruc
 @pytest.fixture
 def template(stack, env):
     """Return a template for the data bucket stack."""
-    DataBucketConstruct(stack, "data-bucket", env=env)
+    data_stack = DataBucketConstruct(stack, "data-bucket", env=env)
+    data_stack.setup_backup_replication()
     template = Template.from_stack(stack)
 
     return template

--- a/tests/infrastructure/test_indexer_lambda_construct.py
+++ b/tests/infrastructure/test_indexer_lambda_construct.py
@@ -51,6 +51,6 @@ def template(stack, env, code):
 
 def test_indexer_role(template):
     """Ensure the template has appropriate IAM roles."""
-    template.resource_count_is("AWS::IAM::Role", 5)
+    template.resource_count_is("AWS::IAM::Role", 4)
     # 4 for RDS stack + 1 for indexer lambda
     template.resource_count_is("AWS::Lambda::Function", 4)

--- a/tests/infrastructure/test_sds_api_manager_construct.py
+++ b/tests/infrastructure/test_sds_api_manager_construct.py
@@ -42,6 +42,6 @@ def template(stack, env):
 
 def test_indexer_role(template):
     """Ensure that the template has appropriate IAM roles."""
-    template.resource_count_is("AWS::IAM::Role", 9)
+    template.resource_count_is("AWS::IAM::Role", 8)
     # Ensure that the template has appropriate lambda count
     template.resource_count_is("AWS::Lambda::Function", 8)


### PR DESCRIPTION
Right now we have this specified as manual steps to go in and update it in the console. We can create the replication rule with L1 constructs, so not as elegant as the L2 methods, but still doable in code rather than manual intervention.

The backup bucket arn needs to exist for this deployment to work.