### PR TITLE
CoDICE lo- and hi-pha does not have a level 1b

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -17,8 +17,6 @@ codice, l1a, lo-sw-angular, codice, l1b, lo-sw-angular, HARD, DOWNSTREAM
 codice, l1a, lo-nsw-angular, codice, l1b, lo-nsw-angular, HARD, DOWNSTREAM
 codice, l1a, lo-sw-species, codice, l1b, lo-sw-species, HARD, DOWNSTREAM
 codice, l1a, lo-nsw-species, codice, l1b, lo-nsw-species, HARD, DOWNSTREAM
-codice, l1a, lo-pha, codice, l1b, lo-pha, HARD, DOWNSTREAM
-codice, l1a, hi-pha, codice, l1b, hi-pha, HARD, DOWNSTREAM
 codice, l1a, hi-omni, codice, l1b, hi-omni, HARD, DOWNSTREAM
 codice, l1a, hi-sectored, codice, l1b, hi-sectored, HARD, DOWNSTREAM
 codice, l1a, lo-ialirt, codice, l1b, lo-ialirt, HARD, DOWNSTREAM


### PR DESCRIPTION
This PR updates the dependency config to remove `lo-pha` and `hi-pha` data products for L1b, since those products are not created at that level.