### PR TITLE
Add retry strategy for batch jobs 

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -34,6 +34,19 @@ logger.setLevel(logging.INFO)
 
 # Create a batch client
 BATCH_CLIENT = boto3.client("batch", region_name="us-west-2")
+# Define the retry strategy for batch jobs
+BATCH_JOB_RETRY_STRATEGY = (
+    {
+        "attempts": 2,
+        "evaluateOnExit": [
+            {
+                "onStatusReason": "Your Spot Task was interrupted.",
+                "action": "RETRY",
+            },
+            {"onReason": "*", "action": "EXIT"},
+        ],
+    },
+)
 # Create an sqs client
 SQS_CLIENT = boto3.client("sqs", region_name="us-west-2")
 
@@ -398,16 +411,7 @@ def try_to_submit_job(
         containerOverrides={
             "command": batch_command,
         },
-        retryStrategy={
-            "attempts": 3,
-            "evaluateOnExit": [
-                {
-                    "onStatusReason": "Your Spot Task was interrupted.",
-                    "action": "RETRY",
-                },
-                {"onReason": "*", "action": "EXIT"},
-            ],
-        },
+        retryStrategy=BATCH_JOB_RETRY_STRATEGY,
     )
     logger.info(f"Submitted job {job_name} with this command: {batch_command}")
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -398,6 +398,16 @@ def try_to_submit_job(
         containerOverrides={
             "command": batch_command,
         },
+        retryStrategy={
+            "attempts": 3,
+            "evaluateOnExit": [
+                {
+                    "onStatusReason": "Your Spot Task was interrupted.",
+                    "action": "RETRY",
+                },
+                {"onReason": "*", "action": "EXIT"},
+            ],
+        },
     )
     logger.info(f"Submitted job {job_name} with this command: {batch_command}")
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -42,6 +42,14 @@ from .conftest import (
     _populate_file_catalog,
 )
 
+batch_job_retry_strategy = {
+    "attempts": 3,
+    "evaluateOnExit": [
+        {"onStatusReason": "Your Spot Task was interrupted.", "action": "RETRY"},
+        {"onReason": "*", "action": "EXIT"},
+    ],
+}
+
 
 def _populate_processing_table(session):
     """Add test data to database."""
@@ -107,6 +115,7 @@ def test_lambda_handler(session):
                     "--upload-to-sdc",
                 ]
             },
+            retryStrategy=batch_job_retry_strategy,
         )
         mock_sqs_client.delete_message.assert_called_once()
 
@@ -196,6 +205,7 @@ def test_lambda_handler_ancillary_event(session):
                     "--upload-to-sdc",
                 ]
             },
+            retryStrategy=batch_job_retry_strategy,
         )
 
 
@@ -541,6 +551,7 @@ def test_idex_l2b(session):
                     "--upload-to-sdc",
                 ]
             },
+            retryStrategy=batch_job_retry_strategy,
         )
 
 
@@ -690,6 +701,7 @@ def test_ultra_l3_map(session, caplog):
                     "--upload-to-sdc",
                 ]
             },
+            retryStrategy=batch_job_retry_strategy,
         )
         # Assert that only one job is submitted.
         assert mock_batch_client.submit_job.call_count == 1
@@ -813,6 +825,7 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--upload-to-sdc",
                 ]
             },
+            retryStrategy=batch_job_retry_strategy,
         )
 
         events = {
@@ -880,6 +893,7 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--upload-to-sdc",
                 ]
             },
+            retryStrategy=batch_job_retry_strategy,
         )
 
 
@@ -968,6 +982,7 @@ def test_def_cadence_map_event(setup_s3, session, tmp_path):
                     "--upload-to-sdc",
                 ]
             },
+            retryStrategy=batch_job_retry_strategy,
         )
 
 
@@ -1349,4 +1364,5 @@ def test_spice_event(session, s3_client):
                     "--upload-to-sdc",
                 ]
             },
+            retryStrategy=batch_job_retry_strategy,
         )

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -42,14 +42,6 @@ from .conftest import (
     _populate_file_catalog,
 )
 
-batch_job_retry_strategy = {
-    "attempts": 3,
-    "evaluateOnExit": [
-        {"onStatusReason": "Your Spot Task was interrupted.", "action": "RETRY"},
-        {"onReason": "*", "action": "EXIT"},
-    ],
-}
-
 
 def _populate_processing_table(session):
     """Add test data to database."""
@@ -115,7 +107,7 @@ def test_lambda_handler(session):
                     "--upload-to-sdc",
                 ]
             },
-            retryStrategy=batch_job_retry_strategy,
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
         mock_sqs_client.delete_message.assert_called_once()
 
@@ -205,7 +197,7 @@ def test_lambda_handler_ancillary_event(session):
                     "--upload-to-sdc",
                 ]
             },
-            retryStrategy=batch_job_retry_strategy,
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
 
 
@@ -551,7 +543,7 @@ def test_idex_l2b(session):
                     "--upload-to-sdc",
                 ]
             },
-            retryStrategy=batch_job_retry_strategy,
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
 
 
@@ -701,7 +693,7 @@ def test_ultra_l3_map(session, caplog):
                     "--upload-to-sdc",
                 ]
             },
-            retryStrategy=batch_job_retry_strategy,
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
         # Assert that only one job is submitted.
         assert mock_batch_client.submit_job.call_count == 1
@@ -825,7 +817,7 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--upload-to-sdc",
                 ]
             },
-            retryStrategy=batch_job_retry_strategy,
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
 
         events = {
@@ -893,7 +885,7 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--upload-to-sdc",
                 ]
             },
-            retryStrategy=batch_job_retry_strategy,
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
 
 
@@ -982,7 +974,7 @@ def test_def_cadence_map_event(setup_s3, session, tmp_path):
                     "--upload-to-sdc",
                 ]
             },
-            retryStrategy=batch_job_retry_strategy,
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
 
 
@@ -1364,5 +1356,5 @@ def test_spice_event(session, s3_client):
                     "--upload-to-sdc",
                 ]
             },
-            retryStrategy=batch_job_retry_strategy,
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )


### PR DESCRIPTION
# Change Summary

## Overview
Retry batch jobs that failed due to status reason = "Your Spot Task was interrupted." 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Add batch job retry strategy.

## Testing
Fix expected calls to include retry strategies. 