### PR TITLE
Added CoDICE l1a->l2 direct event dependencies

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -6,8 +6,6 @@ codice, l0, raw, codice, l1a, all, HARD, DOWNSTREAM
 leapseconds, spice, historical, codice, l1a, all, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, codice, l1a, all, HARD_NO_TRIGGER, DOWNSTREAM
 
-# CoDICE l1a to l1b
-
 codice, l1a, hskp, codice, l1b, hskp, HARD, DOWNSTREAM
 codice, l1a, lo-counters-aggregated, codice, l1b, lo-counters-aggregated, HARD, DOWNSTREAM
 codice, l1a, lo-counters-singles, codice, l1b, lo-counters-singles, HARD, DOWNSTREAM
@@ -25,6 +23,9 @@ codice, l1a, hi-omni, codice, l1b, hi-omni, HARD, DOWNSTREAM
 codice, l1a, hi-sectored, codice, l1b, hi-sectored, HARD, DOWNSTREAM
 codice, l1a, lo-ialirt, codice, l1b, lo-ialirt, HARD, DOWNSTREAM
 codice, l1a, hi-ialirt, codice, l1b, hi-ialirt, HARD, DOWNSTREAM
+
+codice, l1a, lo-pha, codice, l2, lo-direct-events, HARD, DOWNSTREAM
+codice, l1a, hi-pha, codice, l2, hi-direct-events, HARD, DOWNSTREAM
 
 codice, l2, lo-sw-species, codice, l3a, lo-partial-densities, HARD, DOWNSTREAM
 codice, ancillary, mass-per-charge, codice, l3a, lo-partial-densities, HARD, DOWNSTREAM


### PR DESCRIPTION
This PR updates the CoDICE dependencies to include the processing of L1a `lo-pha` and `hi-pha` data products into L2 direct event data products. This supports https://github.com/IMAP-Science-Operations-Center/imap_processing/pull/1810