### PR TITLE
Write all dependencies for processing to a JSON file

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -749,12 +749,12 @@ def bulk_reprocessing_event(session, events):
 
 
 def upload_dependency_file(dependency_file_path: Path, serialized_dependencies: str):
-    """Upload a JSON file containing a cadence job's dependencies to S3.
+    """Upload a JSON file containing a job's dependencies to S3.
 
     Parameters
     ----------
     dependency_file_path : Path
-        The cadence JSON file to upload.
+        The dependency JSON file to upload.
     serialized_dependencies : str
         The serialized upstream dependencies to upload.
     """
@@ -769,9 +769,10 @@ def upload_dependency_file(dependency_file_path: Path, serialized_dependencies: 
     )
     if signed_url["statusCode"] != 200:
         logger.error(
-            f"Failed to get signed URL for cadence file upload: {signed_url['body']}, "
-            f"with status code: {signed_url['statusCode']}. Cadence file upload failed "
-            f"the job did not get kicked off."
+            f"Failed to get S3 pre-signed URL for file: {dependency_file_path}. "
+            f"As a result, failed to kick off job. "
+            f"Error message: {signed_url['body']}, "
+            f"with status code: {signed_url['statusCode']}."
         )
         return None
     try:

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -16,9 +16,6 @@ from imap_data_access import (
     SPICEFilePath,
 )
 from imap_data_access.file_validation import CadenceFilePath
-from imap_data_access.processing_input import (
-    ProcessingInputCollection,
-)
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
@@ -320,7 +317,7 @@ def try_to_submit_job(
     job_info: dict,
     start_date: datetime,
     version: str,
-    upstream_dependencies: ProcessingInputCollection | str,
+    serialized_dependencies: str,
 ):
     """Try to submit a batch job with the given job information.
 
@@ -334,9 +331,8 @@ def try_to_submit_job(
         Start date of the data.
     version : str
         Version of the job.
-    upstream_dependencies : ProcessingInputCollection or str
-        Either a filename string of a JSON file containing the serialized upstream
-        dependencies. Otherwise, a ProcessingInputCollection of the upstream
+    serialized_dependencies : str
+        The serialized ProcessingInputCollection of the upstream
         dependencies.
     """
     instrument = job_info["data_source"]
@@ -366,16 +362,26 @@ def try_to_submit_job(
     logger.info(
         f"Wrote job INPROGRESS to Processing Jobs Table with id: {processing_job.id}"
     )
-
-    # Reformat the upstream dependencies from dependency call to match
-    # what batch job expects.
     # TODO: do we need a reprocessing column to indicate if this is a reprocessing job?
 
-    # If upstream dependencies are a ProcessingInputCollection, serialize them into a
-    # string. Otherwise, it should be a string representing the filename of a JSON file
-    # containing the serialized upstream dependencies.
-    if isinstance(upstream_dependencies, ProcessingInputCollection):
-        upstream_dependencies = upstream_dependencies.serialize()
+    # Serialize the upstream dependencies and write them to a JSON file. The Imap
+    # processing code will read the JSON file and deserialize the dependencies. This is
+    # to avoid passing a large string through the batch job command line.
+    # TODO replace CadenceFilePath with DependencyFilePath after new imap-data-access
+    # release
+    dependency_file = CadenceFilePath.generate_from_inputs(
+        instrument=instrument,
+        data_level=data_level,
+        descriptor=descriptor,
+        start_time=start_date.strftime("%Y%m%d"),
+        version=version,
+        extension="json",
+    )
+    dependency_file_path = Path(dependency_file.construct_path())
+    response = upload_cadence_file(dependency_file_path, serialized_dependencies)
+    # If response is None, then the upload failed and we should skip submitting the job.
+    if not response:
+        return
 
     batch_command = [
         "--instrument",
@@ -389,7 +395,7 @@ def try_to_submit_job(
         "--version",
         version,
         "--dependency",
-        upstream_dependencies,
+        os.path.basename(dependency_file_path),
         "--upload-to-sdc",
     ]
 
@@ -502,7 +508,11 @@ def submit_all_jobs(session, job_node, start_date, end_date, filter_dependencies
         else:
             upstream_deps_for_job = upstream_dependencies
         try_to_submit_job(
-            session, job_node, job_start_date, job_version, upstream_deps_for_job
+            session,
+            job_node,
+            job_start_date,
+            job_version,
+            upstream_deps_for_job.serialize(),
         )
 
 
@@ -738,27 +748,36 @@ def bulk_reprocessing_event(session, events):
             submit_all_jobs(session, job, start_date, end_date)
 
 
-def upload_cadence_file(cadence_file_path: Path, upstream_dependencies):
+def upload_cadence_file(dependency_file_path: Path, serialized_dependencies: str):
     """Upload a JSON file containing a cadence job's dependencies to S3.
 
     Parameters
     ----------
-    cadence_file_path : Path
+    dependency_file_path : Path
         The cadence JSON file to upload.
-    upstream_dependencies : ProcessingInputCollection
-        The upstream dependencies to serialize and upload.
+    serialized_dependencies : str
+        The serialized upstream dependencies to upload.
     """
     # Check if the file already exists
-    if os.path.isfile(cadence_file_path):
-        raise KeyError(f"{cadence_file_path} already exists, cannot create JSON file.")
+    if os.path.isfile(dependency_file_path):
+        raise KeyError(
+            f"{dependency_file_path} already exists, cannot create JSON file."
+        )
     # call the upload API handler directly
     signed_url = upload_api.lambda_handler(
-        {"pathParameters": {"proxy": cadence_file_path.as_posix()}}, None
+        {"pathParameters": {"proxy": dependency_file_path.as_posix()}}, None
     )
+    if signed_url["statusCode"] != 200:
+        logger.error(
+            f"Failed to get signed URL for cadence file upload: {signed_url['body']}, "
+            f"with status code: {signed_url['statusCode']}. Cadence file upload failed "
+            f"the job did not get kicked off."
+        )
+        return None
     try:
         response = requests.put(
             signed_url["body"].strip('"'),
-            data=upstream_dependencies.serialize(),
+            data=serialized_dependencies,
             headers={"Content-Type": "application/json"},
             timeout=60.0,
         )
@@ -767,14 +786,10 @@ def upload_cadence_file(cadence_file_path: Path, upstream_dependencies):
             f"{response.status_code}"
         )
         return response
-    except requests.exceptions.MissingSchema as e:
-        logger.error(f"Schema error in signed url: {signed_url['body']}. Error: {e}")
-        # Log the error but do not raise, so processing continues for other jobs
-        return None
     except Exception as e:
         logger.error(
             f"Unexpected error during cadence file upload: {e}. "
-            f"Cadence file upload failed Job will not be kicked off."
+            f"Cadence file upload failed and the job did not get kicked off."
         )
         return None
 
@@ -822,26 +837,7 @@ def cadence_processing_event(session, events):
             descriptor=job_node[2],
             start_date=start_date,
         )
-        # Serialize the upstream dependencies to a JSON file. This is necessary for map
-        # jobs with many dependencies to avoid passing a long list of dependencies
-        # directly to the batch job. Imap processing code will read the JSON file and
-        # deserialize the dependencies.
-        cadence_dependency_path = CadenceFilePath.generate_from_inputs(
-            instrument=job_node[0],
-            data_level=job_node[1],
-            descriptor=job_node[2],
-            start_time=start_date,
-            version=job_version,
-            extension="json",
-        )
-        cadence_dependency_path = Path(cadence_dependency_path.construct_path())
-        response = upload_cadence_file(cadence_dependency_path, upstream_dependencies)
-        # If response is None, then the upload failed and we should continue to the
-        # next job.
-        if not response:
-            continue
         # Submit the map job with all of the upstream dependencies in the date range
-        # (as JSON file).
         node = {
             "data_source": job_node[0],
             "descriptor": job_node[2],
@@ -852,7 +848,7 @@ def cadence_processing_event(session, events):
             node,
             datetime.datetime.strptime(start_date, "%Y%m%d"),
             job_version,
-            os.path.basename(cadence_dependency_path),
+            upstream_dependencies.serialize(),
         )
 
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -377,8 +377,8 @@ def try_to_submit_job(
         version=version,
         extension="json",
     )
-    dependency_file_path = Path(dependency_file.construct_path())
-    response = upload_cadence_file(dependency_file_path, serialized_dependencies)
+    dependency_file_path = dependency_file.construct_path()
+    response = upload_dependency_file(dependency_file_path, serialized_dependencies)
     # If response is None, then the upload failed and we should skip submitting the job.
     if not response:
         return
@@ -395,7 +395,7 @@ def try_to_submit_job(
         "--version",
         version,
         "--dependency",
-        os.path.basename(dependency_file_path),
+        dependency_file_path.name,
         "--upload-to-sdc",
     ]
 
@@ -748,7 +748,7 @@ def bulk_reprocessing_event(session, events):
             submit_all_jobs(session, job, start_date, end_date)
 
 
-def upload_cadence_file(dependency_file_path: Path, serialized_dependencies: str):
+def upload_dependency_file(dependency_file_path: Path, serialized_dependencies: str):
     """Upload a JSON file containing a cadence job's dependencies to S3.
 
     Parameters

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -98,7 +98,7 @@ def invalid_file():
     )
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True)
 def s3_client():
     """Mock S3 Client, so we don't need network requests."""
     with mock_s3():

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -59,7 +59,7 @@ def _populate_processing_table(session):
     session.commit()
 
 
-def test_lambda_handler(session):
+def test_lambda_handler(session, s3_client):
     """Tests ``lambda_handler`` function."""
     _populate_file_catalog(session)
     events = {
@@ -72,11 +72,10 @@ def test_lambda_handler(session):
             }
         ]
     }
-    serialized_processing_input = [
-        {"type": "spice", "files": ["naif0012.tls", "imap_sclk_0000.tsc"]},
-        {"type": "science", "files": ["imap_swe_l0_raw_20240110_v001.pkts"]},
-    ]
-
+    processing_input = ProcessingInputCollection(
+        SPICEInput("naif0012.tls", "imap_sclk_0000.tsc"),
+        ScienceInput("imap_swe_l0_raw_20240110_v001.pkts"),
+    )
     context = {"context": "sample_context"}
 
     with (
@@ -103,16 +102,32 @@ def test_lambda_handler(session):
                     "--version",
                     "v001",
                     "--dependency",
-                    json.dumps(serialized_processing_input),
+                    "imap_swe_l1a_sci_20240110_v001.json",
                     "--upload-to-sdc",
                 ]
             },
             retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
-        mock_sqs_client.delete_message.assert_called_once()
+    mock_sqs_client.delete_message.assert_called_once()
+    # Verify the function was called with the correct upstream dependencies
+    with patch.object(batch_starter, "try_to_submit_job") as mock_submit:
+        lambda_handler(events, context)
+        mock_submit.assert_called_with(
+            session,
+            {"data_source": "swe", "data_type": "l1a", "descriptor": "sci"},
+            dt.datetime(2024, 1, 10, 0, 0),
+            "v002",
+            processing_input.serialize(),
+        )
+
+    # Clean up: Delete object from the test bucket to avoid conflicts in future tests
+    s3_client.delete_object(
+        Bucket=os.getenv("S3_BUCKET"),
+        Key="imap/cadence/swe/l1a/2024/01/imap_swe_l1a_sci_20240110_v001.json",
+    )
 
 
-def test_lambda_handler_multiple_events(session):
+def test_lambda_handler_multiple_events(session, s3_client):
     """Tests ``lambda_handler`` function with multiple events."""
     # Test Multiple Events:
     _populate_file_catalog(session)
@@ -134,6 +149,12 @@ def test_lambda_handler_multiple_events(session):
     with patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client:
         lambda_handler(multiple_events, context)
         assert mock_batch_client.submit_job.call_count == 2
+
+    # Clean up: Delete object from the test bucket to avoid conflicts in future tests
+    s3_client.delete_object(
+        Bucket=os.getenv("S3_BUCKET"),
+        Key="imap/cadence/swe/l1b/2024/01/imap_swe_l1b_sci_20240101_v001.json",
+    )
 
 
 def test_lambda_handler_ancillary_event(session):
@@ -174,8 +195,8 @@ def test_lambda_handler_ancillary_event(session):
                 "files": ["imap_swe_eu-conversion_20221231_v001.cdf"],
             },
         ]
-        dependencies = ProcessingInputCollection()
-        dependencies.deserialize(json.dumps(inputs))
+        # dependencies = ProcessingInputCollection()
+        # dependencies.deserialize()
         mock_batch_client.submit_job.assert_called_with(
             jobName="swe-l1b-sci-job-2",
             jobQueue="ProcessingJobQueue",
@@ -193,11 +214,22 @@ def test_lambda_handler_ancillary_event(session):
                     "--version",
                     "v002",
                     "--dependency",
-                    dependencies.serialize(),
+                    "imap_swe_l1b_sci_20240102_v002.json",
                     "--upload-to-sdc",
                 ]
             },
             retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
+        )
+    # Assert that the try_to_submit_job function was called with the correct
+    # upstream dependencies
+    with patch.object(batch_starter, "try_to_submit_job") as mock_submit:
+        lambda_handler(events, context)
+        mock_submit.assert_called_with(
+            session,
+            {"data_source": "swe", "data_type": "l1b", "descriptor": "sci"},
+            dt.datetime(2024, 1, 2, 0, 0),
+            "v003",
+            json.dumps(inputs),
         )
 
 
@@ -539,11 +571,21 @@ def test_idex_l2b(session):
                     "--version",
                     "v001",
                     "--dependency",
-                    expected_processing_input.serialize(),
+                    "imap_idex_l2b_sci-1week_20230209_v001.json",
                     "--upload-to-sdc",
                 ]
             },
             retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
+        )
+    # Verify the function was called with the correct upstream dependencies
+    with patch.object(batch_starter, "try_to_submit_job") as mock_submit:
+        lambda_handler(events, context)
+        mock_submit.assert_called_with(
+            session,
+            {"data_source": "idex", "data_type": "l2b", "descriptor": "sci-1week"},
+            dt.datetime(2023, 2, 9, 0, 0),
+            "v002",
+            expected_processing_input.serialize(),
         )
 
 
@@ -689,7 +731,7 @@ def test_ultra_l3_map(session, caplog):
                     "--version",
                     "v001",
                     "--dependency",
-                    expected_processing_input.serialize(),
+                    "imap_ultra_l3_u90-ena-h-sf-sp-full-hae-4deg-3mo_20240201_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -698,6 +740,22 @@ def test_ultra_l3_map(session, caplog):
         # Assert that only one job is submitted.
         assert mock_batch_client.submit_job.call_count == 1
         assert "Already tried to submit job from a GLOWS l3e file." in caplog.text
+
+        # Assert that the try_to_submit_job function was called with the correct
+        # upstream dependencies
+        with patch.object(batch_starter, "try_to_submit_job") as mock_submit:
+            lambda_handler(events, context)
+            mock_submit.assert_called_with(
+                session,
+                {
+                    "data_source": "ultra",
+                    "data_type": "l3",
+                    "descriptor": "u90-ena-h-sf-sp-full-hae-4deg-3mo",
+                },
+                dt.datetime(2024, 2, 1, 0, 0),
+                "v002",
+                expected_processing_input.serialize(),
+            )
 
 
 def test_bulk_reprocessing_special_case(session):
@@ -813,7 +871,7 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--version",
                     "v001",
                     "--dependency",
-                    expected_processing_input.serialize(),
+                    "imap_mag_l1c_norm-mago_20240101_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -881,11 +939,22 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--version",
                     "v002",
                     "--dependency",
-                    expected_processing_input.serialize(),
+                    "imap_mag_l1c_norm-mago_20240101_v002.json",
                     "--upload-to-sdc",
                 ]
             },
             retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
+        )
+    # Assert that the try_to_submit_job function was called with the correct
+    # upstream dependencies
+    with patch.object(batch_starter, "try_to_submit_job") as mock_submit:
+        lambda_handler(events, context)
+        mock_submit.assert_called_with(
+            session,
+            {"data_source": "mag", "data_type": "l1c", "descriptor": "norm-mago"},
+            dt.datetime(2024, 1, 1, 0, 0),
+            "v003",
+            expected_processing_input.serialize(),
         )
 
 
@@ -1022,7 +1091,7 @@ def test_upload_cadence_file(s3_client, tmp_path, cadence_file, caplog):
     )
     with patch("imap_data_access.config", {"DATA_DIR": tmp_path}):
         cadence_dependency_path = pathlib.Path(cadence_file.construct_path())
-        upload_cadence_file(cadence_dependency_path, dependencies)
+        upload_cadence_file(cadence_dependency_path, dependencies.serialize())
     assert "Cadence file uploaded successfully" in caplog.text
 
 
@@ -1352,9 +1421,19 @@ def test_spice_event(session, s3_client):
                     "--version",
                     "v001",
                     "--dependency",
-                    json.dumps(expected_dependency_input),
+                    "imap_idex_l1b_sci-1week_20250429_v001.json",
                     "--upload-to-sdc",
                 ]
             },
             retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
+        )
+
+    with patch.object(batch_starter, "try_to_submit_job") as mock_submit:
+        lambda_handler(events, None)
+        mock_submit.assert_called_with(
+            session,
+            {"data_source": "idex", "data_type": "l1b", "descriptor": "sci-1week"},
+            dt.datetime(2025, 4, 29, 0, 0),
+            "v002",
+            json.dumps(expected_dependency_input),
         )

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -195,8 +195,6 @@ def test_lambda_handler_ancillary_event(session):
                 "files": ["imap_swe_eu-conversion_20221231_v001.cdf"],
             },
         ]
-        # dependencies = ProcessingInputCollection()
-        # dependencies.deserialize()
         mock_batch_client.submit_job.assert_called_with(
             jobName="swe-l1b-sci-job-2",
             jobQueue="ProcessingJobQueue",

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -34,7 +34,7 @@ from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.batch_starter import 
     CadenceDays,
     determine_job_version,
     lambda_handler,
-    upload_cadence_file,
+    upload_dependency_file,
 )
 
 from .conftest import (
@@ -120,12 +120,6 @@ def test_lambda_handler(session, s3_client):
             processing_input.serialize(),
         )
 
-    # Clean up: Delete object from the test bucket to avoid conflicts in future tests
-    s3_client.delete_object(
-        Bucket=os.getenv("S3_BUCKET"),
-        Key="imap/cadence/swe/l1a/2024/01/imap_swe_l1a_sci_20240110_v001.json",
-    )
-
 
 def test_lambda_handler_multiple_events(session, s3_client):
     """Tests ``lambda_handler`` function with multiple events."""
@@ -149,12 +143,6 @@ def test_lambda_handler_multiple_events(session, s3_client):
     with patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client:
         lambda_handler(multiple_events, context)
         assert mock_batch_client.submit_job.call_count == 2
-
-    # Clean up: Delete object from the test bucket to avoid conflicts in future tests
-    s3_client.delete_object(
-        Bucket=os.getenv("S3_BUCKET"),
-        Key="imap/cadence/swe/l1b/2024/01/imap_swe_l1b_sci_20240101_v001.json",
-    )
 
 
 def test_lambda_handler_ancillary_event(session):
@@ -1078,7 +1066,7 @@ def test_cadence_to_datetime_range():
         assert (end_date - start_date) == dt.timedelta(days=CadenceDays.ONE_YEAR.value)
 
 
-def test_upload_cadence_file(s3_client, tmp_path, cadence_file, caplog):
+def test_upload_dependency_file(s3_client, tmp_path, cadence_file, caplog):
     """Test uploading a cadence json file to S3."""
     caplog.set_level("INFO")
     dependencies = ProcessingInputCollection(
@@ -1089,7 +1077,7 @@ def test_upload_cadence_file(s3_client, tmp_path, cadence_file, caplog):
     )
     with patch("imap_data_access.config", {"DATA_DIR": tmp_path}):
         cadence_dependency_path = pathlib.Path(cadence_file.construct_path())
-        upload_cadence_file(cadence_dependency_path, dependencies.serialize())
+        upload_dependency_file(cadence_dependency_path, dependencies.serialize())
     assert "Cadence file uploaded successfully" in caplog.text
 
 


### PR DESCRIPTION
# Change Summary

closes #639

## Overview
This PR updates the 'dependency' keyword in the batch job command to indicate a JSON file containing the serialized dependencies for the job instead of the actual serialized dependencies. For each processing job submitted there will be a corresponding dependency JSON file. 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Upload json file of dependencies to s3 and use the filename as the --dependency argument in the batch job command. 

## Testing
Fixed test to check that the correct json filename is passed into the batch job command. The 'try_to_submit_job' function is mocked in many tests still check that the upstream dependencies are the ones we would expect. 
