### PR TITLE
updates to dependency config for L1D

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -635,10 +635,10 @@ mag, ancillary, l1d-calibration, mag, l1d, norm, HARD, DOWNSTREAM
 
 # all L1D processing occurs in one step
 mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
-mag, l1c, norm-mago, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
-mag, l1c, norm-magi, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
-mag, l1b, burst-mago, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
-mag, l1b, burst-magi, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+mag, l1c, norm-mago, mag, l1d, norm-srf, HARD, DOWNSTREAM
+mag, l1c, norm-magi, mag, l1d, norm-srf, HARD, DOWNSTREAM
+mag, l1b, burst-mago, mag, l1d, norm-srf, HARD, DOWNSTREAM
+mag, l1b, burst-magi, mag, l1d, norm-srf, HARD, DOWNSTREAM
 
 imap_frames, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -635,7 +635,6 @@ mag, ancillary, l1d-calibration, mag, l1d, norm, HARD, DOWNSTREAM
 
 # all L1D processing occurs in one step
 mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
-mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
 mag, l1c, norm-mago, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
 mag, l1c, norm-magi, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
 mag, l1b, burst-mago, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -632,6 +632,22 @@ mag, l1b, burst-mago, mag, l1d, burst, HARD, DOWNSTREAM
 mag, l1b, burst-magi, mag, l1d, burst, HARD, DOWNSTREAM
 mag, ancillary, l1d-calibration, mag, l1d, norm, HARD, DOWNSTREAM
 
+
+# all L1D processing occurs in one step
+mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
+mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
+mag, l1c, norm-mago, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+mag, l1c, norm-magi, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+mag, l1b, burst-mago, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+mag, l1b, burst-magi, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+
+imap_frames, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, mag, l1d, norm-srf, HARD, DOWNSTREAM
+leapseconds, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+
+# MAG L2 and L1D look pretty similar.
 mag, l1c, norm-mago, mag, l2, norm-srf, HARD, DOWNSTREAM
 mag, l1b, burst-mago, mag, l2, burst-srf, HARD, DOWNSTREAM
 mag, ancillary, l2-calibration, mag, l2, norm-srf, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary
Adding L1D dependency changes. This basically passes 4 science files, one ancillary and all the SPICE files from L2 into one L1D step. This step will output multiple science and ancillary outputs. 

I'd appreciate extra looks at the SPICE pieces to make sure they look as expected. I need to include imap_science_100.tf which I think is marked as `imap_frames` in here but I'm not sure. 
