### PR TITLE
Adjust cadence map filename start dates

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -804,8 +804,8 @@ def cadence_processing_event(session, events):
     for job_node in potential_jobs:
         node = {
             "data_source": job_node[0],
-            "descriptor": job_node[2],
             "data_type": job_node[1],
+            "descriptor": job_node[2],
         }
         upstream_dependencies = dependency.get_jobs(
             data_source=node["data_source"],
@@ -832,7 +832,7 @@ def cadence_processing_event(session, events):
             science_input.get_time_range()[0]
             for science_input in primary_science_inputs
         ]
-        cadence_start_date = sorted(start_dates)[0]
+        cadence_start_date = min(start_dates)
 
         job_version = determine_job_version(
             session=session,

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -802,10 +802,15 @@ def cadence_processing_event(session, events):
     logger.info(f"Using {start_date=} and {end_date=} for cadence jobs.")
 
     for job_node in potential_jobs:
+        node = {
+            "data_source": job_node[0],
+            "descriptor": job_node[2],
+            "data_type": job_node[1],
+        }
         upstream_dependencies = dependency.get_jobs(
-            data_source=job_node[0],
-            data_type=job_node[1],
-            descriptor=job_node[2],
+            data_source=node["data_source"],
+            data_type=node["data_type"],
+            descriptor=node["descriptor"],
             dependency_type="UPSTREAM",
             relationship="ALL",
             start_date=start_date,
@@ -815,12 +820,26 @@ def cadence_processing_event(session, events):
             continue
 
         logger.info(f"All required dependencies found for the dependency: {job_node}")
+        # The start date for the cadence job should be the earliest date of the
+        # upstream science dependency. For example, if the job is an ultra l2 map, then
+        # the start date should be the date of the first upstream pset.
+        # For cadence jobs, it is assumed there is at least one primary ScienceInput,
+        # typically only one.
+        primary_science_inputs = upstream_dependencies.get_science_inputs(
+            node["data_source"]
+        )
+        start_dates = [
+            science_input.get_time_range()[0]
+            for science_input in primary_science_inputs
+        ]
+        cadence_start_date = sorted(start_dates)[0]
+
         job_version = determine_job_version(
             session=session,
             instrument=job_node[0],
             data_level=job_node[1],
             descriptor=job_node[2],
-            start_date=start_date,
+            start_date=cadence_start_date,
         )
         # Serialize the upstream dependencies to a JSON file. This is necessary for map
         # jobs with many dependencies to avoid passing a long list of dependencies
@@ -830,7 +849,7 @@ def cadence_processing_event(session, events):
             instrument=job_node[0],
             data_level=job_node[1],
             descriptor=job_node[2],
-            start_time=start_date,
+            start_time=cadence_start_date.strftime("%Y%m%d"),
             version=job_version,
             extension="json",
         )
@@ -842,15 +861,10 @@ def cadence_processing_event(session, events):
             continue
         # Submit the map job with all of the upstream dependencies in the date range
         # (as JSON file).
-        node = {
-            "data_source": job_node[0],
-            "descriptor": job_node[2],
-            "data_type": job_node[1],
-        }
         try_to_submit_job(
             session,
             node,
-            datetime.datetime.strptime(start_date, "%Y%m%d"),
+            cadence_start_date,
             job_version,
             os.path.basename(cadence_dependency_path),
         )

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -947,12 +947,14 @@ def test_def_cadence_map_event(setup_s3, session, tmp_path):
         ) as dt_mock,
         patch("imap_data_access.config", {"DATA_DIR": tmp_path}),
     ):
-        dt_mock.return_value = ("20250301", "20250601")
+        dt_mock.return_value = ("20250228", "20250601")
         lambda_handler(cadence_event, context)
         # Verify the function was called 12 times. There are currently 12 l2 map jobs
         # with the cadence of 3 months.
         assert mock_batch_client.submit_job.call_count == 12
-        # Assert that the function was called with the cadence json file path
+        # Assert that the function was called with the cadence json file path. The
+        # Start date should be the date of the earliest upstream science file in the
+        # cadence range.
         mock_batch_client.submit_job.assert_called_with(
             jobName="ultra-l2-u90-ena-h-sf-nsp-full-hae-6deg-3mo-job-12",
             jobQueue="ProcessingJobQueue",


### PR DESCRIPTION
# Change Summary

closes #682

## Overview
I had mistakenly assumed that the start date to assign to a cadence mapping job should be the end date (the date when the cadence job was triggered) minus the number of days associated with the cadence job. After some conversations with the team during a SIT-4 dry run last week, it was determined that the expected start date should actually be the date of the first pset. 

For example if an ultra l2, 3 month map job got kicked off and the date range to query for files was :

start_date= 20250101
end_date= 20250401

The earliest pset start_date: 
start_date = 20250110

The batch starter code was originally assigning the date to be 20250101 and this PR fixes it to be 20250110.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Fix map start dates

## Testing
Slightly edit the cadence job test so that the earliest pset is slightly after the start date of the cadence date_range. This ensures that the correct date is being used. 
