### PR TITLE
ENH: Add API Key authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,32 @@ Codespaces actually comes with a fully functional virtual desktop.  To open, cli
 Inside of the "scripts" folder is a python script you can use to call the APIs.  It is completely independent of the rest of the project, so you should be able to pull this single file out and run it anywhere.  It only depends on basic python libraries.
 
 Unfortunately right now you need to "hard code" in the lambda API URL and the Cognito App Client at the top of the file after every build.  I'm hoping in the future to determine a better way to automate this.
+
+
+## Account / User Management
+
+There are some things that may need to be run by administrators or updated outside of infrastructure
+as code. These are documented here to help future admins with the steps required.
+
+### API Keys for file access
+
+There are public endpoints and private/team endpoints. The private/team endpoints are meant
+to allow IMAP team members access to data files that may not be publicly released, get access
+to instrument job logs, etc.
+
+#### URLs
+
+The public urls are all located at the root level, with private authorization urls have an additional
+path prefix on the front to indicate it is a restricted endpoint. Examples:
+
+- `/query`: URL to query for publicly released files
+- `/authorized/query`: URL to query for private/team files in addition to public files. Uses oauth2 style
+  authentication, which is primarily used by humans on the team websites.
+- `/api-key/query`: URL to query for private/team files in addition to public files. Uses API keys
+  for authentication, which is primarily used by automated scripts at team institutions for data access.
+
+#### Key management
+
+Management of these keys is done through a script located at `sds_data_manager/lambda_code/authorization`.
+That script can add, remove, and list the current keys. To add keys, add the name and e-mail of the associated
+user or account and get returned an API Key that you can then give to the external user for access.

--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -16,6 +16,7 @@ from aws_cdk import aws_apigatewayv2_integrations as apigwv2_integrations
 from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_cloudwatch as cloudwatch
 from aws_cdk import aws_cloudwatch_actions as cloudwatch_actions
+from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_route53 as route53
 from aws_cdk import aws_route53_targets as targets
@@ -91,6 +92,29 @@ class ApiGateway(Construct):
             id=f"{self.lowercase_prefix}JwtAuthorizer",
             jwt_issuer=self.auth_issuer,
             jwt_audience=[self.auth_audience],
+        )
+
+        # Lambda function for API Key authorizer
+        self.api_key_authorizer_lambda = lambda_.Function(
+            self,
+            f"{self.lowercase_prefix}ApiKeyAuthorizerLambda",
+            runtime=lambda_.Runtime.PYTHON_3_13,
+            handler="lambda_api_key_authorizer.lambda_handler",
+            code=lambda_.Code.from_asset("sds_data_manager/lambda_code/authorization"),
+            timeout=Duration.seconds(10),
+        )
+        self.api_key_authorizer_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["ssm:GetParameter"],
+                resources=["arn:aws:ssm:*:*:parameter/imap-sdc-api-keys"],
+            )
+        )
+
+        self.api_key_authorizer = apigwv2_authorizers.HttpLambdaAuthorizer(
+            id=f"{self.lowercase_prefix}ApiKeyAuthorizer",
+            handler=self.api_key_authorizer_lambda,
+            response_types=[apigwv2_authorizers.HttpLambdaResponseType.SIMPLE],
+            identity_source=["$request.header.x-api-key"],
         )
 
         # Add a custom domain to the API if we have one
@@ -188,6 +212,9 @@ class ApiGateway(Construct):
     ):
         """Add a route to the HTTP API Gateway.
 
+        If the route begins with /authorized, use the JWT authorizer.
+        If the route beings with /api-key, use the API Key authorizer.
+
         Parameters
         ----------
         route : str
@@ -198,8 +225,14 @@ class ApiGateway(Construct):
             Lambda function to trigger when this route is hit.
         """
         # Add the authorizer to the route if it is a route that requires authentication
-        authorizer = self.authorizer if route.startswith("/auth") else None
-        authorization_scopes = [self.auth_scope] if route.startswith("/auth") else None
+        authorizer = None
+        authorization_scopes = None
+        if route.startswith("/api-key"):
+            authorizer = self.api_key_authorizer
+        elif route.startswith("/authorized"):
+            authorizer = self.authorizer
+            authorization_scopes = [self.auth_scope]
+
         # Add the route to the HTTP API
         self.api.add_routes(
             path=route,

--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -94,17 +94,18 @@ class SdsApiManager(Construct):
         upload_api_lambda.add_to_role_policy(s3_read_policy)
         upload_api_lambda.apply_removal_policy(cdk.RemovalPolicy.DESTROY)
 
+        # basic route: /upload/{proxy+}
+        # oauth2 JWT authorizer: /authorized/upload/{proxy+}
+        # API key authorizer: /api-key/upload/{proxy+}
+        auth_route_prefixes = ["", "/authorized", "/api-key"]
+
         # {proxy+} is used to allow for any pathParams after /upload/
-        api.add_route(
-            route="/upload/{proxy+}",
-            http_method="GET",
-            lambda_function=upload_api_lambda,
-        )
-        api.add_route(
-            route="/authorized/upload/{proxy+}",
-            http_method="GET",
-            lambda_function=upload_api_lambda,
-        )
+        for prefix in auth_route_prefixes:
+            api.add_route(
+                route=f"{prefix}/upload/{{proxy+}}",
+                http_method="GET",
+                lambda_function=upload_api_lambda,
+            )
 
         # query API lambda
         query_api_lambda = lambda_.Function(
@@ -126,16 +127,13 @@ class SdsApiManager(Construct):
             layers=layers,
         )
 
-        api.add_route(
-            route="/query",
-            http_method="GET",
-            lambda_function=query_api_lambda,
-        )
-        api.add_route(
-            route="/authorized/query",
-            http_method="GET",
-            lambda_function=query_api_lambda,
-        )
+        for prefix in auth_route_prefixes:
+            # {proxy+} is used to allow for any pathParams after /query/
+            api.add_route(
+                route=f"{prefix}/query",
+                http_method="GET",
+                lambda_function=query_api_lambda,
+            )
 
         # SPICE query API lambda
         spice_query_api_lambda = lambda_.Function(
@@ -208,16 +206,12 @@ class SdsApiManager(Construct):
         download_api.add_to_role_policy(s3_read_policy)
 
         # {proxy+} is used to allow for any pathParams after /download/
-        api.add_route(
-            route="/download/{proxy+}",
-            http_method="GET",
-            lambda_function=download_api,
-        )
-        api.add_route(
-            route="/authorized/download/{proxy+}",
-            http_method="GET",
-            lambda_function=download_api,
-        )
+        for prefix in auth_route_prefixes:
+            api.add_route(
+                route=f"{prefix}/download/{{proxy+}}",
+                http_method="GET",
+                lambda_function=download_api,
+            )
 
         universal_spin_table_handler = lambda_.Function(
             self,
@@ -255,16 +249,13 @@ class SdsApiManager(Construct):
             },
             layers=layers,
         )
-        api.add_route(
-            route="/processing-jobs",
-            http_method="GET",
-            lambda_function=batch_job_query_api_lambda,
-        )
-        api.add_route(
-            route="/authorized/processing-jobs",
-            http_method="GET",
-            lambda_function=batch_job_query_api_lambda,
-        )
+        for prefix in auth_route_prefixes:
+            # {proxy+} is used to allow for any pathParams after /processing-jobs/
+            api.add_route(
+                route=f"{prefix}/processing-jobs",
+                http_method="GET",
+                lambda_function=batch_job_query_api_lambda,
+            )
 
         # API to query batch job logs
         batch_logs_api_lambda = lambda_.Function(
@@ -279,20 +270,14 @@ class SdsApiManager(Construct):
             allow_public_subnet=True,
             layers=layers,
         )
-        api.add_route(
-            # {id+} is used to allow for any pathParams after /batch-logs/
-            # This is needed because the log stream ID can contain slashes
-            route="/processing-logs/{id+}",
-            http_method="GET",
-            lambda_function=batch_logs_api_lambda,
-        )
-        api.add_route(
-            # {id+} is used to allow for any pathParams after /batch-logs/
-            # This is needed because the log stream ID can contain slashes
-            route="/authorized/processing-logs/{id+}",
-            http_method="GET",
-            lambda_function=batch_logs_api_lambda,
-        )
+        for prefix in auth_route_prefixes:
+            api.add_route(
+                # {id+} is used to allow for any pathParams after /batch-logs/
+                # This is needed because the log stream ID can contain slashes
+                route=f"{prefix}/processing-logs/{{id+}}",
+                http_method="GET",
+                lambda_function=batch_logs_api_lambda,
+            )
 
         batch_logs_read_policy = iam.PolicyStatement(
             effect=iam.Effect.ALLOW,

--- a/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
+++ b/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
@@ -1,0 +1,27 @@
+"""Authorization for API Keys within the SDS."""
+
+import json
+
+import boto3
+
+# Retrieve the API keys from AWS Systems Manager Parameter Store
+# Do this outside of the lambda handler body to cache the keys
+# to avoid unnecessary calls to SSM
+ssm = boto3.client("ssm")
+try:
+    response = ssm.get_parameter(Name="imap-sdc-api-keys", WithDecryption=True)
+    key_dict = json.loads(response["Parameter"]["Value"])
+    valid_keys = set(key_dict.keys())
+except Exception:
+    # Could not load keys, deny access
+    valid_keys = set()
+
+
+def lambda_handler(event, context):
+    """Get the API Key from the request header and check if it is valid."""
+    api_key = event.get("headers", {}).get("x-api-key", None)
+
+    if api_key and api_key in valid_keys:
+        return {"isAuthorized": True, "context": {"apiKey": api_key}}
+    else:
+        return {"isAuthorized": False}

--- a/sds_data_manager/lambda_code/authorization/manage_api_keys.py
+++ b/sds_data_manager/lambda_code/authorization/manage_api_keys.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Simple script to manage API keys in AWS SSM Parameter Store (SecureString).
+
+AWS_PROFILE and AWS_REGION environment variables should be set to the appropriate values
+for the account and region where the SSM parameter is stored.
+
+Usage:
+  python manage_api_keys.py list
+  python manage_api_keys.py add <owner> <email>
+  python manage_api_keys.py remove <key>
+  AWS_PROFILE=imap-sdc-dev AWS_DEFAULT_REGION=us-west-2 \
+    python sds_data_manager/lambda_code/authorization/manage_api_keys.py \
+        add "First Last" "user@example.com"
+
+Requires AWS credentials with SSM permissions.
+"""
+
+import json
+import secrets
+import sys
+from datetime import UTC, datetime
+
+import boto3
+
+PARAM_NAME = "imap-sdc-api-keys"
+ssm = boto3.client("ssm")
+
+
+def get_keys():
+    """Retrieve API keys and metadata from SSM Parameter Store as a dict."""
+    try:
+        resp = ssm.get_parameter(Name=PARAM_NAME, WithDecryption=True)
+        return json.loads(resp["Parameter"]["Value"])
+    except ssm.exceptions.ParameterNotFound:
+        return {}
+    except Exception as e:
+        print(f"Error retrieving parameter: {e}")
+        sys.exit(1)
+
+
+def put_keys(keys):
+    """Store API keys and metadata in SSM Parameter Store as JSON."""
+    value = json.dumps(keys, indent=2)
+    try:
+        ssm.put_parameter(
+            Name=PARAM_NAME,
+            Value=value,
+            Type="SecureString",
+            Overwrite=True,
+        )
+        print(f"Updated {PARAM_NAME} with {len(keys)} key(s).")
+    except Exception as e:
+        print(f"Error updating parameter: {e}")
+        sys.exit(1)
+
+
+def list_keys():
+    """List current API keys and their metadata."""
+    keys = get_keys()
+    print("Current API Keys:")
+    for k, meta in keys.items():
+        owner = meta.get("owner", "?")
+        email = meta.get("email", "?")
+        created = meta.get("created", "?")
+        print(f"- {k}\n    owner={owner}, email={email}, created={created}")
+
+
+def add_key(owner, email):
+    """Generate and add a new API key with owner and email metadata."""
+    keys = get_keys()
+    # Generate a secure random 32-byte hex key
+    new_key = secrets.token_hex(32)
+    while new_key in keys:
+        new_key = secrets.token_hex(32)
+    keys[new_key] = {
+        "owner": owner,
+        "email": email,
+        "created": datetime.now(UTC).isoformat(),
+    }
+    put_keys(keys)
+    print(f"Added key: {new_key}")
+    print("Share this key securely with the user.")
+
+
+def remove_key(key):
+    """Remove an API key."""
+    keys = get_keys()
+    if key not in keys:
+        print("Key not found.")
+        return
+    del keys[key]
+    put_keys(keys)
+    print(f"Removed key: {key}")
+
+
+def main():
+    """CLI entry point."""
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python manage_api_keys.py [list|add|remove] <key> [owner] [email]"
+        )
+        sys.exit(1)
+    cmd = sys.argv[1]
+    if cmd == "list":
+        list_keys()
+    elif cmd == "add" and len(sys.argv) == 4:
+        add_key(sys.argv[2], sys.argv[3])
+    elif cmd == "remove" and len(sys.argv) == 3:
+        remove_key(sys.argv[2])
+    else:
+        print(
+            "Usage: python manage_api_keys.py [list|add|remove] <key> [owner] [email]"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/infrastructure/test_apigateway.py
+++ b/tests/infrastructure/test_apigateway.py
@@ -26,6 +26,8 @@ def template(stack, code):
     apigw.add_route("/test-route", "GET", test_func)
     # Add a route with an authorizer
     apigw.add_route("/authorized/test-route", "GET", test_func)
+    # Add a route with an API key authorizer
+    apigw.add_route("/api-key/test-route", "GET", test_func)
     template = Template.from_stack(stack)
     return template
 
@@ -43,14 +45,18 @@ def test_apigw_routes(template):
             },
         },
     )
-    # Test that we have an authorizer
-    template.resource_count_is("AWS::ApiGatewayV2::Authorizer", 1)
+    # Test that we have two authorizers
+    template.resource_count_is("AWS::ApiGatewayV2::Authorizer", 2)
     template.has_resource_properties(
         "AWS::ApiGatewayV2::Authorizer",
         props={"AuthorizerType": "JWT"},
     )
+    template.has_resource_properties(
+        "AWS::ApiGatewayV2::Authorizer",
+        props={"AuthorizerType": "REQUEST"},
+    )
 
-    template.resource_count_is("AWS::ApiGatewayV2::Route", 2)
+    template.resource_count_is("AWS::ApiGatewayV2::Route", 3)
     # No authorizer
     template.has_resource_properties(
         "AWS::ApiGatewayV2::Route",
@@ -60,6 +66,11 @@ def test_apigw_routes(template):
     template.has_resource_properties(
         "AWS::ApiGatewayV2::Route",
         props={"AuthorizationType": "JWT", "RouteKey": "GET /authorized/test-route"},
+    )
+    # Lambda authorizer
+    template.has_resource_properties(
+        "AWS::ApiGatewayV2::Route",
+        props={"AuthorizationType": "CUSTOM", "RouteKey": "GET /api-key/test-route"},
     )
 
 

--- a/tests/infrastructure/test_sds_api_manager_construct.py
+++ b/tests/infrastructure/test_sds_api_manager_construct.py
@@ -42,6 +42,6 @@ def template(stack, env):
 
 def test_indexer_role(template):
     """Ensure that the template has appropriate IAM roles."""
-    template.resource_count_is("AWS::IAM::Role", 10)
+    template.resource_count_is("AWS::IAM::Role", 11)
     # Ensure that the template has appropriate lambda count
-    template.resource_count_is("AWS::Lambda::Function", 9)
+    template.resource_count_is("AWS::Lambda::Function", 10)


### PR DESCRIPTION
This adds api key authorization through a lambda function authorizer. The keys are stored in AWS SSM and retrieved from there. There is a new script added to manage the keys, listing, removing, and adding keys that I tested out and currently is available in dev for you to try as well.

Then you can make a request like:
```
IMAP_API_KEY=key-you-made-from-script IMAP_DATA_ACCESS_URL=https://api.dev.imap-mission.com/api-key imap-data-access --debug query --instrument swapi
```

and you should get data back.