### PR TITLE
Add missing CoDICE hi-priority dependency

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -18,6 +18,7 @@ codice, l1a, lo-nsw-angular, codice, l1b, lo-nsw-angular, HARD, DOWNSTREAM
 codice, l1a, lo-sw-species, codice, l1b, lo-sw-species, HARD, DOWNSTREAM
 codice, l1a, lo-nsw-species, codice, l1b, lo-nsw-species, HARD, DOWNSTREAM
 codice, l1a, hi-omni, codice, l1b, hi-omni, HARD, DOWNSTREAM
+codice, l1a, hi-priority, codice, l1b, hi-priority, HARD, DOWNSTREAM
 codice, l1a, hi-sectored, codice, l1b, hi-sectored, HARD, DOWNSTREAM
 codice, l1a, lo-ialirt, codice, l1b, lo-ialirt, HARD, DOWNSTREAM
 codice, l1a, hi-ialirt, codice, l1b, hi-ialirt, HARD, DOWNSTREAM


### PR DESCRIPTION
This PR adds a missing dependency for L1a -> L1b for the `hi-priority` CoDICE data product