### PR TITLE
I-ALiRT - added ancillary data

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -20,6 +20,8 @@ from imap_data_access.processing_input import (
     SPICESource,
 )
 from imap_processing import imap_module_directory
+from imap_processing.cdf.utils import load_cdf
+from imap_processing.ialirt.l0.parse_mag import process_packet
 from imap_processing.ialirt.l0.process_hit import process_hit
 from imap_processing.ialirt.l0.process_swe import process_swe
 from imap_processing.utils import packet_file_to_datasets
@@ -37,6 +39,35 @@ KERNELS = {
     "science_frames",
 }
 EFS_BASE_PATH = Path("/mnt/data")
+
+
+def get_ancillary(instrument, descriptor):
+    """Query and download ancillary data if not already present.
+
+    Parameters
+    ----------
+    instrument : str
+        The name of the instrument.
+    descriptor : str
+        The name of the descriptor.
+
+    Returns
+    -------
+    download_path : Path
+        Download path of calibration file.
+    """
+    imap_data_access.config["DATA_DIR"] = EFS_BASE_PATH
+    calibration_file = imap_data_access.query(
+        table="ancillary", instrument=instrument, descriptor=descriptor
+    )[0]
+
+    download_path = EFS_BASE_PATH / calibration_file["file_path"]
+
+    if not download_path.exists():
+        imap_data_access.download(calibration_file["file_path"])
+        logger.info(f"Adding to {download_path} to calibration files.")
+
+    return download_path
 
 
 def get_latest_spice_kernels() -> ProcessingInputCollection:
@@ -215,10 +246,23 @@ def process_algorithms(combined: xr.Dataset, algorithm_table):
     processors = [
         ("hit", process_hit),
         ("swe", process_swe),
+        ("mag", process_packet),
     ]
 
     for instrument, process_func in processors:
-        insert_data(process_func(combined), algorithm_table, instrument)
+        if instrument == "swe":
+            download_path = get_ancillary(instrument, "l1b-in-flight-cal")
+            result = process_func(combined, [download_path])
+        elif instrument == "mag":
+            download_path = get_ancillary(instrument, "l1b-calibration")
+            calibration_data = load_cdf(download_path)
+            result, _ = process_func(combined, calibration_data)
+        else:
+            result = process_func(combined)
+
+        logger.info("%s result: %s", instrument, result)
+        if result:
+            insert_data(result, algorithm_table, instrument)
 
 
 def insert_data(data: list[dict], algorithm_table, instrument: str):
@@ -255,7 +299,6 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
 
         if existing:
             if any(key.startswith(instrument) for key in existing.keys()):
-                logger.info(f"{instrument.upper()} data already exists for met={met}.")
                 continue
 
             update_expr = "SET " + ", ".join(
@@ -275,10 +318,9 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
                 UpdateExpression=update_expr,
                 ExpressionAttributeValues=expression_values,
             )
-            logger.info(f"Updated met={met} with {instrument.upper()} data.")
         else:
             algorithm_table.put_item(Item=raw)
-            logger.info(f"Inserted new {instrument.upper()} item for met={met}.")
+        logger.info(f"Inserted {instrument.upper()}.")
 
 
 def lambda_handler(event, context):

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -57,6 +57,7 @@ def get_ancillary(instrument, descriptor):
         Download path of calibration file.
     """
     imap_data_access.config["DATA_DIR"] = EFS_BASE_PATH
+    # TODO: this only takes the first file. Sort out what calibration files are needed.
     calibration_file = imap_data_access.query(
         table="ancillary", instrument=instrument, descriptor=descriptor
     )[0]

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -61,11 +61,8 @@ def get_ancillary(instrument, descriptor):
         table="ancillary", instrument=instrument, descriptor=descriptor
     )[0]
 
-    download_path = EFS_BASE_PATH / calibration_file["file_path"]
-
-    if not download_path.exists():
-        imap_data_access.download(calibration_file["file_path"])
-        logger.info(f"Adding to {download_path} to calibration files.")
+    download_path = imap_data_access.download(calibration_file["file_path"])
+    logger.info(f"Adding to {download_path} to calibration files.")
 
     return download_path
 

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -16,6 +16,7 @@ from imap_data_access.processing_input import (
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
     download_spice_file,
+    get_ancillary,
     get_latest_spice_kernels,
     insert_data,
     lambda_handler,
@@ -221,9 +222,13 @@ def test_insert_data(setup_dynamodb):
     assert item3["hit_e_a_side_low_en"] == Decimal("5.0")
 
 
+@mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.get_ancillary")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.process_hit")
+@mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.process_packet")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.process_swe")
-def test_process_algorithms(mock_swe, mock_hit, setup_dynamodb):
+def test_process_algorithms(
+    mock_swe, mock_packet, mock_hit, mock_get_ancillary, setup_dynamodb
+):
     """Tests process_algorithms function."""
     algorithm_table = setup_dynamodb["algorithm_table"]
 
@@ -241,6 +246,14 @@ def test_process_algorithms(mock_swe, mock_hit, setup_dynamodb):
             "swe_normalized_counts_quarter_1_esa_0": Decimal("0.123"),
         }
     ]
+    mock_packet.return_value = [
+        {
+            "apid": 478,
+            "met": 333,
+            "mag_phi_4s_b_gsm": Decimal("0.456"),
+        }
+    ]
+    mock_get_ancillary.return_value = Path("/mock/path.csv")
 
     process_algorithms(combined=None, algorithm_table=algorithm_table)
 
@@ -255,6 +268,7 @@ def test_process_algorithms(mock_swe, mock_hit, setup_dynamodb):
         item["met"] == 222 and "swe_normalized_counts_quarter_1_esa_0" in item
         for item in response
     )
+    assert any(item["met"] == 333 and "mag_phi_4s_b_gsm" in item for item in response)
 
 
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
@@ -304,3 +318,27 @@ def test_download_spice_file(mock_download, mock_furnsh):
         "naif0012.tls",
         "imap_pred_20260922_20261020_v01.bsp",
     ]
+
+
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.download"
+)
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.AncillaryFilePath"
+)
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.query")
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.EFS_BASE_PATH",
+    Path("/mock/efs"),
+)
+def test_get_ancillary(mock_query, mock_ancillaryfilepath, mock_download):
+    """Test get_ancillary function."""
+    mock_query.return_value = [{"file_path": "swe/l1b-in-flight-cal/calibration.cdf"}]
+    mock_path = Path("/mock/efs/swe/l1b-in-flight-cal/calibration.cdf")
+    mock_construct_path = MagicMock(return_value=mock_path)
+    mock_ancillaryfilepath.return_value.construct_path = mock_construct_path
+
+    with patch.object(Path, "exists", return_value=False):
+        path = get_ancillary("swe", "l1b-in-flight-cal")
+
+    assert path == mock_path

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -222,15 +222,17 @@ def test_insert_data(setup_dynamodb):
     assert item3["hit_e_a_side_low_en"] == Decimal("5.0")
 
 
+@mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.load_cdf")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.get_ancillary")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.process_hit")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.process_packet")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.process_swe")
 def test_process_algorithms(
-    mock_swe, mock_packet, mock_hit, mock_get_ancillary, setup_dynamodb
+    mock_swe, mock_packet, mock_hit, mock_get_ancillary, mock_load_cdf, setup_dynamodb
 ):
     """Tests process_algorithms function."""
     algorithm_table = setup_dynamodb["algorithm_table"]
+    mock_load_cdf.return_value = {"mock": "calibration data"}
 
     mock_hit.return_value = [
         {
@@ -246,13 +248,17 @@ def test_process_algorithms(
             "swe_normalized_counts_quarter_1_esa_0": Decimal("0.123"),
         }
     ]
-    mock_packet.return_value = [
-        {
-            "apid": 478,
-            "met": 333,
-            "mag_phi_4s_b_gsm": Decimal("0.456"),
-        }
-    ]
+    mock_packet.return_value = (
+        [
+            {
+                "apid": 478,
+                "met": 333,
+                "mag_phi_4s_b_gsm": Decimal("0.456"),
+            }
+        ],
+        None,
+    )
+
     mock_get_ancillary.return_value = Path("/mock/path.csv")
 
     process_algorithms(combined=None, algorithm_table=algorithm_table)

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -333,8 +333,9 @@ def test_download_spice_file(mock_download, mock_furnsh):
 )
 def test_get_ancillary(mock_query, mock_ancillaryfilepath, mock_download):
     """Test get_ancillary function."""
-    mock_query.return_value = [{"file_path": "swe/l1b-in-flight-cal/calibration.cdf"}]
     mock_path = Path("/mock/efs/swe/l1b-in-flight-cal/calibration.cdf")
+    mock_download.return_value = mock_path
+    mock_query.return_value = [{"file_path": "swe/l1b-in-flight-cal/calibration.cdf"}]
     mock_construct_path = MagicMock(return_value=mock_path)
     mock_ancillaryfilepath.return_value.construct_path = mock_construct_path
 


### PR DESCRIPTION
# Change Summary

## Overview
Added ability to download ancillary data from s3.

## Updated Files
- ialirt_ingest.py
   - Added ability to download ancillary data from s3.

## Testing
- test_ialirt_ingest.py
   - Deployed and confirmed that it is working.
