### PR TITLE
v7.0.0 Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "sds-data-manager"
-version = "6.0.0"
+version = "7.0.0"
 description = "IMAP Science Operations Center AWS data manager"
 authors = ["IMAP SDS Developers <imap.sdc@lists.lasp.colorado.edu>"]
 readme = "README.md"


### PR DESCRIPTION
Updated version number for the `v7.0.0` release (needed for SIT-4 re-run)