### PR TITLE
SPICE Indexer Intervals Calculation Change (and Metakernel API speed-up)

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -37,7 +37,7 @@ MAXIMUM_J2000_INTERVAL = [
 COVERAGE_ANGULAR_VELOCITY_ONLY = False  # Only include segments with angular velocity?
 COVERAGE_SPICE_ARRAY_LENGTH = 10000  # Use an array size of 10000 for coverage calc
 COVERAGE_LEVEL = "INTERVAL"  # the granularity at which the coverage is examined
-COVERAGE_TOLERANCE = 50000.0  # Tolerance value expressed in ticks of the spacecraft.
+COVERAGE_TOLERANCE = 0.0  # Tolerance value expressed in ticks of the spacecraft.
 COVERAGE_TIME_SYSTEM = "TDB"  # Whether to use J2000 (TDB) or spacecraft clock (SCLK)
 
 
@@ -127,18 +127,20 @@ def get_coverage_dictionary(spice_file: Path, **kwargs):
     for i_window in range(card):
         # 4) Retrieve the time span of each interval
         (left, right) = spiceypy.wnfetd(cover, i_window)
-        results_j2000.append([left, right])
-        # 5) Convert the time span to datetime
-        results_datetime.append(
-            [spiceypy.et2datetime(left), spiceypy.et2datetime(right)]
-        )
-        # 6) Convert the time span to spacecraft clock time
-        results_sclk.append(
-            [
-                spiceypy.sce2s(SPACECRAFT_ID, left),
-                spiceypy.sce2s(SPACECRAFT_ID, right),
-            ]
-        )
+        # 5) Throw out any singleton points. You cannot interpolate between these. 
+        if left != right:
+            results_j2000.append([left, right])
+            # 6) Convert the time span to datetime
+            results_datetime.append(
+                [spiceypy.et2datetime(left), spiceypy.et2datetime(right)]
+            )
+            # 7) Convert the time span to spacecraft clock time
+            results_sclk.append(
+                [
+                    spiceypy.sce2s(SPACECRAFT_ID, left),
+                    spiceypy.sce2s(SPACECRAFT_ID, right),
+                ]
+            )
 
     return results_j2000, results_datetime, results_sclk
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -127,7 +127,7 @@ def get_coverage_dictionary(spice_file: Path, **kwargs):
     for i_window in range(card):
         # 4) Retrieve the time span of each interval
         (left, right) = spiceypy.wnfetd(cover, i_window)
-        # 5) Throw out any singleton points. You cannot interpolate between these. 
+        # 5) Throw out any singleton points. You cannot interpolate between these.
         if left != right:
             results_j2000.append([left, right])
             # 6) Convert the time span to datetime

--- a/tests/lambda_endpoints/test_spice_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_spice_indexer_lambda.py
@@ -161,7 +161,7 @@ def test_s3_spice_files(mock_download, session, events_client, s3_client):
     assert len(result) == 1
     assert result[0]["kernel_type"] == "attitude_history"
     assert result[0]["version"] == 1
-    assert len(result[0]["file_intervals_datetime"]) == 395  # 395 gaps detected
+    assert len(result[0]["file_intervals_datetime"]) == 1  # 1 gap detected
     result = spice_query_api.lambda_handler(
         {"queryStringParameters": {"type": "leapseconds"}}, None
     )


### PR DESCRIPTION
# Change Summary

## Overview
One major factor slowing down the metakernel API is that many of the CK files we have received so far contain single points of data (*in addition* to intervals that allow interpolation). So within the database, this shows up as hundreds of tiny intervals of size 0, and therefore the metakernel API searches through hundreds of gaps between these points. 
 
In reality, we should discard these single points of data, and not treat them as a valid intervals to store in the database, because:
1) It sounds like these won't event be expected in production, so if we do, it is an error.
2) SPICE routines that need the CK data do not interpolate between these points. For example, "pxform", used to transform vectors between frames, will not interpolate between two single points even if they are incredibly close. So these data points are functionally useless to many of our routines (unless we use specialty SPICE functions to pull out the exact data points). 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
   - Set coverage tolerance to 0
   - Discard any coverage of length 0

## Testing
The testing files we have does coincidentally contain a TON of these datapoints, and it is filtering these out correctly. 