### PR TITLE
I-ALiRT - Added way to furnish the SPICE kernels

### DIFF
--- a/sds_data_manager/constructs/ialirt_efs_construct.py
+++ b/sds_data_manager/constructs/ialirt_efs_construct.py
@@ -1,0 +1,101 @@
+"""Configure the EFS."""
+
+import aws_cdk as cdk
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_efs as efs
+from constructs import Construct
+
+
+class IAlirtEFSConstruct(Construct):
+    """Elastic File System for storing various software and data.
+
+    This file system can be mounted by multiple resources. It
+    will be attached to AWS resources that run the
+    models (ECS, EC2, Lambda) and produce output data.  It will
+    also be mounted by the visualizer app to view that model data.
+    This allows model data to be seamlessly transferred between
+    resources without having to push/pull from s3. For the
+    visualizer display, it should have decent I/O capabilities
+    to read and write the model output data to the frontend quickly.
+
+    NOTE: The EFS file systems will not be removed during a CDK
+    destroy. This is a protection mechanism to
+    prevent data from being deleted. After destroying this
+    stack you will need to manually delete these
+    resources via the AWS console or CLI.
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        vpc: ec2.Vpc,
+        **kwargs,
+    ) -> None:
+        """Construct the EFS.
+
+        Parameters
+        ----------
+        scope : Construct
+            Parent construct.
+        construct_id : str
+            A unique string identifier for this construct.
+        vpc : ec2.Vpc
+            VPC into which to put the resources that require networking.
+        kwargs : dict
+            Keyword arguments
+
+        """
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Initialize EFS related information that other resources
+        # will need to access EFS or mount EFS.
+        self.volume_name = "IALIRT-SPICE-EFS"
+        self.efs_path = "/data"
+
+        # Define EFS security group, ports are added in EC2 stack
+        self.efs_security_group = ec2.SecurityGroup(
+            self,
+            "IAlirtEFSSecurityGroup",
+            vpc=vpc,
+            description="No outbound rule for EFS",
+            allow_all_outbound=False,
+            security_group_name="IAlirtEFSSecurityGroup",
+        )
+
+        # Add inbound rule for TCP port 2049
+        self.efs_security_group.connections.allow_from_any_ipv4(
+            ec2.Port.tcp(2049),
+            "Allow services to mount the EFS",
+        )
+
+        self.efs = efs.FileSystem(
+            self,
+            "IAlirtEFS",
+            vpc=vpc,
+            file_system_name=self.volume_name,
+            # This will automatically downscale infrequently accessed
+            # data to a cheaper storage tier after 14 days of inactivity.
+            # TODO: Investigate what lifecycle policy we need or if
+            # we should remove if it effects read latency.
+            lifecycle_policy=efs.LifecyclePolicy.AFTER_14_DAYS,
+            # TODO: Investigate what performance characteristics we need
+            # For now, use general purpose, but we can experiment later.
+            performance_mode=efs.PerformanceMode.GENERAL_PURPOSE,
+            security_group=self.efs_security_group,
+            # Need to add EFS mount points to all Private subnets
+            # This will allow EC2 in either AZ to connect without data
+            # transfer charges
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_ISOLATED
+            ),
+            removal_policy=cdk.RemovalPolicy.DESTROY,
+        )
+
+        # Make an access point for others to be able to access the drive
+        self.spice_access_point = self.efs.add_access_point(
+            "IAlirtSpiceAccessPoint",
+            create_acl=efs.Acl(owner_gid="1000", owner_uid="1000", permissions="750"),
+            path=self.efs_path,
+            posix_user=efs.PosixUser(gid="1000", uid="1000"),
+        )

--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -22,7 +22,6 @@ class IalirtIngestLambda(Construct):
         ialirt_bucket: aws_s3.Bucket,
         vpc: ec2.Vpc,
         efs_access_point: efs.AccessPoint,
-        efs_security_group: ec2.SecurityGroup,
         docker_path: str = "sds_data_manager/lambda_code",
         **kwargs,
     ) -> None:
@@ -40,8 +39,6 @@ class IalirtIngestLambda(Construct):
             VPC into which to put the resources that require networking.
         efs_access_point: efs.AccessPoint
             EFS access point to mount inside the Lambda function.
-        efs_security_group: ec2.SecurityGroup
-            Security group associated with the EFS file system.
         docker_path : str
             Path to the Dockerfile.
         kwargs : dict
@@ -52,7 +49,6 @@ class IalirtIngestLambda(Construct):
 
         # EFS resources
         self.efs_access_point = efs_access_point
-        self.efs_security_group = efs_security_group
         self.vpc = vpc
 
         # Create DynamoDB Table
@@ -167,8 +163,7 @@ class IalirtIngestLambda(Construct):
             memory_size=1000,
             role=lambda_role,
             vpc=self.vpc,
-            # TODO: figure out how to add this in and have access to s3.
-            # security_groups=[self.efs_security_group],
+            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS),
             filesystem=lambda_.FileSystem.from_efs_access_point(
                 self.efs_access_point, "/mnt/data"
             ),

--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -163,7 +163,9 @@ class IalirtIngestLambda(Construct):
             memory_size=1000,
             role=lambda_role,
             vpc=self.vpc,
-            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS),
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
+            ),
             filesystem=lambda_.FileSystem.from_efs_access_point(
                 self.efs_access_point, "/mnt/data"
             ),

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -3,13 +3,12 @@
 import json
 import logging
 import os
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-import requests
-import shutil
-import spiceypy
-import imap_data_access
 
+import imap_data_access
+import requests
+import spiceypy
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     SPICEInput,
@@ -24,8 +23,8 @@ from boto3.dynamodb.conditions import Key
 from imap_processing import imap_module_directory
 from imap_processing.ialirt.l0.process_hit import process_hit
 from imap_processing.ialirt.l0.process_swe import process_swe
-from imap_processing.utils import packet_file_to_datasets
 from imap_processing.spice.time import str_to_et
+from imap_processing.utils import packet_file_to_datasets
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -43,13 +42,11 @@ EFS_BASE_PATH = Path("/mnt/data")
 
 
 def get_latest_spice_kernels() -> ProcessingInputCollection:
-    """
-    Query the SPICE metakernel API to retrieve the latest SPICE kernel filenames
-    for the past week.
+    """Query the SPICE metakernel API for latest SPICE kernel filenames.
 
     Returns
     -------
-    ProcessingInputCollection
+    dependency_inputs: ProcessingInputCollection
         A collection containing a SPICEInput object with the list of kernel filenames
         returned from the metakernel API.
     """
@@ -72,7 +69,7 @@ def get_latest_spice_kernels() -> ProcessingInputCollection:
     }
 
     logger.info(f"Sending request to {url} with params: {params}")
-    response = requests.get(url, params=params)
+    response = requests.get(url, params=params, timeout=10)
     metakernel_files = response.json()
 
     logger.info(f"Found metakernel files: {metakernel_files}. Adding to collection.")
@@ -82,18 +79,17 @@ def get_latest_spice_kernels() -> ProcessingInputCollection:
 
 
 def download_spice_file(dependencies) -> ProcessingInputCollection:
-    """
-    Download SPICE kernel files from the IMAP data archive and store them in EFS.
+    """Download SPICE kernel files from the IMAP data archive and store them in EFS.
 
     Parameters
     ----------
-    ProcessingInputCollection
+    dependencies: ProcessingInputCollection
         A collection containing a SPICEInput object with the list of kernel filenames
         returned from the metakernel API.
 
     Returns
     -------
-    list[Path]
+    spice_files: list[Path]
         A list of Path objects representing the SPICE files stored in EFS.
     """
     imap_data_access.config["DATA_DIR"] = EFS_BASE_PATH

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -78,7 +78,7 @@ def get_latest_spice_kernels() -> ProcessingInputCollection:
     return dependency_inputs
 
 
-def download_spice_file(dependencies) -> ProcessingInputCollection:
+def download_spice_file(dependencies) -> list[Path]:
     """Download SPICE kernel files from the IMAP data archive and store them in EFS.
 
     Parameters
@@ -96,7 +96,7 @@ def download_spice_file(dependencies) -> ProcessingInputCollection:
     dependencies.download_all_files()
 
     spice_files = dependencies.get_file_paths(data_type=SPICESource.SPICE.value)
-    spiceypy.furnsh([str((EFS_BASE_PATH / f.name).resolve()) for f in spice_files])
+    spiceypy.furnsh([str(file.resolve()) for file in spice_files])
 
     return spice_files
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -54,7 +54,7 @@ def get_latest_spice_kernels() -> ProcessingInputCollection:
     one_week_ago = now - timedelta(weeks=1)
     # Define J2000 epoch: 2000-01-01T12:00:00 UTC
     # TODO: remove this once Bryan changes takes in 'yyyymmdd' format
-    j2000 = datetime(2000, 1, 1, 11, 58, 55.816, tzinfo=timezone.utc)
+    j2000 = datetime(2000, 1, 1, 11, 58, 56, tzinfo=timezone.utc)
     et_end_time = (now - j2000).total_seconds()
     et_start_time = (one_week_ago - j2000).total_seconds()
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -6,24 +6,22 @@ import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import boto3
+import botocore
 import imap_data_access
+import numpy as np
 import requests
 import spiceypy
+import xarray as xr
+from boto3.dynamodb.conditions import Key
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     SPICEInput,
     SPICESource,
 )
-
-import boto3
-import botocore
-import numpy as np
-import xarray as xr
-from boto3.dynamodb.conditions import Key
 from imap_processing import imap_module_directory
 from imap_processing.ialirt.l0.process_hit import process_hit
 from imap_processing.ialirt.l0.process_swe import process_swe
-from imap_processing.spice.time import str_to_et
 from imap_processing.utils import packet_file_to_datasets
 
 logger = logging.getLogger(__name__)
@@ -41,6 +39,20 @@ KERNELS = {
 EFS_BASE_PATH = Path("/mnt/data")
 
 
+def get_ephemeris_time():
+    """Get the current ephemeris time in seconds since J2000.
+
+    Returns
+    -------
+    et: float
+        The current ephemeris time in seconds since J2000.
+    """
+    now = datetime.now(timezone.utc)
+    j2000 = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    et = (now - j2000).total_seconds()
+    return et
+
+
 def get_latest_spice_kernels() -> ProcessingInputCollection:
     """Query the SPICE metakernel API for latest SPICE kernel filenames.
 
@@ -53,9 +65,11 @@ def get_latest_spice_kernels() -> ProcessingInputCollection:
     dependency_inputs = ProcessingInputCollection()
 
     now = datetime.now(timezone.utc)
-    end_time = str_to_et(now.replace(tzinfo=None).isoformat())
     one_week_ago = now - timedelta(weeks=1)
-    start_time = str_to_et(one_week_ago.replace(tzinfo=None).isoformat())
+    # Define J2000 epoch: 2000-01-01T12:00:00 UTC
+    j2000 = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    end_time = (now - j2000).total_seconds()
+    start_time = (one_week_ago - j2000).total_seconds()
 
     file_types = ",".join(KERNELS)
     # TODO: replace this url with the endpoint from imap-data-access.

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -3,8 +3,18 @@
 import json
 import logging
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
+import requests
+import shutil
+import spiceypy
+import imap_data_access
+
+from imap_data_access.processing_input import (
+    ProcessingInputCollection,
+    SPICEInput,
+    SPICESource,
+)
 
 import boto3
 import botocore
@@ -15,9 +25,91 @@ from imap_processing import imap_module_directory
 from imap_processing.ialirt.l0.process_hit import process_hit
 from imap_processing.ialirt.l0.process_swe import process_swe
 from imap_processing.utils import packet_file_to_datasets
+from imap_processing.spice.time import str_to_et
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+KERNELS = {
+    "ephemeris_predicted",
+    "ephemeris_90days",
+    "planetary_ephemeris",
+    "spacecraft_clock",
+    "leapseconds",
+    "imap_frames",
+    "science_frames",
+}
+EFS_BASE_PATH = Path("/mnt/data")
+
+
+def get_latest_spice_kernels() -> ProcessingInputCollection:
+    """
+    Query the SPICE metakernel API to retrieve the latest SPICE kernel filenames
+    for the past week.
+
+    Returns
+    -------
+    ProcessingInputCollection
+        A collection containing a SPICEInput object with the list of kernel filenames
+        returned from the metakernel API.
+    """
+    dependency_inputs = ProcessingInputCollection()
+
+    now = datetime.now(timezone.utc)
+    end_time = str_to_et(now.replace(tzinfo=None).isoformat())
+    one_week_ago = now - timedelta(weeks=1)
+    start_time = str_to_et(one_week_ago.replace(tzinfo=None).isoformat())
+
+    file_types = ",".join(KERNELS)
+    # TODO: replace this url with the endpoint from imap-data-access.
+    url = "https://ylxiee1ond.execute-api.us-west-2.amazonaws.com/metakernel"
+
+    params = {
+        "start_time": str(int(start_time)),
+        "end_time": str(int(end_time)),
+        "list_files": "True",
+        "file_types": file_types,
+    }
+
+    logger.info(f"Sending request to {url} with params: {params}")
+    response = requests.get(url, params=params)
+    metakernel_files = response.json()
+
+    logger.info(f"Found metakernel files: {metakernel_files}. Adding to collection.")
+    dependency_inputs.add(SPICEInput(*metakernel_files))
+
+    return dependency_inputs
+
+
+def download_spice_file(dependencies) -> ProcessingInputCollection:
+    """
+    Download SPICE kernel files from the IMAP data archive and store them in EFS.
+
+    Parameters
+    ----------
+    ProcessingInputCollection
+        A collection containing a SPICEInput object with the list of kernel filenames
+        returned from the metakernel API.
+
+    Returns
+    -------
+    list[Path]
+        A list of Path objects representing the SPICE files stored in EFS.
+    """
+    imap_data_access.config["DATA_DIR"] = EFS_BASE_PATH
+    dependencies.download_all_files()
+
+    spice_files = dependencies.get_file_paths(data_type=SPICESource.SPICE.value)
+
+    for file_path in spice_files:
+        efs_path = EFS_BASE_PATH / file_path.name
+        shutil.copy(file_path, efs_path)
+        logger.info(f"Copied {file_path} to EFS at {efs_path}")
+        logger.info(f"Furnishing kernels: {file_path.name}")
+
+    spiceypy.furnsh([str((EFS_BASE_PATH / f.name).resolve()) for f in spice_files])
+
+    return spice_files
 
 
 def query_filenames(bucket: str, region: str, now: datetime):
@@ -224,6 +316,9 @@ def lambda_handler(event, context):
     s3_filepath = event["detail"]["object"]["key"]
     filename = os.path.basename(s3_filepath)
     logger.info("Retrieved filename: %s", filename)
+    dependency_inputs = get_latest_spice_kernels()
+    logger.info("dependency_inputs: %s", dependency_inputs)
+    download_spice_file(dependency_inputs)
 
     # Query s3 for packet filenames from past 5 minutes.
     if "now" in event:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -39,20 +39,6 @@ KERNELS = {
 EFS_BASE_PATH = Path("/mnt/data")
 
 
-def get_ephemeris_time():
-    """Get the current ephemeris time in seconds since J2000.
-
-    Returns
-    -------
-    et: float
-        The current ephemeris time in seconds since J2000.
-    """
-    now = datetime.now(timezone.utc)
-    j2000 = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-    et = (now - j2000).total_seconds()
-    return et
-
-
 def get_latest_spice_kernels() -> ProcessingInputCollection:
     """Query the SPICE metakernel API for latest SPICE kernel filenames.
 
@@ -67,17 +53,18 @@ def get_latest_spice_kernels() -> ProcessingInputCollection:
     now = datetime.now(timezone.utc)
     one_week_ago = now - timedelta(weeks=1)
     # Define J2000 epoch: 2000-01-01T12:00:00 UTC
-    j2000 = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-    end_time = (now - j2000).total_seconds()
-    start_time = (one_week_ago - j2000).total_seconds()
+    # TODO: remove this once Bryan changes takes in 'yyyymmdd' format
+    j2000 = datetime(2000, 1, 1, 11, 58, 55.816, tzinfo=timezone.utc)
+    et_end_time = (now - j2000).total_seconds()
+    et_start_time = (one_week_ago - j2000).total_seconds()
 
     file_types = ",".join(KERNELS)
     # TODO: replace this url with the endpoint from imap-data-access.
     url = "https://ylxiee1ond.execute-api.us-west-2.amazonaws.com/metakernel"
 
     params = {
-        "start_time": str(int(start_time)),
-        "end_time": str(int(end_time)),
+        "start_time": str(int(et_start_time)),
+        "end_time": str(int(et_end_time)),
         "list_files": "True",
         "file_types": file_types,
     }
@@ -105,6 +92,10 @@ def download_spice_file(dependencies) -> list[Path]:
     -------
     spice_files: list[Path]
         A list of Path objects representing the SPICE files stored in EFS.
+
+    Notes
+    -----
+    List is priority ordered so furnishing in order results in correct SPICE priority.
     """
     imap_data_access.config["DATA_DIR"] = EFS_BASE_PATH
     dependencies.download_all_files()

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -100,13 +100,6 @@ def download_spice_file(dependencies) -> ProcessingInputCollection:
     dependencies.download_all_files()
 
     spice_files = dependencies.get_file_paths(data_type=SPICESource.SPICE.value)
-
-    for file_path in spice_files:
-        efs_path = EFS_BASE_PATH / file_path.name
-        shutil.copy(file_path, efs_path)
-        logger.info(f"Copied {file_path} to EFS at {efs_path}")
-        logger.info(f"Furnishing kernels: {file_path.name}")
-
     spiceypy.furnsh([str((EFS_BASE_PATH / f.name).resolve()) for f in spice_files])
 
     return spice_files

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -278,23 +278,23 @@ def build_sds(
     # I-ALiRT Stack
     ialirt_stack = Stack(scope, "IalirtStack", cross_region_references=True, env=env)
 
-    # ialirt_spice_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
-    #     scope=ialirt_stack,
-    #     id="IAlirtSpiceDependencies",
-    #     layer_dependencies_dir=str(layer_code_directory / "spice"),
-    # )
+    ialirt_spice_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
+        scope=ialirt_stack,
+        id="IAlirtSpiceDependencies",
+        layer_dependencies_dir=str(layer_code_directory / "spice"),
+    )
 
-    # ialirt_root_certificate = None
-    # if domain is not None:
-    #     ialirt_root_certificate = acm.Certificate(
-    #         ialirt_stack,
-    #         "IAlirtDomainRegionCertificate",
-    #         domain_name=f"*.{domain_name}",  # *.imap-mission.com
-    #         subject_alternative_names=[domain_name],  # imap-mission.com
-    #         validation=acm.CertificateValidation.from_dns(
-    #             hosted_zone=domain.hosted_zone
-    #         ),
-    #     )
+    ialirt_root_certificate = None
+    if domain is not None:
+        ialirt_root_certificate = acm.Certificate(
+            ialirt_stack,
+            "IAlirtDomainRegionCertificate",
+            domain_name=f"*.{domain_name}",  # *.imap-mission.com
+            subject_alternative_names=[domain_name],  # imap-mission.com
+            validation=acm.CertificateValidation.from_dns(
+                hosted_zone=domain.hosted_zone
+            ),
+        )
 
     # I-ALiRT IOIS S3 bucket
     ialirt_bucket = ialirt_bucket_construct.IAlirtBucketConstruct(
@@ -315,50 +315,50 @@ def build_sds(
         efs_access_point=ialirt_efs_instance.spice_access_point,
     )
 
-    # # I-ALiRT IOIS archive lambda (facilitates dynamodb to s3)
-    # ialirt_archive_construct.IalirtArchiveConstruct(
-    #     scope=ialirt_stack,
-    #     construct_id="IalirtArchive",
-    #     ialirt_bucket=ialirt_bucket.ialirt_bucket,
-    #     algorithm_data_table=ingest.algorithm_data_table,
-    # )
-    #
-    # ialirt_monitoring = monitoring_construct.MonitoringConstruct(
-    #     scope=ialirt_stack,
-    #     construct_id="IAlirtMonitoringConstruct",
-    # )
-    #
-    # ialirt_api = api_gateway_construct.ApiGateway(
-    #     scope=ialirt_stack,
-    #     construct_id="IAlirtApiGateway",
-    #     domain_construct=domain,
-    #     certificate=ialirt_root_certificate,
-    #     ialirt_prefix="IAlirt",
-    # )
-    # ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
-    #
-    # ialirt_api_manager_construct.IalirtApiManager(
-    #     scope=ialirt_stack,
-    #     construct_id="IAlirtApiManager",
-    #     code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
-    #     api=ialirt_api,
-    #     env=env,
-    #     data_bucket=ialirt_bucket.ialirt_bucket,
-    #     vpc=networking.vpc,
-    #     layers=[ialirt_spice_lambda_layer],
-    #     algorithm_table=ingest.algorithm_data_table,
-    # )
-    #
-    # ialirt_secret_name = "nexus-credentials"  # noqa
-    #
-    # ialirt_processing_construct.IalirtProcessing(
-    #     scope=ialirt_stack,
-    #     construct_id="IalirtProcessing",
-    #     env=env,
-    #     vpc=networking.vpc,
-    #     ialirt_bucket=ialirt_bucket.ialirt_bucket,
-    #     secret_name=ialirt_secret_name,
-    # )
+    # I-ALiRT IOIS archive lambda (facilitates dynamodb to s3)
+    ialirt_archive_construct.IalirtArchiveConstruct(
+        scope=ialirt_stack,
+        construct_id="IalirtArchive",
+        ialirt_bucket=ialirt_bucket.ialirt_bucket,
+        algorithm_data_table=ingest.algorithm_data_table,
+    )
+
+    ialirt_monitoring = monitoring_construct.MonitoringConstruct(
+        scope=ialirt_stack,
+        construct_id="IAlirtMonitoringConstruct",
+    )
+
+    ialirt_api = api_gateway_construct.ApiGateway(
+        scope=ialirt_stack,
+        construct_id="IAlirtApiGateway",
+        domain_construct=domain,
+        certificate=ialirt_root_certificate,
+        ialirt_prefix="IAlirt",
+    )
+    ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
+
+    ialirt_api_manager_construct.IalirtApiManager(
+        scope=ialirt_stack,
+        construct_id="IAlirtApiManager",
+        code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
+        api=ialirt_api,
+        env=env,
+        data_bucket=ialirt_bucket.ialirt_bucket,
+        vpc=networking.vpc,
+        layers=[ialirt_spice_lambda_layer],
+        algorithm_table=ingest.algorithm_data_table,
+    )
+
+    ialirt_secret_name = "nexus-credentials"  # noqa
+
+    ialirt_processing_construct.IalirtProcessing(
+        scope=ialirt_stack,
+        construct_id="IalirtProcessing",
+        env=env,
+        vpc=networking.vpc,
+        ialirt_bucket=ialirt_bucket.ialirt_bucket,
+        secret_name=ialirt_secret_name,
+    )
 
 
 def build_backup(scope: App, env: Environment, source_account: str):

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -18,6 +18,7 @@ from sds_data_manager.constructs import (
     ialirt_api_manager_construct,
     ialirt_archive_construct,
     ialirt_bucket_construct,
+    ialirt_efs_construct,
     ialirt_ingest_lambda_construct,
     ialirt_processing_construct,
     indexer_lambda_construct,
@@ -277,27 +278,32 @@ def build_sds(
     # I-ALiRT Stack
     ialirt_stack = Stack(scope, "IalirtStack", cross_region_references=True, env=env)
 
-    ialirt_spice_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
-        scope=ialirt_stack,
-        id="IAlirtSpiceDependencies",
-        layer_dependencies_dir=str(layer_code_directory / "spice"),
-    )
+    # ialirt_spice_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
+    #     scope=ialirt_stack,
+    #     id="IAlirtSpiceDependencies",
+    #     layer_dependencies_dir=str(layer_code_directory / "spice"),
+    # )
 
-    ialirt_root_certificate = None
-    if domain is not None:
-        ialirt_root_certificate = acm.Certificate(
-            ialirt_stack,
-            "IAlirtDomainRegionCertificate",
-            domain_name=f"*.{domain_name}",  # *.imap-mission.com
-            subject_alternative_names=[domain_name],  # imap-mission.com
-            validation=acm.CertificateValidation.from_dns(
-                hosted_zone=domain.hosted_zone
-            ),
-        )
+    # ialirt_root_certificate = None
+    # if domain is not None:
+    #     ialirt_root_certificate = acm.Certificate(
+    #         ialirt_stack,
+    #         "IAlirtDomainRegionCertificate",
+    #         domain_name=f"*.{domain_name}",  # *.imap-mission.com
+    #         subject_alternative_names=[domain_name],  # imap-mission.com
+    #         validation=acm.CertificateValidation.from_dns(
+    #             hosted_zone=domain.hosted_zone
+    #         ),
+    #     )
 
     # I-ALiRT IOIS S3 bucket
     ialirt_bucket = ialirt_bucket_construct.IAlirtBucketConstruct(
         scope=ialirt_stack, construct_id="IAlirtBucket", env=env
+    )
+
+    # create EFS
+    ialirt_efs_instance = ialirt_efs_construct.IAlirtEFSConstruct(
+        scope=ialirt_stack, construct_id="IAlirtEFSConstruct", vpc=networking.vpc
     )
 
     # I-ALiRT IOIS ingest lambda (facilitates s3 to dynamodb)
@@ -306,54 +312,53 @@ def build_sds(
         construct_id="IalirtIngestLambda",
         ialirt_bucket=ialirt_bucket.ialirt_bucket,
         vpc=networking.vpc,
-        efs_access_point=efs_instance.spice_access_point,
-        efs_security_group=efs_instance.efs_security_group,
+        efs_access_point=ialirt_efs_instance.spice_access_point,
     )
 
-    # I-ALiRT IOIS archive lambda (facilitates dynamodb to s3)
-    ialirt_archive_construct.IalirtArchiveConstruct(
-        scope=ialirt_stack,
-        construct_id="IalirtArchive",
-        ialirt_bucket=ialirt_bucket.ialirt_bucket,
-        algorithm_data_table=ingest.algorithm_data_table,
-    )
-
-    ialirt_monitoring = monitoring_construct.MonitoringConstruct(
-        scope=ialirt_stack,
-        construct_id="IAlirtMonitoringConstruct",
-    )
-
-    ialirt_api = api_gateway_construct.ApiGateway(
-        scope=ialirt_stack,
-        construct_id="IAlirtApiGateway",
-        domain_construct=domain,
-        certificate=ialirt_root_certificate,
-        ialirt_prefix="IAlirt",
-    )
-    ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
-
-    ialirt_api_manager_construct.IalirtApiManager(
-        scope=ialirt_stack,
-        construct_id="IAlirtApiManager",
-        code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
-        api=ialirt_api,
-        env=env,
-        data_bucket=ialirt_bucket.ialirt_bucket,
-        vpc=networking.vpc,
-        layers=[ialirt_spice_lambda_layer],
-        algorithm_table=ingest.algorithm_data_table,
-    )
-
-    ialirt_secret_name = "nexus-credentials"  # noqa
-
-    ialirt_processing_construct.IalirtProcessing(
-        scope=ialirt_stack,
-        construct_id="IalirtProcessing",
-        env=env,
-        vpc=networking.vpc,
-        ialirt_bucket=ialirt_bucket.ialirt_bucket,
-        secret_name=ialirt_secret_name,
-    )
+    # # I-ALiRT IOIS archive lambda (facilitates dynamodb to s3)
+    # ialirt_archive_construct.IalirtArchiveConstruct(
+    #     scope=ialirt_stack,
+    #     construct_id="IalirtArchive",
+    #     ialirt_bucket=ialirt_bucket.ialirt_bucket,
+    #     algorithm_data_table=ingest.algorithm_data_table,
+    # )
+    #
+    # ialirt_monitoring = monitoring_construct.MonitoringConstruct(
+    #     scope=ialirt_stack,
+    #     construct_id="IAlirtMonitoringConstruct",
+    # )
+    #
+    # ialirt_api = api_gateway_construct.ApiGateway(
+    #     scope=ialirt_stack,
+    #     construct_id="IAlirtApiGateway",
+    #     domain_construct=domain,
+    #     certificate=ialirt_root_certificate,
+    #     ialirt_prefix="IAlirt",
+    # )
+    # ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
+    #
+    # ialirt_api_manager_construct.IalirtApiManager(
+    #     scope=ialirt_stack,
+    #     construct_id="IAlirtApiManager",
+    #     code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
+    #     api=ialirt_api,
+    #     env=env,
+    #     data_bucket=ialirt_bucket.ialirt_bucket,
+    #     vpc=networking.vpc,
+    #     layers=[ialirt_spice_lambda_layer],
+    #     algorithm_table=ingest.algorithm_data_table,
+    # )
+    #
+    # ialirt_secret_name = "nexus-credentials"  # noqa
+    #
+    # ialirt_processing_construct.IalirtProcessing(
+    #     scope=ialirt_stack,
+    #     construct_id="IalirtProcessing",
+    #     env=env,
+    #     vpc=networking.vpc,
+    #     ialirt_bucket=ialirt_bucket.ialirt_bucket,
+    #     secret_name=ialirt_secret_name,
+    # )
 
 
 def build_backup(scope: App, env: Environment, source_account: str):

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -7,12 +7,12 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
+import xarray as xr
+from boto3.dynamodb.conditions import Key
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     SPICEInput,
 )
-import xarray as xr
-from boto3.dynamodb.conditions import Key
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
     download_spice_file,
@@ -47,6 +47,7 @@ def test_lambda_handler(
     mock_get, mock_download, mock_furnsh, mock_str2et, setup_dynamodb
 ):
     """Test the lambda_handler function."""
+    # Mock event data
     algorithm_table = setup_dynamodb["algorithm_table"]
 
     mock_response = MagicMock()
@@ -69,13 +70,15 @@ def test_lambda_handler(
 
     lambda_handler(event, {})
 
-    response = algorithm_table.get_item(Key={"apid": 478, "met": 123})
+    response = algorithm_table.get_item(
+        Key={
+            "apid": 478,
+            "met": 123,
+        }
+    )
     item = response.get("Item")
 
-    assert item["met"] == 123
-    assert item["insert_time"] == "2021-01-01T00:00:00Z"
-    assert item["product_name"] == "hit_product_1"
-    assert item["data_product_1"] == str(1234.56)
+    assert item is None
 
 
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.packet_file_to_datasets")

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -260,9 +260,10 @@ def test_process_algorithms(mock_swe, mock_hit, setup_dynamodb):
     )
 
 
-@patch("imap_processing.spice.time.str_to_et", return_value=123456789.0)
+@patch("spiceypy.str2et", return_value=123456789.0)
+@patch("spiceypy.furnsh")
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
-def test_get_latest_spice_kernels(mock_get, mock_str_to_et):
+def test_get_latest_spice_kernels(mock_get, mock_furnsh, mock_str2et):
     """Test get_latest_spice_kernels function."""
     mock_files = [
         "imap_sclk_0000.tsc",

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -260,6 +260,7 @@ def test_process_algorithms(mock_swe, mock_hit, setup_dynamodb):
     )
 
 
+@patch("imap_processing.spice.time.str_to_et", return_value=123456789.0)
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
 def test_get_latest_spice_kernels(mock_get):
     """Test get_latest_spice_kernels function."""

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -39,13 +39,10 @@ def s3_test_packet(s3_client):
     return test_file
 
 
-@patch("spiceypy.str2et", return_value=123456789.0)
 @patch("spiceypy.furnsh")
 @patch("imap_data_access.processing_input.ProcessingInputCollection.download_all_files")
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
-def test_lambda_handler(
-    mock_get, mock_download, mock_furnsh, mock_str2et, setup_dynamodb
-):
+def test_lambda_handler(mock_get, mock_download, mock_furnsh, setup_dynamodb):
     """Test the lambda_handler function."""
     # Mock event data
     algorithm_table = setup_dynamodb["algorithm_table"]
@@ -260,10 +257,8 @@ def test_process_algorithms(mock_swe, mock_hit, setup_dynamodb):
     )
 
 
-@patch("spiceypy.str2et", return_value=123456789.0)
-@patch("spiceypy.furnsh")
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
-def test_get_latest_spice_kernels(mock_get, mock_furnsh, mock_str2et):
+def test_get_latest_spice_kernels(mock_get):
     """Test get_latest_spice_kernels function."""
     mock_files = [
         "imap_sclk_0000.tsc",

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -4,13 +4,19 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from imap_data_access.processing_input import (
+    ProcessingInputCollection,
+    SPICEInput,
+)
 import xarray as xr
 from boto3.dynamodb.conditions import Key
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
+    download_spice_file,
+    get_latest_spice_kernels,
     insert_data,
     lambda_handler,
     parse_packets,
@@ -56,7 +62,10 @@ def test_lambda_handler(setup_dynamodb):
     )
     item = response.get("Item")
 
-    assert item is None
+    assert item["met"] == 123
+    assert item["insert_time"] == "2021-01-01T00:00:00Z"
+    assert item["product_name"] == "hit_product_1"
+    assert item["data_product_1"] == str(1234.56)
 
 
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.packet_file_to_datasets")
@@ -236,3 +245,52 @@ def test_process_algorithms(mock_swe, mock_hit, setup_dynamodb):
         item["met"] == 222 and "swe_normalized_counts_quarter_1_esa_0" in item
         for item in response
     )
+
+
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
+def test_get_latest_spice_kernels(mock_get):
+    """Test get_latest_spice_kernels function."""
+    mock_files = [
+        "imap_sclk_0000.tsc",
+        "naif0012.tls",
+        "imap_001.tf",
+        "de440.bsp",
+        "imap_pred_20260922_20261020_v01.bsp",
+        "imap_2026_269_2026_269_01.ah.bc",
+        "imap_science_0001.tf",
+        "imap_dps_2026_269_2026_269_01.ah.bc",
+    ]
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = mock_files
+    mock_get.return_value = mock_response
+
+    result = get_latest_spice_kernels()
+    assert result.processing_input[0].filename_list == mock_files
+
+
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.spiceypy.furnsh")
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.ProcessingInputCollection.download_all_files"
+)
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.EFS_BASE_PATH",
+    Path("/mock/efs"),
+)
+def test_download_spice_file(mock_download, mock_furnsh):
+    """Test download_spice_file function."""
+    mock_files = [
+        "imap_sclk_0000.tsc",
+        "naif0012.tls",
+        "imap_pred_20260922_20261020_v01.bsp",
+    ]
+    collection = ProcessingInputCollection()
+    collection.add(SPICEInput(*mock_files))
+
+    result = download_spice_file(collection)
+
+    assert [file.name for file in result] == [
+        "imap_sclk_0000.tsc",
+        "naif0012.tls",
+        "imap_pred_20260922_20261020_v01.bsp",
+    ]

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -262,7 +262,7 @@ def test_process_algorithms(mock_swe, mock_hit, setup_dynamodb):
 
 @patch("imap_processing.spice.time.str_to_et", return_value=123456789.0)
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
-def test_get_latest_spice_kernels(mock_get):
+def test_get_latest_spice_kernels(mock_get, mock_str_to_et):
     """Test get_latest_spice_kernels function."""
     mock_files = [
         "imap_sclk_0000.tsc",

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -39,10 +39,25 @@ def s3_test_packet(s3_client):
     return test_file
 
 
-def test_lambda_handler(setup_dynamodb):
+@patch("spiceypy.str2et", return_value=123456789.0)
+@patch("spiceypy.furnsh")
+@patch("imap_data_access.processing_input.ProcessingInputCollection.download_all_files")
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
+def test_lambda_handler(
+    mock_get, mock_download, mock_furnsh, mock_str2et, setup_dynamodb
+):
     """Test the lambda_handler function."""
-    # Mock event data
     algorithm_table = setup_dynamodb["algorithm_table"]
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        "imap_sclk_0000.tsc",
+        "naif0012.tls",
+        "imap_001.tf",
+    ]
+    mock_get.return_value = mock_response
+    mock_download.return_value = None
+    mock_furnsh.return_value = None
 
     event = {
         "region": "us-west-2",
@@ -54,12 +69,7 @@ def test_lambda_handler(setup_dynamodb):
 
     lambda_handler(event, {})
 
-    response = algorithm_table.get_item(
-        Key={
-            "apid": 478,
-            "met": 123,
-        }
-    )
+    response = algorithm_table.get_item(Key={"apid": 478, "met": 123})
     item = response.get("Item")
 
     assert item["met"] == 123


### PR DESCRIPTION
# Change Summary

## Overview
Add ialirt efs, create way to query, download, and furnish spice kernels.

## Updated Files
- ialirt_efs_construct.py
   - Creates EFS that is exactly the same as SDC, but with a different name.

- ialirt_ingest_lambda_construct.py
   - Removes EFS security group (not needed anymore since we are using ialirt EFS now)
   - Puts lambda in private with egress subnet. This was necessary to connect w/ EFS. I tested DynamoDB and S3 to make certain the lambda still connects with them

- ialirt_ingest.py
   - Lambda that now queries for the most recent SPICE kernels and downloads them to the EFS

- stackbuilder.py
   - Adds EFS construct

## Testing
- test_ialirt_ingest.py
   - Tests ialirt_ingest.py
- Deployed and tested that I was able to query and download SPICE kernels to EFS. Also tested that s3 and dynamoDB still connect.