### PR TITLE
BUG cadence maps contain overlapping data

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -82,8 +82,14 @@ def cadence_to_datetime_range(
         The start date and end date of the cadence. The end_date is set to today
     """
     end_date = datetime.datetime.today()
+    # Find the start date by subtracting the number of days in the cadence from the end
+    # date. Subtract one day from the number of days in the cadence because the query in
+    # dependency.py get_files() is inclusive for both the start and end date.
+    # To avoid overlapping data by one day, we essentially bump the start date up by
+    # one.
     start_date = end_date - datetime.timedelta(
         days=CadenceDays.str_lookup(cadence).value
+        - 1  # subtract one day from cadence days
     )
     if as_str:
         start_date = start_date.strftime("%Y%m%d")

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1516,16 +1516,18 @@ def test_cadence_to_datetime_range():
         start_date, end_date = batch_starter.cadence_to_datetime_range(
             cadence="3mo", as_str=True
         )
-        assert start_date == "20231231"
+        assert start_date == "20240101"
         assert end_date == "20240401"
 
         start_date, end_date = batch_starter.cadence_to_datetime_range(cadence="6mo")
         assert (end_date - start_date) == dt.timedelta(
-            days=CadenceDays.ONE_YEAR.value / 2
+            days=(CadenceDays.ONE_YEAR.value / 2) - 1
         )
 
         start_date, end_date = batch_starter.cadence_to_datetime_range(cadence="1yr")
-        assert (end_date - start_date) == dt.timedelta(days=CadenceDays.ONE_YEAR.value)
+        assert (end_date - start_date) == dt.timedelta(
+            days=CadenceDays.ONE_YEAR.value - 1
+        )
 
 
 def test_upload_dependency_file(s3_client, tmp_path, dependency_file, caplog):


### PR DESCRIPTION
# Change Summary

## Overview
I noticed this issue before SIT-4 when we were testing the cadence maps. When the jobs get triggered by and eventBridge the way batch_starter is currently calculating the date range will cause the same file to be added on a dependency for two concurrent maps. This is because our get_files() function is end and start date inclusive. This is a fix to bump the start date of the map by one to ensure that the maps have unique data. We also discussed changing the get_files() function to be end_date exclusive so maybe that is preferred here? I am open to suggestions. 

** NOTE @sdhoyt this will not impact the SIT-4 rerun filenames because we are manually supplying the start and end date just fyi. 

## Updated Files
-sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Fix date range

## Testing
Fix cadence daterange test
