### PR TITLE
IDEX combine l2b and l2c

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -468,11 +468,10 @@ planetary_ephemeris, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, D
 imap_frames, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 
 idex, l1b, sci-1week, idex, l2a, sci-1week, HARD, DOWNSTREAM
-idex, l2a, sci-1week, idex, l2b, sci-1mo, HARD, DOWNSTREAM
-leapseconds, spice, historical, idex, l2b, sci-1mo, HARD_NO_TRIGGER, DOWNSTREAM
-spacecraft_clock, spice, historical, idex, l2b, sci-1mo, HARD_NO_TRIGGER, DOWNSTREAM
-idex, l1b, evt, idex, l2b, sci-1mo, HARD_NO_TRIGGER, DOWNSTREAM
-idex, l2b, sci-1mo, idex, l2c, all, HARD, DOWNSTREAM
+idex, l2a, sci-1week, idex, l2b, all-1mo, HARD, DOWNSTREAM
+leapseconds, spice, historical, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
+idex, l1b, evt, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 
 # <---- LO Dependencies ---->
 lo, l0, raw, lo, l1a, all, HARD, DOWNSTREAM

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1454,7 +1454,7 @@ def test_idex_l2b(session):
         lambda_handler(cadence_event, None)
         # Verify the function was called
         mock_batch_client.submit_job.assert_called_with(
-            jobName="idex-l2b-sci-1mo-job-1",
+            jobName="idex-l2b-all-1mo-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-idex",
             containerOverrides={
@@ -1464,13 +1464,13 @@ def test_idex_l2b(session):
                     "--data-level",
                     "l2b",
                     "--descriptor",
-                    "sci-1mo",
+                    "all-1mo",
                     "--start-date",
                     "20230109",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_idex_l2b_sci-1mo_20230109_v001.json",
+                    "imap_idex_l2b_all-1mo_20230109_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1488,7 +1488,7 @@ def test_idex_l2b(session):
         lambda_handler(cadence_event, None)
         mock_submit.assert_called_with(
             session,
-            {"data_source": "idex", "data_type": "l2b", "descriptor": "sci-1mo"},
+            {"data_source": "idex", "data_type": "l2b", "descriptor": "all-1mo"},
             dt.datetime(2023, 1, 9, 0, 0),
             "v001",
             expected_processing_input.serialize(),


### PR DESCRIPTION
# Change Summary

## Overview
Combine l2c and l2b dependencies. L2c will be produced by l2b 

## Updated Files>
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - Combine l2b and l2c jobs

## Testing
Fix descriptor in idex l2b test
