### PR TITLE
Use DependencyFilePath instead of CadenceFilePath

### DIFF
--- a/lambda_layer/database/requirements.txt
+++ b/lambda_layer/database/requirements.txt
@@ -153,9 +153,9 @@ greenlet==3.2.2 ; python_version < "3.14" and (platform_machine == "aarch64" or 
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.31.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:4f8544cc9f6f936d43253cff0ebd26734d483bc8d4818160694a989f017d5dc4 \
-    --hash=sha256:c0c8064bcd0978087764c846ba8c420027ca5c6d76b6f7fba9c4602691a1db9d
+imap-data-access==0.32.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:d67f00a3037b9f1bd3acb032d2b6c45b5b62ba9206292bb7ee19c2118a6c9540 \
+    --hash=sha256:e13f83bb26a2c0c5f15fe369a997e7a9ba07beab9411db7f2e4bb742f404fab1
 psycopg2-binary==2.9.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:04392983d0bb89a8717772a193cfaac58871321e3ec69514e1c4e0d4957b5aff \
     --hash=sha256:056470c3dc57904bbf63d6f534988bafc4e970ffd50f6271fc4ee7daad9498a5 \

--- a/lambda_layer/spice/requirements.txt
+++ b/lambda_layer/spice/requirements.txt
@@ -97,9 +97,9 @@ charset-normalizer==3.4.2 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.31.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:4f8544cc9f6f936d43253cff0ebd26734d483bc8d4818160694a989f017d5dc4 \
-    --hash=sha256:c0c8064bcd0978087764c846ba8c420027ca5c6d76b6f7fba9c4602691a1db9d
+imap-data-access==0.32.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:d67f00a3037b9f1bd3acb032d2b6c45b5b62ba9206292bb7ee19c2118a6c9540 \
+    --hash=sha256:e13f83bb26a2c0c5f15fe369a997e7a9ba07beab9411db7f2e4bb742f404fab1
 numpy==2.2.6 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff \
     --hash=sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47 \

--- a/poetry.lock
+++ b/poetry.lock
@@ -890,13 +890,13 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.31.0"
+version = "0.32.0"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap_data_access-0.31.0-py3-none-any.whl", hash = "sha256:c0c8064bcd0978087764c846ba8c420027ca5c6d76b6f7fba9c4602691a1db9d"},
-    {file = "imap_data_access-0.31.0.tar.gz", hash = "sha256:4f8544cc9f6f936d43253cff0ebd26734d483bc8d4818160694a989f017d5dc4"},
+    {file = "imap_data_access-0.32.0-py3-none-any.whl", hash = "sha256:e13f83bb26a2c0c5f15fe369a997e7a9ba07beab9411db7f2e4bb742f404fab1"},
+    {file = "imap_data_access-0.32.0.tar.gz", hash = "sha256:d67f00a3037b9f1bd3acb032d2b6c45b5b62ba9206292bb7ee19c2118a6c9540"},
 ]
 
 [package.dependencies]
@@ -2545,4 +2545,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "432ad0833543623071bca5a23ce4da39d0baf9286cfad59a607b713d49930fa8"
+content-hash = "bdad3b772fa6271819919de67a2affe38e69362ed3fb628e80d646a9ef86758c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ python = ">=3.10,<4"
 # WARNING - Please run this command when updateing `imap-data-access` to ensure that
 # the correct version and hash are used:
 #   poetry export -f requirements.txt -o lambda_layer/database/requirements.txt --with layer-database
-imap-data-access = ">=0.31.0"
+imap-data-access = ">=0.32.0"
 
 # Optional dependencies - install with `poetry install -E docs`
 sphinx = {version="^7.1.0", optional=true}

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -12,10 +12,10 @@ import imap_data_access
 import requests
 from imap_data_access import (
     AncillaryFilePath,
+    DependencyFilePath,
     ScienceFilePath,
     SPICEFilePath,
 )
-from imap_data_access.file_validation import CadenceFilePath
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
@@ -323,8 +323,7 @@ def duplicate_job(
     bool
         True if the job is a duplicate, False otherwise.
     """
-    # TODO switch to DependencyFilePath
-    previous_dependency_file = CadenceFilePath.generate_from_inputs(
+    previous_dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,
         descriptor=descriptor,
@@ -435,8 +434,7 @@ def try_to_submit_job(
     # processing code will read the JSON file and deserialize the dependencies. This is
     # to avoid passing a large string through the batch job command line.
     # release
-    # TODO switch to DependencyFilePath
-    dependency_file = CadenceFilePath.generate_from_inputs(
+    dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,
         descriptor=descriptor,

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -142,9 +142,9 @@ charset-normalizer==3.4.2 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.31.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:4f8544cc9f6f936d43253cff0ebd26734d483bc8d4818160694a989f017d5dc4 \
-    --hash=sha256:c0c8064bcd0978087764c846ba8c420027ca5c6d76b6f7fba9c4602691a1db9d
+imap-data-access==0.32.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:d67f00a3037b9f1bd3acb032d2b6c45b5b62ba9206292bb7ee19c2118a6c9540 \
+    --hash=sha256:e13f83bb26a2c0c5f15fe369a997e7a9ba07beab9411db7f2e4bb742f404fab1
 imap-processing==0.16.2 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:1257d0427e4ea7f1551d76d449c0892d4c4fb09f34deb8bb30c2a8d4d20a5570 \
     --hash=sha256:59126773aaf6c2509e308e8f311897b5e41d25807d419904212460815bd70ab0

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -75,10 +75,10 @@ def science_file():
 
 
 @pytest.fixture(scope="module")
-def cadence_file():
-    """Path to a valid cadence file."""
+def dependency_file():
+    """Path to a valid dependency file."""
     return (
-        "imap/cadence/ultra/l2/2025/03/imap_ultra_l2_u45-ena-h-hf-nsp-test-hae-6deg"
+        "imap/dependency/ultra/l2/2025/03/imap_ultra_l2_u45-ena-h-hf-nsp-test-hae-6deg"
         "-3mo_20250301_v001.json"
     )
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1280,18 +1280,18 @@ def test_cadence_to_datetime_range():
         assert (end_date - start_date) == dt.timedelta(days=CadenceDays.ONE_YEAR.value)
 
 
-def test_upload_dependency_file(s3_client, tmp_path, cadence_file, caplog):
+def test_upload_dependency_file(s3_client, tmp_path, dependency_file, caplog):
     """Test uploading a cadence json file to S3."""
     caplog.set_level("INFO")
     dependencies = ProcessingInputCollection(
         ScienceInput("imap_ultra_l1c_45sensor-pset_20250201_v001.cdf")
     )
-    cadence_file = imap_data_access.file_validation.CadenceFilePath(
-        basename(cadence_file)
+    dep_file = imap_data_access.file_validation.DependencyFilePath(
+        basename(dependency_file)
     )
     with patch("imap_data_access.config", {"DATA_DIR": tmp_path}):
-        cadence_dependency_path = pathlib.Path(cadence_file.construct_path())
-        upload_dependency_file(cadence_dependency_path, dependencies.serialize())
+        dependency_path = pathlib.Path(dep_file.construct_path())
+        upload_dependency_file(dependency_path, dependencies.serialize())
     assert "Dependency file uploaded successfully" in caplog.text
 
 

--- a/tests/lambda_endpoints/test_upload_api.py
+++ b/tests/lambda_endpoints/test_upload_api.py
@@ -89,13 +89,13 @@ def test_ancillary_file_upload(s3_client, ancillary_file):
     assert response["statusCode"] == 409
 
 
-def test_cadence_file_upload(s3_client, cadence_file):
+def test_cadence_file_upload(s3_client, dependency_file):
     """Test cadence files being uploaded."""
     event = {
         "version": "2.0",
         "routeKey": "$default",
         "rawPath": "/",
-        "pathParameters": {"proxy": cadence_file},
+        "pathParameters": {"proxy": dependency_file},
     }
     response = upload_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 200
@@ -103,14 +103,14 @@ def test_cadence_file_upload(s3_client, cadence_file):
     # Try to upload again and we should get a 409 duplicate error
     s3_client.put_object(
         Bucket=os.getenv("S3_BUCKET"),
-        Key=cadence_file,
+        Key=dependency_file,
         Body=b"test",
     )
     event = {
         "version": "2.0",
         "routeKey": "$default",
         "rawPath": "/",
-        "pathParameters": {"proxy": cadence_file},
+        "pathParameters": {"proxy": dependency_file},
     }
     response = upload_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 409


### PR DESCRIPTION
# Change Summary

## Overview
Update batch starter to use DependencyFilePath and CadenceFilePath. Bump imap-data-access version. 


## Updated Files
- pyproject.toml
   - Bump imap-data-access 
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Switch to use DependencyFilePath 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
