### PR TITLE
Add json header to query API

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/query_api.py
@@ -143,6 +143,7 @@ def lambda_handler(event, context):
     # Format the response
     response = {
         "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
         "body": json.dumps(search_results),  # returns a list of tuples
     }
 

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -112,6 +112,7 @@ def lambda_handler(event, context):
     # Format the response
     response = {
         "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
         "body": json.dumps(search_results),  # returns a list of tuples
     }
 

--- a/tests/lambda_endpoints/test_query_api.py
+++ b/tests/lambda_endpoints/test_query_api.py
@@ -62,8 +62,9 @@ def test_query_result_body(session):
 
     assert json.loads(returned_query["body"])
 
+
 def test_query_result_header(session):
-    """Tests that the query result header is json"""
+    """Tests that the query result header is json."""
     _populate_test_data(session)
     event = {"queryStringParameters": {}}
 

--- a/tests/lambda_endpoints/test_query_api.py
+++ b/tests/lambda_endpoints/test_query_api.py
@@ -62,6 +62,16 @@ def test_query_result_body(session):
 
     assert json.loads(returned_query["body"])
 
+def test_query_result_header(session):
+    """Tests that the query result header is json"""
+    _populate_test_data(session)
+    event = {"queryStringParameters": {}}
+
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["headers"] is not None
+    assert returned_query["headers"]["Content-Type"] == "application/json"
+
 
 def test_start_date_query(session, expected_response):
     """Test that start date can be queried."""


### PR DESCRIPTION
# Change Summary

## Overview
adds app json header to the query API - makes the API much nicer if using a client to poke the API

## Testing
Have added a unit test but this ciode is untested. Should be trivial change i am hoping :-)
