### PR TITLE
Add capability to query by ingest date within SPICE API

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -38,7 +38,13 @@ def lambda_handler(event, context):
         query = select(models.SPICEFiles)
 
         # get a list of all valid search parameters
-        valid_parameters = ["file_name", "start_time", "end_time", "type", "latest"]
+        valid_parameters = ["file_name", 
+                            "start_time", 
+                            "end_time", 
+                            "type", 
+                            "latest",
+                            "start_ingest_date",
+                            "end_ingest_date"]
 
         # go through each query parameter to set up sqlalchemy query conditions
         for param, value in query_params.items():
@@ -99,6 +105,10 @@ def lambda_handler(event, context):
                     (models.SPICEFiles.file_root == latest_versions_subq.c.file_root)
                     & (models.SPICEFiles.version == latest_versions_subq.c.max_version),
                 )
+            elif param == 'start_ingest_date':
+                query = query.where(models.SPICEFiles.ingestion_date >= datetime.datetime.strptime(value, "%Y%m%d"))
+            elif param == 'end_ingest_date':
+                query = query.where(models.SPICEFiles.ingestion_date <= datetime.datetime.strptime(value, "%Y%m%d"))
 
         search_results = session.execute(query).scalars().all()
 

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -64,59 +64,50 @@ def lambda_handler(event, context):
                     " valid options are: {valid_parameters}"
                 )
                 return response
-
-            if param == "start_time":
-                try:
+            try:
+                if param == "start_time":
                     query = query.where(models.SPICEFiles.max_date_j2000 >= int(value))
-                except ValueError:
-                    response = {
-                        "statusCode": 400,
-                        "body": json.dumps(f"Invalid value for {param}: {value}"),
-                    }
-                    logger.debug(f"Invalid value for {param}: {value}")
-                    return response
-            elif param == "end_time":
-                try:
+                elif param == "end_time":
                     query = query.where(models.SPICEFiles.min_date_j2000 <= int(value))
-                except ValueError:
-                    response = {
-                        "statusCode": 400,
-                        "body": json.dumps(f"Invalid value for {param}: {value}"),
-                    }
-                    logger.debug(f"Invalid value for {param}: {value}")
-                    return response
-            elif param == "type":
-                query = query.where(models.SPICEFiles.kernel_type == value)
-            elif param == "file_name":
-                query = query.where(models.SPICEFiles.file_name == value)
-            elif param == "latest" and value.lower() == "true":
-                # Make a subquery that gives us (file_root, MAX(version))
-                latest_versions_subq = (
-                    session.query(
-                        models.SPICEFiles.file_root,
-                        func.max(models.SPICEFiles.version).label("max_version"),
+                elif param == "type":
+                    query = query.where(models.SPICEFiles.kernel_type == value)
+                elif param == "file_name":
+                    query = query.where(models.SPICEFiles.file_name == value)
+                elif param == "latest" and value.lower() == "true":
+                    # Make a subquery that gives us (file_root, MAX(version))
+                    latest_versions_subq = (
+                        session.query(
+                            models.SPICEFiles.file_root,
+                            func.max(models.SPICEFiles.version).label("max_version"),
+                        )
+                        .group_by(models.SPICEFiles.file_root)
+                        .subquery()
                     )
-                    .group_by(models.SPICEFiles.file_root)
-                    .subquery()
-                )
 
-                # Join main query to subquery so that we only keep rows
-                # with the matching max version for each file_root
-                query = query.join(
-                    latest_versions_subq,
-                    (models.SPICEFiles.file_root == latest_versions_subq.c.file_root)
-                    & (models.SPICEFiles.version == latest_versions_subq.c.max_version),
-                )
-            elif param == "start_ingest_date":
-                query = query.where(
-                    models.SPICEFiles.ingestion_date
-                    >= datetime.datetime.strptime(value, "%Y%m%d")
-                )
-            elif param == "end_ingest_date":
-                query = query.where(
-                    models.SPICEFiles.ingestion_date
-                    <= datetime.datetime.strptime(value, "%Y%m%d")
-                )
+                    # Join main query to subquery so that we only keep rows
+                    # with the matching max version for each file_root
+                    query = query.join(
+                        latest_versions_subq,
+                        (models.SPICEFiles.file_root == latest_versions_subq.c.file_root)
+                        & (models.SPICEFiles.version == latest_versions_subq.c.max_version),
+                    )
+                elif param == "start_ingest_date":
+                    query = query.where(
+                        models.SPICEFiles.ingestion_date
+                        >= datetime.datetime.strptime(value, "%Y%m%d")
+                    )
+                elif param == "end_ingest_date":
+                    query = query.where(
+                        models.SPICEFiles.ingestion_date
+                        <= datetime.datetime.strptime(value, "%Y%m%d")
+                    )
+            except ValueError:
+                response = {
+                    "statusCode": 400,
+                    "body": json.dumps(f"Invalid value for {param}: {value}"),
+                }
+                logger.debug(f"Invalid value for {param}: {value}")
+                return response
 
         search_results = session.execute(query).scalars().all()
 

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -88,8 +88,14 @@ def lambda_handler(event, context):
                     # with the matching max version for each file_root
                     query = query.join(
                         latest_versions_subq,
-                        (models.SPICEFiles.file_root == latest_versions_subq.c.file_root)
-                        & (models.SPICEFiles.version == latest_versions_subq.c.max_version),
+                        (
+                            models.SPICEFiles.file_root
+                            == latest_versions_subq.c.file_root
+                        )
+                        & (
+                            models.SPICEFiles.version
+                            == latest_versions_subq.c.max_version
+                        ),
                     )
                 elif param == "start_ingest_date":
                     query = query.where(

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -98,15 +98,11 @@ def lambda_handler(event, context):
                         ),
                     )
                 elif param == "start_ingest_date":
-                    query = query.where(
-                        models.SPICEFiles.ingestion_date
-                        >= datetime.datetime.strptime(value, "%Y%m%d")
-                    )
+                    parsed_date = datetime.datetime.strptime(value, "%Y%m%d")
+                    query = query.where(models.SPICEFiles.ingestion_date >= parsed_date)
                 elif param == "end_ingest_date":
-                    query = query.where(
-                        models.SPICEFiles.ingestion_date
-                        <= datetime.datetime.strptime(value, "%Y%m%d")
-                    )
+                    parsed_date = datetime.datetime.strptime(value, "%Y%m%d")
+                    query = query.where(models.SPICEFiles.ingestion_date <= parsed_date)
             except ValueError:
                 response = {
                     "statusCode": 400,

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
@@ -38,13 +38,15 @@ def lambda_handler(event, context):
         query = select(models.SPICEFiles)
 
         # get a list of all valid search parameters
-        valid_parameters = ["file_name", 
-                            "start_time", 
-                            "end_time", 
-                            "type", 
-                            "latest",
-                            "start_ingest_date",
-                            "end_ingest_date"]
+        valid_parameters = [
+            "file_name",
+            "start_time",
+            "end_time",
+            "type",
+            "latest",
+            "start_ingest_date",
+            "end_ingest_date",
+        ]
 
         # go through each query parameter to set up sqlalchemy query conditions
         for param, value in query_params.items():
@@ -105,10 +107,16 @@ def lambda_handler(event, context):
                     (models.SPICEFiles.file_root == latest_versions_subq.c.file_root)
                     & (models.SPICEFiles.version == latest_versions_subq.c.max_version),
                 )
-            elif param == 'start_ingest_date':
-                query = query.where(models.SPICEFiles.ingestion_date >= datetime.datetime.strptime(value, "%Y%m%d"))
-            elif param == 'end_ingest_date':
-                query = query.where(models.SPICEFiles.ingestion_date <= datetime.datetime.strptime(value, "%Y%m%d"))
+            elif param == "start_ingest_date":
+                query = query.where(
+                    models.SPICEFiles.ingestion_date
+                    >= datetime.datetime.strptime(value, "%Y%m%d")
+                )
+            elif param == "end_ingest_date":
+                query = query.where(
+                    models.SPICEFiles.ingestion_date
+                    <= datetime.datetime.strptime(value, "%Y%m%d")
+                )
 
         search_results = session.execute(query).scalars().all()
 

--- a/tests/lambda_endpoints/test_spice_query_api.py
+++ b/tests/lambda_endpoints/test_spice_query_api.py
@@ -250,7 +250,6 @@ def test_ingest_time_queries(session):
         }
     }
     returned_query = spice_query_api.lambda_handler(event=event, context={})
-    print(returned_query)
     assert len(json.loads(returned_query["body"])) == 0
 
     # This event *does* contain the time range of the test ck file
@@ -261,5 +260,4 @@ def test_ingest_time_queries(session):
         }
     }
     returned_query = spice_query_api.lambda_handler(event=event, context={})
-    print(returned_query)
     assert len(json.loads(returned_query["body"])) == 1

--- a/tests/lambda_endpoints/test_spice_query_api.py
+++ b/tests/lambda_endpoints/test_spice_query_api.py
@@ -215,7 +215,7 @@ def test_invalid_query(session):
     expected_response = json.dumps(
         "size is not a valid query parameter. "
         + "Valid query parameters are: "
-        + "['file_name', 'start_time', 'end_time', 'type'," 
+        + "['file_name', 'start_time', 'end_time', 'type',"
         + " 'latest', 'start_ingest_date', 'end_ingest_date']"
     )
     returned_query = spice_query_api.lambda_handler(event=event, context={})

--- a/tests/lambda_endpoints/test_spice_query_api.py
+++ b/tests/lambda_endpoints/test_spice_query_api.py
@@ -215,7 +215,8 @@ def test_invalid_query(session):
     expected_response = json.dumps(
         "size is not a valid query parameter. "
         + "Valid query parameters are: "
-        + "['file_name', 'start_time', 'end_time', 'type', 'latest', 'start_ingest_date', 'end_ingest_date']"
+        + "['file_name', 'start_time', 'end_time', 'type'," 
+        + " 'latest', 'start_ingest_date', 'end_ingest_date']"
     )
     returned_query = spice_query_api.lambda_handler(event=event, context={})
     assert returned_query["statusCode"] == 400
@@ -238,7 +239,7 @@ def test_latest_query(session, expected_ck_response):
 
 
 def test_ingest_time_queries(session):
-    """Test 'start_ingest_date' and 'end_ingest_date' for accuracy"""
+    """Test 'start_ingest_date' and 'end_ingest_date' for accuracy."""
     _insert_ck_test_data(session)
 
     # This event *does not* contain the time range of the test ck file

--- a/tests/lambda_endpoints/test_spice_query_api.py
+++ b/tests/lambda_endpoints/test_spice_query_api.py
@@ -236,20 +236,29 @@ def test_latest_query(session, expected_ck_response):
     returned_query = spice_query_api.lambda_handler(event=event, context={})
     assert returned_query["body"] == expected_ck_response
 
+
 def test_ingest_time_queries(session):
     """Test 'start_ingest_date' and 'end_ingest_date' for accuracy"""
     _insert_ck_test_data(session)
 
     # This event *does not* contain the time range of the test ck file
-    event = {"queryStringParameters": {'start_ingest_date': '20220101',
-                                       'end_ingest_date': '20230101'}}
+    event = {
+        "queryStringParameters": {
+            "start_ingest_date": "20220101",
+            "end_ingest_date": "20230101",
+        }
+    }
     returned_query = spice_query_api.lambda_handler(event=event, context={})
     print(returned_query)
     assert len(json.loads(returned_query["body"])) == 0
 
     # This event *does* contain the time range of the test ck file
-    event = {"queryStringParameters": {'start_ingest_date': '20250401',
-                                       'end_ingest_date': '20250415'}}
+    event = {
+        "queryStringParameters": {
+            "start_ingest_date": "20250401",
+            "end_ingest_date": "20250415",
+        }
+    }
     returned_query = spice_query_api.lambda_handler(event=event, context={})
     print(returned_query)
     assert len(json.loads(returned_query["body"])) == 1

--- a/tests/lambda_endpoints/test_spice_query_api.py
+++ b/tests/lambda_endpoints/test_spice_query_api.py
@@ -215,10 +215,9 @@ def test_invalid_query(session):
     expected_response = json.dumps(
         "size is not a valid query parameter. "
         + "Valid query parameters are: "
-        + "['file_name', 'start_time', 'end_time', 'type', 'latest']"
+        + "['file_name', 'start_time', 'end_time', 'type', 'latest', 'start_ingest_date', 'end_ingest_date']"
     )
     returned_query = spice_query_api.lambda_handler(event=event, context={})
-
     assert returned_query["statusCode"] == 400
     assert returned_query["body"] == expected_response
 
@@ -236,3 +235,21 @@ def test_latest_query(session, expected_ck_response):
     event = {"queryStringParameters": {"latest": "True"}}
     returned_query = spice_query_api.lambda_handler(event=event, context={})
     assert returned_query["body"] == expected_ck_response
+
+def test_ingest_time_queries(session):
+    """Test 'start_ingest_date' and 'end_ingest_date' for accuracy"""
+    _insert_ck_test_data(session)
+
+    # This event *does not* contain the time range of the test ck file
+    event = {"queryStringParameters": {'start_ingest_date': '20220101',
+                                       'end_ingest_date': '20230101'}}
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+    print(returned_query)
+    assert len(json.loads(returned_query["body"])) == 0
+
+    # This event *does* contain the time range of the test ck file
+    event = {"queryStringParameters": {'start_ingest_date': '20250401',
+                                       'end_ingest_date': '20250415'}}
+    returned_query = spice_query_api.lambda_handler(event=event, context={})
+    print(returned_query)
+    assert len(json.loads(returned_query["body"])) == 1


### PR DESCRIPTION
# Change Summary

## Overview
Added "start_ingest_date" and "end_ingest_date" to the SPICE API. This was requested by the MAG team, and it is easy enough to implement since we store that data in the database anyway

## Updated Files
- sds_data_manager/lambda_code/SDSCode/api_lambdas/spice_query_api.py
   - added ability to query by ingest date of the SPICE files
- tests/lambda_endpoints/test_spice_query_api.py
   - added a test to make sure the new query parameters work as expected

## Testing
Appended one test to the end of the file 
