### PR TITLE
I-ALIRT - Coverage plots

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import boto3
-import botocore
 import imap_data_access
 import requests
 import spiceypy
@@ -56,7 +55,7 @@ def get_dsn(download_dir: Path):
     dsn_path = dsn_files[0]
 
     download_path = imap_data_access.download(dsn_path["file_path"])
-    logger.info(f"Adding to {download_path} to calibration files.")
+    logger.info(f"Downloading to {download_path}.")
 
     # Placeholder
     # TODO: parse the file and return a populated dict once we know the file structure.
@@ -105,8 +104,8 @@ def get_latest_spice_kernels() -> ProcessingInputCollection:
     return dependency_inputs
 
 
-def download_spice_file(dependencies) -> list[Path]:
-    """Download SPICE kernel files.
+def setup_spice_file(dependencies) -> list[Path]:
+    """Download and furnish SPICE kernel files.
 
     Parameters
     ----------
@@ -131,50 +130,44 @@ def download_spice_file(dependencies) -> list[Path]:
     return spice_files
 
 
-def get_latest_outage_file(bucket: str, region: str) -> str | None:
+def get_latest_outage_file(download_dir: Path) -> Path | None:
     """Get the most recent outage file key from S3.
 
     Parameters
     ----------
-    bucket : str
-        The name of the S3 bucket.
-    region : str
-        The region in which the s3 bucket resides.
+    download_dir : Path
+        The directory where the file will be downloaded.
 
     Returns
     -------
-    latest_outage_file : str
+    download_path : Path
         File path.
     """
-    s3_client = boto3.client(
-        "s3",
-        region_name=region,
-        config=botocore.client.Config(signature_version="s3v4"),
+    imap_data_access.config["DATA_DIR"] = download_dir
+    outages = imap_data_access.query(
+        table="ancillary",
+        instrument="ialirt",
+        descriptor="outages",
+        version="latest",
     )
-
-    response = s3_client.list_objects_v2(Bucket=bucket, Prefix="outages")
-    objects = response.get("Contents", [])
-    if not objects:
+    if not outages:
         return None
 
-    # Assumes filenames sort by date, e.g., outages_20260922.txt
-    latest_outage_file = max(objects, key=lambda obj: obj["Key"])["Key"]
-    return latest_outage_file
+    latest_outage_file = outages[0]
+
+    download_path = imap_data_access.download(latest_outage_file["file_path"])
+    logger.info(f"Downloading to {download_path}.")
+
+    return download_path
 
 
-def parse_outage_file(
-    bucket: str, region: str, key: str
-) -> dict[str, list[tuple[str, str]]]:
-    """Download outage file and parse into outages dict.
+def parse_outage_file(file_path: Path) -> dict[str, list[tuple[str, str]]]:
+    """Parse outage file into outages dict.
 
     Parameters
     ----------
-    bucket : str
-        The name of the S3 bucket.
-    region : str
-        The region in which the s3 bucket resides.
-    key : str
-        The key of the latest S3 object containing the outage data.
+    file_path : Path
+        File path.
 
     Returns
     -------
@@ -195,14 +188,7 @@ def parse_outage_file(
         ],
     }
     """
-    s3_client = boto3.client(
-        "s3",
-        region_name=region,
-        config=botocore.client.Config(signature_version="s3v4"),
-    )
-
-    response = s3_client.get_object(Bucket=bucket, Key=key)
-    content = response["Body"].read().decode("utf-8").strip().splitlines()
+    content = file_path.read_text(encoding="utf-8").strip().splitlines()
 
     outages: dict[str, list[tuple[str, str]]] = {}
     for line in content:
@@ -227,6 +213,12 @@ def generate_and_upload_30_days(bucket: str, region: str, outages: dict, dsn: di
         Dictionary containing outages data.
     dsn : dict
         Dictionary containing DSN data.
+
+    Notes
+    -----
+    Example dictionary structure for outages and dsn:
+    outages = {"Kiel": [("2026-09-22T13:50:00.00Z", "2026-09-22T14:10:00.00Z")]}
+    dsn = {"DSS-55": [("2026-09-22T08:00:00.00Z", "2026-09-22T09:00:00.00Z")]}
     """
     today = datetime.now(timezone.utc)
 
@@ -276,13 +268,13 @@ def lambda_handler(event, context):
     # Download latest SPICE kernels
     dependency_inputs = get_latest_spice_kernels()
     logger.info("dependency_inputs: %s", dependency_inputs)
-    download_spice_file(dependency_inputs)
+    setup_spice_file(dependency_inputs)
 
     # Get latest outage file
-    latest_key = get_latest_outage_file(bucket, region)
+    outage_file_path = get_latest_outage_file(Path("/tmp"))  # noqa: S108
 
-    if latest_key:
-        outages = parse_outage_file(bucket, region, latest_key)
+    if outage_file_path:
+        outages = parse_outage_file(outage_file_path)
         logger.info("Parsed outages: %s", outages)
     else:
         outages = {}

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -3,14 +3,13 @@
 import json
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
 import boto3
 import botocore
-from pathlib import Path
+import imap_data_access
 import requests
 import spiceypy
-
-
-import imap_data_access
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     SPICEInput,
@@ -22,8 +21,8 @@ logger.setLevel(logging.INFO)
 
 
 KERNELS = {
-    "planetary_ephemeris", # e.g., de440s.bsp
-    "planetary_constants", # e.g. pck00011.tpc
+    "planetary_ephemeris",  # e.g., de440s.bsp
+    "planetary_constants",  # e.g. pck00011.tpc
 }
 
 
@@ -37,9 +36,12 @@ def get_dsn(download_dir: Path):
 
     Returns
     -------
+    dsn_path : Path
+        Path to the downloaded DSN file.
     dsn_dict : dict
         Contents of latest contact schedule.
     """
+    imap_data_access.config["DATA_DIR"] = download_dir
     dsn_files = imap_data_access.query(
         table="ancillary",
         instrument="ialirt",
@@ -51,15 +53,16 @@ def get_dsn(download_dir: Path):
         dsn_dict = {}
         logger.info("No DSN files found for IALiRT. Returning empty dict.")
 
-    dsn_file = dsn_files[0]
+    dsn_path = dsn_files[0]
 
-    download_path = imap_data_access.download(dsn_file["file_path"])
+    download_path = imap_data_access.download(dsn_path["file_path"])
     logger.info(f"Adding to {download_path} to calibration files.")
 
+    # Placeholder
     # TODO: parse the file and return a populated dict once we know the file structure.
     dsn_dict = {}
 
-    return dsn_dict
+    return download_path, dsn_dict
 
 
 def get_latest_spice_kernels() -> ProcessingInputCollection:
@@ -159,8 +162,39 @@ def get_latest_outage_file(bucket: str, region: str) -> str | None:
     return latest_outage_file
 
 
-def parse_outage_file(bucket: str, region: str, key: str) -> dict[str, list[tuple[str, str]]]:
-    """Download outage file and parse into outages dict."""
+def parse_outage_file(
+    bucket: str, region: str, key: str
+) -> dict[str, list[tuple[str, str]]]:
+    """Download outage file and parse into outages dict.
+
+    Parameters
+    ----------
+    bucket : str
+        The name of the S3 bucket.
+    region : str
+        The region in which the s3 bucket resides.
+    key : str
+        The key of the latest S3 object containing the outage data.
+
+    Returns
+    -------
+    outages : dict
+        Dictionary containing the data.
+
+    Notes
+    -----
+    Input text file format:
+    Kiel,2026-09-22T13:50:00.00Z,2026-09-22T14:10:00Z
+    Kiel,2026-09-25T08:00:00.00Z,2026-09-25T09:30:00Z
+
+    Output dictionary structure:
+        outages = {
+        "Kiel": [
+            ("2026-09-22T13:50:00.00Z", "2026-09-22T14:10:00Z"),
+            ("2026-09-25T08:00:00.00Z", "2026-09-25T09:30:00Z"),
+        ],
+    }
+    """
     s3_client = boto3.client(
         "s3",
         region_name=region,
@@ -180,33 +214,57 @@ def parse_outage_file(bucket: str, region: str, key: str) -> dict[str, list[tupl
     return outages
 
 
-def upload_coverage_to_s3(bucket: str, region: str, key: str, table_output: str):
-    """Upload human-readable coverage summary table to S3."""
-    s3_client = boto3.client("s3", region_name=region)
-    s3_client.put_object(
-        Bucket=bucket,
-        Key=key,
-        Body=table_output.encode("utf-8"),
-        ContentType="text/plain"
-    )
-    logger.info(f"Uploaded coverage table to s3://{bucket}/{key}")
-
-
 def generate_and_upload_30_days(bucket: str, region: str, outages: dict, dsn: dict):
+    """Upload new coverage json files to S3.
+
+    Parameters
+    ----------
+    bucket : str
+        The name of the S3 bucket.
+    region : str
+        The region in which the s3 bucket resides.
+    outages : dict
+        Dictionary containing outages data.
+    dsn : dict
+        Dictionary containing DSN data.
+
+    Returns
+    -------
+    latest_outage_file : str
+        File path.
+    """
     today = datetime.now(timezone.utc)
 
     for i in range(30):
         day = today + timedelta(days=i)
         start_time = day.strftime("%Y-%m-%dT00:00:00Z")
 
-        coverage_dict = generate_coverage(start_time=start_time, outages=outages, dsn=dsn)
-        table_output = format_coverage_summary(coverage_dict, start_time)
+        # Placeholder for after we import from imap_processing.
+        # coverage_dict = generate_coverage(start_time=start_time, outages=outages, dsn=dsn)
+        # table_output = format_coverage_summary(coverage_dict, start_time)
+        table_output = (
+            "# I-ALiRT Coverage Summary\n"
+            "# Generated: 2026-09-22T00:00:00Z\n"
+            "# Stations: Kiel, DSS-55\n"
+            "# Time format: UTC (ISOC)\n"
+            "Time (UTC)                Kiel     DSS-55\n"
+            "-----------------------------------------\n"
+            "2026-09-22T07:00:00.000   1        0\n"
+            "2026-09-22T08:00:00.000   1        0\n"
+            "-----------------------------------------\n"
+            "Total Coverage Percent: 37.5%"
+        )
 
         output_key = f"coverage/coverage_{day.strftime('%Y%m%d')}.json"
 
-        upload_coverage_to_s3(bucket, region, output_key, table_output)
-        logger.info(f"Uploaded (overwritten if existed): s3://{bucket}/{output_key}")
-
+        s3_client = boto3.client("s3", region_name=region)
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=output_key,
+            Body=table_output.encode("utf-8"),
+            ContentType="text/plain",
+        )
+        logger.info(f"Uploaded coverage table to s3://{bucket}/{output_key}")
 
 
 def lambda_handler(event, context):
@@ -217,7 +275,7 @@ def lambda_handler(event, context):
     region = event["region"]
 
     # Get dsn_schedule
-    dsn = get_dsn(Path("/tmp"))  # noqa: S108
+    _, dsn = get_dsn(Path("/tmp"))  # noqa: S108
 
     # Download latest SPICE kernels
     dependency_inputs = get_latest_spice_kernels()
@@ -225,7 +283,7 @@ def lambda_handler(event, context):
     download_spice_file(dependency_inputs)
 
     # Get latest outage file
-    latest_key = get_latest_outage_file(bucket, region, "outages")
+    latest_key = get_latest_outage_file(bucket, region)
 
     if not latest_key:
         logger.info("No outage files found in bucket %s", bucket)
@@ -234,5 +292,3 @@ def lambda_handler(event, context):
     logger.info("Parsed outages: %s", outages)
 
     generate_and_upload_30_days(bucket, region, outages, dsn)
-
-    return

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -157,7 +157,7 @@ def get_latest_outage_file(bucket: str, region: str) -> str | None:
     if not objects:
         return None
 
-    # Assumes filenames sort by date, e.g., outages_2026_09_22.txt
+    # Assumes filenames sort by date, e.g., outages_20260922.txt
     latest_outage_file = max(objects, key=lambda obj: obj["Key"])["Key"]
     return latest_outage_file
 
@@ -227,20 +227,16 @@ def generate_and_upload_30_days(bucket: str, region: str, outages: dict, dsn: di
         Dictionary containing outages data.
     dsn : dict
         Dictionary containing DSN data.
-
-    Returns
-    -------
-    latest_outage_file : str
-        File path.
     """
     today = datetime.now(timezone.utc)
 
     for i in range(30):
         day = today + timedelta(days=i)
-        start_time = day.strftime("%Y-%m-%dT00:00:00Z")
+        # start_time = day.strftime("%Y-%m-%dT00:00:00Z")
 
         # Placeholder for after we import from imap_processing.
-        # coverage_dict = generate_coverage(start_time=start_time, outages=outages, dsn=dsn)
+        # coverage_dict = generate_coverage(start_time=start_time,
+        # outages=outages, dsn=dsn)
         # table_output = format_coverage_summary(coverage_dict, start_time)
         table_output = (
             "# I-ALiRT Coverage Summary\n"
@@ -285,10 +281,13 @@ def lambda_handler(event, context):
     # Get latest outage file
     latest_key = get_latest_outage_file(bucket, region)
 
-    if not latest_key:
-        logger.info("No outage files found in bucket %s", bucket)
-
-    outages = parse_outage_file(bucket, region, latest_key)
-    logger.info("Parsed outages: %s", outages)
+    if latest_key:
+        outages = parse_outage_file(bucket, region, latest_key)
+        logger.info("Parsed outages: %s", outages)
+    else:
+        outages = {}
+        logger.info(
+            "No outage files found in bucket %s. Using empty outages dict.", bucket
+        )
 
     generate_and_upload_30_days(bucket, region, outages, dsn)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -1,0 +1,238 @@
+"""IALiRT coverage plots lambda."""
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+import boto3
+import botocore
+from pathlib import Path
+import requests
+import spiceypy
+
+
+import imap_data_access
+from imap_data_access.processing_input import (
+    ProcessingInputCollection,
+    SPICEInput,
+    SPICESource,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+KERNELS = {
+    "planetary_ephemeris", # e.g., de440s.bsp
+    "planetary_constants", # e.g. pck00011.tpc
+}
+
+
+def get_dsn(download_dir: Path):
+    """Query and download DSN data.
+
+    Parameters
+    ----------
+    download_dir : Path
+        The directory where the file will be downloaded.
+
+    Returns
+    -------
+    dsn_dict : dict
+        Contents of latest contact schedule.
+    """
+    dsn_files = imap_data_access.query(
+        table="ancillary",
+        instrument="ialirt",
+        descriptor="contact-schedule",
+        version="latest",
+    )
+
+    if not dsn_files:
+        dsn_dict = {}
+        logger.info("No DSN files found for IALiRT. Returning empty dict.")
+
+    dsn_file = dsn_files[0]
+
+    download_path = imap_data_access.download(dsn_file["file_path"])
+    logger.info(f"Adding to {download_path} to calibration files.")
+
+    # TODO: parse the file and return a populated dict once we know the file structure.
+    dsn_dict = {}
+
+    return dsn_dict
+
+
+def get_latest_spice_kernels() -> ProcessingInputCollection:
+    """Query the SPICE metakernel API for latest SPICE kernel filenames.
+
+    Returns
+    -------
+    dependency_inputs: ProcessingInputCollection
+        A collection containing a SPICEInput object with the list of kernel filenames
+        returned from the metakernel API.
+    """
+    dependency_inputs = ProcessingInputCollection()
+
+    now = datetime.now(timezone.utc)
+    one_week_ago = now - timedelta(weeks=1)
+    # Define J2000 epoch: 2000-01-01T12:00:00 UTC
+    # TODO: remove this once Bryan changes takes in 'yyyymmdd' format
+    j2000 = datetime(2000, 1, 1, 11, 58, 56, tzinfo=timezone.utc)
+    et_end_time = (now - j2000).total_seconds()
+    et_start_time = (one_week_ago - j2000).total_seconds()
+
+    file_types = ",".join(KERNELS)
+    # TODO: replace this url with the endpoint from imap-data-access.
+    url = "https://ylxiee1ond.execute-api.us-west-2.amazonaws.com/metakernel"
+
+    params = {
+        "start_time": str(int(et_start_time)),
+        "end_time": str(int(et_end_time)),
+        "list_files": "True",
+        "file_types": file_types,
+    }
+
+    logger.info(f"Sending request to {url} with params: {params}")
+    response = requests.get(url, params=params, timeout=10)
+    metakernel_files = response.json()
+
+    logger.info(f"Found metakernel files: {metakernel_files}. Adding to collection.")
+    dependency_inputs.add(SPICEInput(*metakernel_files))
+
+    return dependency_inputs
+
+
+def download_spice_file(dependencies) -> list[Path]:
+    """Download SPICE kernel files.
+
+    Parameters
+    ----------
+    dependencies: ProcessingInputCollection
+        A collection containing a SPICEInput object with the list of kernel filenames
+        returned from the metakernel API.
+
+    Returns
+    -------
+    spice_files: list[Path]
+        A list of Path objects representing the SPICE files stored in EFS.
+
+    Notes
+    -----
+    List is priority ordered so furnishing in order results in correct SPICE priority.
+    """
+    dependencies.download_all_files()
+
+    spice_files = dependencies.get_file_paths(data_type=SPICESource.SPICE.value)
+    spiceypy.furnsh([str(file.resolve()) for file in spice_files])
+
+    return spice_files
+
+
+def get_latest_outage_file(bucket: str, region: str) -> str | None:
+    """Get the most recent outage file key from S3.
+
+    Parameters
+    ----------
+    bucket : str
+        The name of the S3 bucket.
+    region : str
+        The region in which the s3 bucket resides.
+
+    Returns
+    -------
+    latest_outage_file : str
+        File path.
+    """
+    s3_client = boto3.client(
+        "s3",
+        region_name=region,
+        config=botocore.client.Config(signature_version="s3v4"),
+    )
+
+    response = s3_client.list_objects_v2(Bucket=bucket, Prefix="outages")
+    objects = response.get("Contents", [])
+    if not objects:
+        return None
+
+    # Assumes filenames sort by date, e.g., outages_2026_09_22.txt
+    latest_outage_file = max(objects, key=lambda obj: obj["Key"])["Key"]
+    return latest_outage_file
+
+
+def parse_outage_file(bucket: str, region: str, key: str) -> dict[str, list[tuple[str, str]]]:
+    """Download outage file and parse into outages dict."""
+    s3_client = boto3.client(
+        "s3",
+        region_name=region,
+        config=botocore.client.Config(signature_version="s3v4"),
+    )
+
+    response = s3_client.get_object(Bucket=bucket, Key=key)
+    content = response["Body"].read().decode("utf-8").strip().splitlines()
+
+    outages: dict[str, list[tuple[str, str]]] = {}
+    for line in content:
+        if not line.strip():
+            continue
+        station, start, end = [x.strip() for x in line.split(",")]
+        outages.setdefault(station, []).append((start, end))
+
+    return outages
+
+
+def upload_coverage_to_s3(bucket: str, region: str, key: str, table_output: str):
+    """Upload human-readable coverage summary table to S3."""
+    s3_client = boto3.client("s3", region_name=region)
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=table_output.encode("utf-8"),
+        ContentType="text/plain"
+    )
+    logger.info(f"Uploaded coverage table to s3://{bucket}/{key}")
+
+
+def generate_and_upload_30_days(bucket: str, region: str, outages: dict, dsn: dict):
+    today = datetime.now(timezone.utc)
+
+    for i in range(30):
+        day = today + timedelta(days=i)
+        start_time = day.strftime("%Y-%m-%dT00:00:00Z")
+
+        coverage_dict = generate_coverage(start_time=start_time, outages=outages, dsn=dsn)
+        table_output = format_coverage_summary(coverage_dict, start_time)
+
+        output_key = f"coverage/coverage_{day.strftime('%Y%m%d')}.json"
+
+        upload_coverage_to_s3(bucket, region, output_key, table_output)
+        logger.info(f"Uploaded (overwritten if existed): s3://{bucket}/{output_key}")
+
+
+
+def lambda_handler(event, context):
+    """Create coverage json files."""
+    logger.info("Received event: %s", json.dumps(event))
+
+    bucket = event["detail"]["bucket"]["name"]
+    region = event["region"]
+
+    # Get dsn_schedule
+    dsn = get_dsn(Path("/tmp"))  # noqa: S108
+
+    # Download latest SPICE kernels
+    dependency_inputs = get_latest_spice_kernels()
+    logger.info("dependency_inputs: %s", dependency_inputs)
+    download_spice_file(dependency_inputs)
+
+    # Get latest outage file
+    latest_key = get_latest_outage_file(bucket, region, "outages")
+
+    if not latest_key:
+        logger.info("No outage files found in bucket %s", bucket)
+
+    outages = parse_outage_file(bucket, region, latest_key)
+    logger.info("Parsed outages: %s", outages)
+
+    generate_and_upload_30_days(bucket, region, outages, dsn)
+
+    return

--- a/tests/lambda_endpoints/test_ialirt_coverage.py
+++ b/tests/lambda_endpoints/test_ialirt_coverage.py
@@ -9,13 +9,13 @@ from imap_data_access.processing_input import (
 )
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import (
-    download_spice_file,
     generate_and_upload_30_days,
     get_dsn,
     get_latest_outage_file,
     get_latest_spice_kernels,
     lambda_handler,
     parse_outage_file,
+    setup_spice_file,
 )
 
 
@@ -62,38 +62,39 @@ def test_lambda_handler(
     lambda_handler(event, {})
 
 
-def test_get_latest_outage_file(s3_client):
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.imap_data_access.download"
+)
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.imap_data_access.AncillaryFilePath"
+)
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.imap_data_access.query")
+def test_get_latest_outage_file(
+    mock_query, mock_ancillaryfilepath, mock_download, tmp_path
+):
     """Test the get_latest_outage_file function."""
-    bucket = "test-data-bucket"
-    region = "us-west-2"
+    mock_path = Path("/ialirt/outages/outages_20260922.txt")
+    mock_download.return_value = mock_path
+    mock_query.return_value = [{"file_path": "ialirt/outages/outages_20260922.txt"}]
+    mock_construct_path = MagicMock(return_value=mock_path)
+    mock_ancillaryfilepath.return_value.construct_path = mock_construct_path
 
-    # Files in the desired time range
-    keys = [
-        "outages/outages_20260921.txt",
-        "outages/outages_20260922.txt",
-    ]
+    with patch.object(Path, "exists", return_value=False):
+        path = get_latest_outage_file(tmp_path)
 
-    for key in keys:
-        s3_client.put_object(Bucket=bucket, Key=key, Body=b"dummy data")
-
-    result = get_latest_outage_file(bucket, region)
-
-    assert result == "outages/outages_20260922.txt"
+    assert path == mock_path
 
 
-def test_parse_outage_file(s3_client):
-    """Test the parse_outage_file function."""
-    bucket = "test-data-bucket"
-    region = "us-west-2"
-    key = "outages_2026_09_22.txt"
+def test_parse_outage_file(tmp_path: Path):
+    """Test the parse_outage_file function with a local file."""
+    file_path = tmp_path / "outages_2026_09_22.txt"
     file_content = (
         "Kiel,2026-09-22T13:50:00.00Z,2026-09-22T14:10:00Z\n"
         "DSS-75,2026-09-25T08:00:00.00Z,2026-09-25T09:30:00Z\n"
     )
+    file_path.write_text(file_content, encoding="utf-8")
 
-    s3_client.put_object(Bucket=bucket, Key=key, Body=file_content)
-
-    outages = parse_outage_file(bucket, region, key)
+    outages = parse_outage_file(file_path)
 
     expected_outages = {
         "Kiel": [("2026-09-22T13:50:00.00Z", "2026-09-22T14:10:00Z")],
@@ -152,8 +153,8 @@ def test_get_latest_spice_kernels(mock_get):
 @patch(
     "sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.ProcessingInputCollection.download_all_files"
 )
-def test_download_spice_file(mock_download, mock_furnsh):
-    """Test download_spice_file function."""
+def test_setup_spice_file(mock_download, mock_furnsh):
+    """Test setup_spice_file function."""
     mock_files = [
         "de440.bsp",
         "pck00011.tpc",
@@ -161,7 +162,7 @@ def test_download_spice_file(mock_download, mock_furnsh):
     collection = ProcessingInputCollection()
     collection.add(SPICEInput(*mock_files))
 
-    result = download_spice_file(collection)
+    result = setup_spice_file(collection)
 
     assert [file.name for file in result] == [
         "de440.bsp",

--- a/tests/lambda_endpoints/test_ialirt_coverage.py
+++ b/tests/lambda_endpoints/test_ialirt_coverage.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     SPICEInput,
@@ -11,64 +10,56 @@ from imap_data_access.processing_input import (
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import (
     download_spice_file,
+    generate_and_upload_30_days,
     get_dsn,
     get_latest_outage_file,
     get_latest_spice_kernels,
+    lambda_handler,
     parse_outage_file,
 )
 
 
-@pytest.fixture
-def s3_test_packet(s3_client):
-    """Add a fake binary packet file to the mock S3 bucket."""
-    test_file = "iois_1_packets_YYYY_DOY_HH_MM_SS.ccsds"
-
-    s3_client.put_object(
-        Bucket="test-data-bucket",
-        Key=test_file,
-        Body=b"dummy test data",
-    )
-
-    return test_file
-
-
 @patch("spiceypy.furnsh")
 @patch("imap_data_access.processing_input.ProcessingInputCollection.download_all_files")
-@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
-def test_lambda_handler(mock_get, mock_download, mock_furnsh, setup_dynamodb):
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.requests.get")
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.get_dsn")
+def test_lambda_handler(
+    mock_get_dsn,
+    mock_requests_get,
+    mock_download,
+    mock_furnsh,
+    s3_client,
+):
     """Test the lambda_handler function."""
-    # Mock event data
-    algorithm_table = setup_dynamodb["algorithm_table"]
+    bucket = "test-data-bucket"
+    region = "us-west-2"
+
+    s3_client.put_object(
+        Bucket=bucket,
+        Key="outages_20260922.txt",
+        Body=(
+            "Kiel,2026-09-22T13:50:00.00Z,2026-09-22T14:10:00.00Z\n"
+            "DSS-75,2026-09-25T08:00:00.00Z,2026-09-25T09:30:00.00Z"
+        ),
+    )
 
     mock_response = MagicMock()
-    mock_response.json.return_value = [
-        "imap_sclk_0000.tsc",
-        "naif0012.tls",
-        "imap_001.tf",
-    ]
-    mock_get.return_value = mock_response
+    mock_response.json.return_value = ["de440.bsp", "pck00011.tpc"]
+    mock_requests_get.return_value = mock_response
+
     mock_download.return_value = None
     mock_furnsh.return_value = None
+    mock_get_dsn.return_value = (Path("/dsn_contact_schedule.txt"), {})
 
     event = {
-        "region": "us-west-2",
+        "region": region,
         "detail": {
             "object": {"key": "packets/file.txt"},
-            "bucket": {"name": "test-data-bucket"},
+            "bucket": {"name": bucket},
         },
     }
 
     lambda_handler(event, {})
-
-    response = algorithm_table.get_item(
-        Key={
-            "apid": 478,
-            "met": 123,
-        }
-    )
-    item = response.get("Item")
-
-    assert item is None
 
 
 def test_get_latest_outage_file(s3_client):
@@ -78,8 +69,8 @@ def test_get_latest_outage_file(s3_client):
 
     # Files in the desired time range
     keys = [
-        "outages/outages_2026_09_21.txt",
-        "outages/outages_2026_09_22.txt",
+        "outages/outages_20260921.txt",
+        "outages/outages_20260922.txt",
     ]
 
     for key in keys:
@@ -87,7 +78,7 @@ def test_get_latest_outage_file(s3_client):
 
     result = get_latest_outage_file(bucket, region)
 
-    assert result == "outages/outages_2026_09_22.txt"
+    assert result == "outages/outages_20260922.txt"
 
 
 def test_parse_outage_file(s3_client):
@@ -110,6 +101,35 @@ def test_parse_outage_file(s3_client):
     }
 
     assert outages == expected_outages
+
+
+def test_generate_and_upload_30_days(s3_client):
+    """Test the generate_and_upload_30_days function."""
+    bucket = "test-data-bucket"
+    region = "us-west-2"
+    s3_client.create_bucket(Bucket=bucket)
+
+    outages = {"Kiel": [("2026-09-22T13:50:00.00Z", "2026-09-22T14:10:00.00Z")]}
+    dsn = {"DSS-55": [("2026-09-22T08:00:00.00Z", "2026-09-22T09:00:00.00Z")]}
+
+    generate_and_upload_30_days(bucket, region, outages, dsn)
+
+    objects = s3_client.list_objects_v2(Bucket=bucket)
+    keys = [obj["Key"] for obj in objects.get("Contents", [])]
+
+    # Verify that 30 files were created
+    assert len(keys) == 30
+
+    # Check the naming pattern
+    assert keys[0].startswith("coverage/coverage_")
+
+    # Download and verify one file's content
+    response = s3_client.get_object(Bucket=bucket, Key=keys[0])
+    content = response["Body"].read().decode("utf-8")
+
+    assert "# I-ALiRT Coverage Summary" in content
+    assert "Kiel" in content
+    assert "DSS-55" in content
 
 
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.requests.get")
@@ -156,7 +176,7 @@ def test_download_spice_file(mock_download, mock_furnsh):
     "sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.imap_data_access.AncillaryFilePath"
 )
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.imap_data_access.query")
-def test_get_dsn(mock_query, mock_ancillaryfilepath, mock_download):
+def test_get_dsn(mock_query, mock_ancillaryfilepath, mock_download, tmp_path):
     """Test get_dsn function."""
     mock_path = Path("/ialirt/contact-schedule/dsn_file.txt")
     mock_download.return_value = mock_path
@@ -165,7 +185,7 @@ def test_get_dsn(mock_query, mock_ancillaryfilepath, mock_download):
     mock_ancillaryfilepath.return_value.construct_path = mock_construct_path
 
     with patch.object(Path, "exists", return_value=False):
-        path, dict = get_dsn(Path("/tmp"))
+        path, dict = get_dsn(tmp_path)
 
     assert path == mock_path
     assert dict == {}

--- a/tests/lambda_endpoints/test_ialirt_coverage.py
+++ b/tests/lambda_endpoints/test_ialirt_coverage.py
@@ -1,0 +1,180 @@
+"""Test the I-Alirt ingest lambda function."""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+import xarray as xr
+from boto3.dynamodb.conditions import Key
+from imap_data_access.processing_input import (
+    ProcessingInputCollection,
+    SPICEInput,
+)
+
+from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
+    download_spice_file,
+    get_ancillary,
+    get_latest_spice_kernels,
+    insert_data,
+    lambda_handler,
+    parse_packets,
+    process_algorithms,
+    query_filenames,
+)
+from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import get_latest_outage_file
+
+
+@pytest.fixture
+def s3_test_packet(s3_client):
+    """Add a fake binary packet file to the mock S3 bucket."""
+    test_file = "iois_1_packets_YYYY_DOY_HH_MM_SS.ccsds"
+
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key=test_file,
+        Body=b"dummy test data",
+    )
+
+    return test_file
+
+
+@patch("spiceypy.furnsh")
+@patch("imap_data_access.processing_input.ProcessingInputCollection.download_all_files")
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
+def test_lambda_handler(mock_get, mock_download, mock_furnsh, setup_dynamodb):
+    """Test the lambda_handler function."""
+    # Mock event data
+    algorithm_table = setup_dynamodb["algorithm_table"]
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        "imap_sclk_0000.tsc",
+        "naif0012.tls",
+        "imap_001.tf",
+    ]
+    mock_get.return_value = mock_response
+    mock_download.return_value = None
+    mock_furnsh.return_value = None
+
+    event = {
+        "region": "us-west-2",
+        "detail": {
+            "object": {"key": "packets/file.txt"},
+            "bucket": {"name": "test-data-bucket"},
+        },
+    }
+
+    lambda_handler(event, {})
+
+    response = algorithm_table.get_item(
+        Key={
+            "apid": 478,
+            "met": 123,
+        }
+    )
+    item = response.get("Item")
+
+    assert item is None
+
+
+def test_get_latest_outage_file(s3_client):
+    """Test the query_filenames function."""
+    bucket = "test-data-bucket"
+    region = "us-west-2"
+
+    # Files in the desired time range
+    keys = [
+        "outages/outages_2026_09_21.txt",
+        "outages/outages_2026_09_22.txt",
+    ]
+
+    for key in keys:
+        s3_client.put_object(Bucket=bucket, Key=key, Body=b"dummy data")
+
+    result = get_latest_outage_file(bucket, region)
+
+    assert result == 'outages/outages_2026_09_22.txt'
+
+
+def test_query_filenames_crossing_hour_boundary(s3_client):
+    """Test query_filenames when crossing hour boundary."""
+    bucket = "test-data-bucket"
+    region = "us-west-2"
+
+    now = datetime(2025, 4, 28, 1, 2, 0, tzinfo=timezone.utc)
+
+    first_prefix_key = "packets/iois_1_packets_2025_118_00_58_00"
+    second_prefix_key = "packets/iois_1_packets_2025_118_01_00_00"
+    outside_range_key = "packets/iois_1_packets_2025_118_00_50_00"
+
+    for key in [first_prefix_key, second_prefix_key, outside_range_key]:
+        s3_client.put_object(Bucket=bucket, Key=key, Body=b"dummy data")
+
+    result = query_filenames(bucket, region, now)
+
+    assert sorted(result) == sorted([first_prefix_key, second_prefix_key])
+
+
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.requests.get")
+def test_get_latest_spice_kernels(mock_get):
+    """Test get_latest_spice_kernels function."""
+    mock_files = [
+        "de440.bsp",
+        "pck00011.tpc",
+    ]
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = mock_files
+    mock_get.return_value = mock_response
+
+    result = get_latest_spice_kernels()
+    assert result.processing_input[0].filename_list == mock_files
+
+
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.spiceypy.furnsh")
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.ProcessingInputCollection.download_all_files"
+)
+def test_download_spice_file(mock_download, mock_furnsh):
+    """Test download_spice_file function."""
+    mock_files = [
+        "de440.bsp",
+        "pck00011.tpc",
+    ]
+    collection = ProcessingInputCollection()
+    collection.add(SPICEInput(*mock_files))
+
+    result = download_spice_file(collection)
+
+    assert [file.name for file in result] == [
+        "de440.bsp",
+        "pck00011.tpc",
+    ]
+
+
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.download"
+)
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.AncillaryFilePath"
+)
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.query")
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.EFS_BASE_PATH",
+    Path("/mock/efs"),
+)
+def test_get_dsn(mock_query, mock_ancillaryfilepath, mock_download):
+    """Test get_ancillary function."""
+    mock_path = Path("/mock/efs/swe/l1b-in-flight-cal/calibration.cdf")
+    mock_download.return_value = mock_path
+    mock_query.return_value = [{"file_path": "swe/l1b-in-flight-cal/calibration.cdf"}]
+    mock_construct_path = MagicMock(return_value=mock_path)
+    mock_ancillaryfilepath.return_value.construct_path = mock_construct_path
+
+    with patch.object(Path, "exists", return_value=False):
+        path = get_ancillary("swe", "l1b-in-flight-cal")
+
+    assert path == mock_path

--- a/tests/lambda_endpoints/test_ialirt_coverage.py
+++ b/tests/lambda_endpoints/test_ialirt_coverage.py
@@ -1,30 +1,21 @@
-"""Test the I-Alirt ingest lambda function."""
+"""Test the I-Alirt coverage lambda function."""
 
-from datetime import datetime, timezone
-from decimal import Decimal
 from pathlib import Path
-from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
-import xarray as xr
-from boto3.dynamodb.conditions import Key
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     SPICEInput,
 )
 
-from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
+from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import (
     download_spice_file,
-    get_ancillary,
+    get_dsn,
+    get_latest_outage_file,
     get_latest_spice_kernels,
-    insert_data,
-    lambda_handler,
-    parse_packets,
-    process_algorithms,
-    query_filenames,
+    parse_outage_file,
 )
-from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import get_latest_outage_file
 
 
 @pytest.fixture
@@ -81,7 +72,7 @@ def test_lambda_handler(mock_get, mock_download, mock_furnsh, setup_dynamodb):
 
 
 def test_get_latest_outage_file(s3_client):
-    """Test the query_filenames function."""
+    """Test the get_latest_outage_file function."""
     bucket = "test-data-bucket"
     region = "us-west-2"
 
@@ -96,26 +87,29 @@ def test_get_latest_outage_file(s3_client):
 
     result = get_latest_outage_file(bucket, region)
 
-    assert result == 'outages/outages_2026_09_22.txt'
+    assert result == "outages/outages_2026_09_22.txt"
 
 
-def test_query_filenames_crossing_hour_boundary(s3_client):
-    """Test query_filenames when crossing hour boundary."""
+def test_parse_outage_file(s3_client):
+    """Test the parse_outage_file function."""
     bucket = "test-data-bucket"
     region = "us-west-2"
+    key = "outages_2026_09_22.txt"
+    file_content = (
+        "Kiel,2026-09-22T13:50:00.00Z,2026-09-22T14:10:00Z\n"
+        "DSS-75,2026-09-25T08:00:00.00Z,2026-09-25T09:30:00Z\n"
+    )
 
-    now = datetime(2025, 4, 28, 1, 2, 0, tzinfo=timezone.utc)
+    s3_client.put_object(Bucket=bucket, Key=key, Body=file_content)
 
-    first_prefix_key = "packets/iois_1_packets_2025_118_00_58_00"
-    second_prefix_key = "packets/iois_1_packets_2025_118_01_00_00"
-    outside_range_key = "packets/iois_1_packets_2025_118_00_50_00"
+    outages = parse_outage_file(bucket, region, key)
 
-    for key in [first_prefix_key, second_prefix_key, outside_range_key]:
-        s3_client.put_object(Bucket=bucket, Key=key, Body=b"dummy data")
+    expected_outages = {
+        "Kiel": [("2026-09-22T13:50:00.00Z", "2026-09-22T14:10:00Z")],
+        "DSS-75": [("2026-09-25T08:00:00.00Z", "2026-09-25T09:30:00Z")],
+    }
 
-    result = query_filenames(bucket, region, now)
-
-    assert sorted(result) == sorted([first_prefix_key, second_prefix_key])
+    assert outages == expected_outages
 
 
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.requests.get")
@@ -156,25 +150,22 @@ def test_download_spice_file(mock_download, mock_furnsh):
 
 
 @patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.download"
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.imap_data_access.download"
 )
 @patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.AncillaryFilePath"
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.imap_data_access.AncillaryFilePath"
 )
-@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_data_access.query")
-@patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.EFS_BASE_PATH",
-    Path("/mock/efs"),
-)
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.imap_data_access.query")
 def test_get_dsn(mock_query, mock_ancillaryfilepath, mock_download):
-    """Test get_ancillary function."""
-    mock_path = Path("/mock/efs/swe/l1b-in-flight-cal/calibration.cdf")
+    """Test get_dsn function."""
+    mock_path = Path("/ialirt/contact-schedule/dsn_file.txt")
     mock_download.return_value = mock_path
-    mock_query.return_value = [{"file_path": "swe/l1b-in-flight-cal/calibration.cdf"}]
+    mock_query.return_value = [{"file_path": "ialirt/contact-schedule/dsn_file.txt"}]
     mock_construct_path = MagicMock(return_value=mock_path)
     mock_ancillaryfilepath.return_value.construct_path = mock_construct_path
 
     with patch.object(Path, "exists", return_value=False):
-        path = get_ancillary("swe", "l1b-in-flight-cal")
+        path, dict = get_dsn(Path("/tmp"))
 
     assert path == mock_path
+    assert dict == {}


### PR DESCRIPTION
# Change Summary

## Overview
Adds code that will be used to generate json files that the webteam will use to create coverage plots that show coverage for each ground station partner and DSS station. This code incorporates outages as well.

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
- ialirt_coverage.py
   - Code that will be used to generate json files that the webteam will use to create coverage plots that show coverage for each ground station partner and DSS station. 

## Testing
test_ialirt_coverage.py
