### PR TITLE
Remove cadence start and end date parameters (used for SIT4)

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -792,9 +792,6 @@ def cadence_processing_event(session, events):
         Event input from an Event Bridge rule.
     """
     cadence = events.get("cadence")
-    # TODO: remove start_date and end_date handling after SIT-4.
-    start_date = events.get("start_date")
-    end_date = events.get("end_date")
     logger.info(f"A cadence event was triggered with the parameters: {cadence=}")
     if not cadence:
         raise ValueError("Cadence event must include 'cadence' key.")
@@ -803,13 +800,7 @@ def cadence_processing_event(session, events):
     potential_jobs = sorted(dep_config.get_cadence_jobs(cadence), key=lambda x: x[2])
     logger.info(f"Found {len(potential_jobs)} potential L2 map jobs: {potential_jobs}")
     # Get the start and end dates for this job
-    if not start_date and not end_date:
-        start_date, end_date = cadence_to_datetime_range(cadence, as_str=True)
-    elif not start_date or not end_date:
-        raise ValueError(
-            "Cadence event must include both 'start_date' and 'end_date' if either is"
-            " provided."
-        )
+    start_date, end_date = cadence_to_datetime_range(cadence, as_str=True)
     logger.info(f"Using {start_date=} and {end_date=} for cadence jobs.")
 
     for job_node in potential_jobs:


### PR DESCRIPTION
# Change Summary

closes #683
## Overview
The "start_date" and "end_date" parameters were used temporarily for SIT-4. In production, the start and end dates will be calculated from the time the batch starter was triggered by the EventBridge event. 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Remove handling for start_date and end_date parameters
