### PR TITLE
I-ALiRT - minor revision to grab latest calibration file

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -59,10 +59,19 @@ def get_ancillary(instrument, descriptor):
         Download path of calibration file.
     """
     imap_data_access.config["DATA_DIR"] = EFS_BASE_PATH
-    # TODO: this only takes the first file. Sort out what calibration files are needed.
-    calibration_file = imap_data_access.query(
-        table="ancillary", instrument=instrument, descriptor=descriptor
-    )[0]
+    calibration_files = imap_data_access.query(
+        table="ancillary",
+        instrument=instrument,
+        descriptor=descriptor,
+        version="latest",
+    )
+
+    if not calibration_files:
+        raise FileNotFoundError(
+            f"No calibration file found for {instrument=}, {descriptor=}"
+        )
+
+    calibration_file = calibration_files[0]
 
     download_path = imap_data_access.download(calibration_file["file_path"])
     logger.info(f"Adding to {download_path} to calibration files.")
@@ -268,11 +277,6 @@ def process_algorithms(combined: xr.Dataset, algorithm_table):
             result = process_func(combined)
 
         logger.info("%s result: %s", instrument, result)
-        # TODO: remove this once we fix codice and swapi
-        #  in imap_processing to use int(met).
-        for item in result:
-            if isinstance(item.get("met"), np.generic):
-                item["met"] = int(item["met"])
 
         if any(result) and all(result):
             insert_data(result, algorithm_table, instrument)


### PR DESCRIPTION
# Change Summary

## Overview
Quick update to grab the latest calibration file from each instrument.

## Updated Files
- ialirt_ingest.py
   - Quick update to grab the latest calibration file from each instrument.

## Testing
Tested in out in the console:
calibration_files = imap_data_access.query(
        table="ancillary", instrument="mag", descriptor="l1b-calibration", version="latest")
calibration_files
[{'file_path': 'imap/ancillary/mag/imap_mag_l1b-calibration_20240229_v001.cdf', 'instrument': 'mag', 'descriptor': 'l1b-calibration', 'start_date': '20240229', 'end_date': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '20250703 15:36:06'}]
calibration_files[0]
{'file_path': 'imap/ancillary/mag/imap_mag_l1b-calibration_20240229_v001.cdf', 'instrument': 'mag', 'descriptor': 'l1b-calibration', 'start_date': '20240229', 'end_date': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '20250703 15:36:06'}
