### PR TITLE
MNT: Change routes for batch jobs API

### DIFF
--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -256,7 +256,12 @@ class SdsApiManager(Construct):
             layers=layers,
         )
         api.add_route(
-            route="/batch-job",
+            route="/processing-jobs",
+            http_method="GET",
+            lambda_function=batch_job_query_api_lambda,
+        )
+        api.add_route(
+            route="/authorized/processing-jobs",
             http_method="GET",
             lambda_function=batch_job_query_api_lambda,
         )
@@ -275,7 +280,16 @@ class SdsApiManager(Construct):
             layers=layers,
         )
         api.add_route(
-            route="/batch-logs",
+            # {id+} is used to allow for any pathParams after /batch-logs/
+            # This is needed because the log stream ID can contain slashes
+            route="/processing-logs/{id+}",
+            http_method="GET",
+            lambda_function=batch_logs_api_lambda,
+        )
+        api.add_route(
+            # {id+} is used to allow for any pathParams after /batch-logs/
+            # This is needed because the log stream ID can contain slashes
+            route="/authorized/processing-logs/{id+}",
             http_method="GET",
             lambda_function=batch_logs_api_lambda,
         )

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/batch_logs_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/batch_logs_api.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from urllib.parse import unquote
 
 import boto3
 
@@ -30,25 +31,11 @@ def lambda_handler(event, context):
     """
     logger.info("Received event: " + json.dumps(event, indent=2))
 
-    if not event.get("queryStringParameters"):
-        return {
-            "statusCode": 400,
-            "body": (
-                "Required Batch job log stream ID. Please provide 'job_log_stream_id'. "
-                "Eg. job_log_stream_id=ProcessingJob-codice-l3/default/bcc41f2cc3f146eb"
-                "818a12eec1d7177c"
-            ),
-        }
-
-    job_log_stream_id = event["queryStringParameters"].get("job_log_stream_id")
-
-    if not job_log_stream_id:
-        logger.info("No job_log_stream_id provided in query parameters.")
-        return {
-            "statusCode": 400,
-            "body": json.dumps({"error": "job_log_stream_id is required."}),
-        }
-    logger.info(f"Fetching logs for job_log_stream_id: {job_log_stream_id}")
+    # NOTE: We are using pathParams with the {id+} field in the API Gateway
+    # We are guaranteed to have the id in the pathParameters and if it is not
+    # a valid id, we will return an error message below.
+    # e.g. ProcessingJob-codice-l3/default/bcc41f2cc3f146eb818a12eec1d7177c
+    job_log_stream_id = unquote(event["pathParameters"]["id"])
 
     # Get logs from CloudWatch
     try:
@@ -66,7 +53,9 @@ def lambda_handler(event, context):
         logger.error(f"Error fetching logs: {e}")
         return {
             "statusCode": 500,
-            "body": json.dumps({"error": f"Could not fetch logs: {e!s}"}),
+            "body": json.dumps(
+                {"error": f"Could not fetch logs for id [{job_log_stream_id}]: {e!s}"}
+            ),
         }
 
     return {

--- a/tests/lambda_endpoints/test_batch_logs_api.py
+++ b/tests/lambda_endpoints/test_batch_logs_api.py
@@ -6,27 +6,6 @@ from unittest.mock import patch
 from sds_data_manager.lambda_code.SDSCode.api_lambdas import batch_logs_api
 
 
-def test_lambda_handler_missing_query_params():
-    """Test lambda handler with missing query parameters."""
-    event = {}
-    result = batch_logs_api.lambda_handler(event, None)
-    assert result["statusCode"] == 400
-    assert "Required Batch job log stream ID." in result["body"]
-
-
-def test_lambda_handler_missing_job_log_stream_id():
-    """Test lambda handler with missing job_log_stream_id."""
-    event = {"queryStringParameters": {}}
-    result = batch_logs_api.lambda_handler(event, None)
-    assert result["statusCode"] == 400
-    assert "Required Batch job log stream ID." in result["body"]
-
-    event = {"queryStringParameters": {"job_log_stream_id": ""}}
-    result = batch_logs_api.lambda_handler(event, None)
-    assert result["statusCode"] == 400
-    assert "job_log_stream_id is required." in result["body"]
-
-
 def test_lambda_handler_success():
     """Test lambda handler with valid job_log_stream_id."""
 
@@ -40,11 +19,7 @@ def test_lambda_handler_success():
             }
 
     with patch.object(batch_logs_api, "LOGS_CLIENT", MockLogsClient()):
-        event = {
-            "queryStringParameters": {
-                "job_log_stream_id": "ProcessingJob-test/default/abc123"
-            }
-        }
+        event = {"pathParameters": {"id": "ProcessingJob-test/default/abc123"}}
         result = batch_logs_api.lambda_handler(event, None)
         assert result["statusCode"] == 200
         assert "log line 1" in result["body"]
@@ -60,11 +35,7 @@ def test_lambda_handler_logs_client_error():
             raise Exception("CloudWatch error")
 
     with patch.object(batch_logs_api, "LOGS_CLIENT", MockLogsClient()):
-        event = {
-            "queryStringParameters": {
-                "job_log_stream_id": "ProcessingJob-test/default/abc123"
-            }
-        }
+        event = {"pathParameters": {"id": "ProcessingJob-test/default/abc123"}}
         result = batch_logs_api.lambda_handler(event, None)
         assert result["statusCode"] == 500
         assert "Could not fetch logs" in result["body"]


### PR DESCRIPTION
* batch -> processing
* job id query param -> path param

Batch is an implementation detail IMO. We really want to refer to these more generally as "processing jobs" I think.

APIs should use path params for getting an ID from a route. This is a bit odd with the id containing slashes, but we can get it to work with a proxy+ url.