### PR TITLE
Spice metakernel frame query bug

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
@@ -52,7 +52,7 @@ class ScienceFramesKernels(Enum):
 
 
 class IMAPFramesKernels(Enum):
-    """Container for Frames Kernel Types."""
+    """Container for IMAP Frames Kernel Type."""
 
     IMAP_FRAMES = auto()
 

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
@@ -254,7 +254,6 @@ def _metakernel_builder(
                 },
                 None,
             )
-
             metakernel.load_spice(
                 json.loads(spice_files["body"]),
                 spice_category.spice_category_name(),

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
@@ -40,16 +40,26 @@ class PlanetaryConstantsKernels(Enum):
         return "planetary_constants_category"
 
 
-class FramesKernels(Enum):
+class ScienceFramesKernels(Enum):
     """Container for Frames Kernel Types."""
 
     SCIENCE_FRAMES = auto()
+
+    @staticmethod
+    def spice_category_name():
+        """Category of SPICE file."""
+        return "science_frames_category"
+
+
+class IMAPFramesKernels(Enum):
+    """Container for Frames Kernel Types."""
+
     IMAP_FRAMES = auto()
 
     @staticmethod
     def spice_category_name():
         """Category of SPICE file."""
-        return "frames_category"
+        return "imap_frames_category"
 
 
 class SpacecraftClockKernels(Enum):
@@ -121,7 +131,8 @@ class KernelCollection:
         default_factory=lambda: [
             LeapsecondKernels,
             PlanetaryConstantsKernels,
-            FramesKernels,
+            IMAPFramesKernels,
+            ScienceFramesKernels,
             SpacecraftClockKernels,
             PlanetaryEphemerisKernels,
             SpacecraftEphemerisKernels,
@@ -243,6 +254,7 @@ def _metakernel_builder(
                 },
                 None,
             )
+
             metakernel.load_spice(
                 json.loads(spice_files["body"]),
                 spice_category.spice_category_name(),

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
@@ -41,7 +41,7 @@ class PlanetaryConstantsKernels(Enum):
 
 
 class ScienceFramesKernels(Enum):
-    """Container for Frames Kernel Types."""
+    """Container for Science Frames Kernel Type."""
 
     SCIENCE_FRAMES = auto()
 

--- a/tests/lambda_endpoints/test_spice_metakernel_api.py
+++ b/tests/lambda_endpoints/test_spice_metakernel_api.py
@@ -291,3 +291,35 @@ def test_metakernel_string_input(session):
         None,
     )
     assert len(json.loads(result["body"])) == 8
+
+
+def test_metakernel_frames(session):
+    """Test that the frame kernels are returned."""
+    _insert_test_file(session, "imap_science_0001.tf", [[1, 300]], upload_time=1)
+    _insert_test_file(session, "imap_001.tf", [[1, 300]], upload_time=1)
+
+    result = spice_metakernel_api.lambda_handler(
+        {
+            "queryStringParameters": {
+                "start_time": 53,
+                "end_time": 60,
+                "file_types": "imap_frames,science_frames",
+                "list_files": "True",
+            }
+        },
+        None,
+    )
+    assert len(json.loads(result["body"])) == 2
+    # Fip file type order and make sure both tf files are returned
+    result = spice_metakernel_api.lambda_handler(
+        {
+            "queryStringParameters": {
+                "start_time": 53,
+                "end_time": 60,
+                "file_types": "science_frames,imap_frames",
+                "list_files": "True",
+            }
+        },
+        None,
+    )
+    assert len(json.loads(result["body"])) == 2


### PR DESCRIPTION
# Change Summary

## Overview
This PR addresses the bug where batch jobs were missing the imap_frames kernel even though it was listed in the dependencies. 

If both the science_frames and imap_frames kernels were listed as dependencies, the metakernel.load_spice function was filtering one out due to them sharing a class inside of the 'kernelCollection'.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_metakernel_api.py
   - Separated out the frames into two separate classes.

## Testing
tests/lambda_endpoints/test_spice_metakernel_api.py 
Add test for frame kernels
