### PR TITLE
Add hash to dependency file

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -348,6 +348,10 @@ def duplicate_job(
     # If the file already exists, then we know that an exact duplicate job has been
     # run with the same dependencies, start date, descriptor, instrument, data level,
     # and version.
+    # TODO currently this will skip bulk reprocessing jobs that have been kicked off
+    #   Due to algorithm updates. The job might look like a duplicate but have new code.
+    #   We need to somehow track if we are reprocessing due to a manual trigger
+    #   or not.
     return _file_exists(s3_key_path_str)
 
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -1,6 +1,7 @@
 """Functions for supporting the batch starter component of the architecture."""
 
 import datetime
+import hashlib
 import json
 import logging
 import os
@@ -19,7 +20,8 @@ from imap_data_access import (
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
-from ..api_lambdas import download_api, upload_api
+from ..api_lambdas import upload_api
+from ..api_lambdas.upload_api import _file_exists
 from ..database import database as db
 from ..database import models
 from . import dependency
@@ -323,6 +325,12 @@ def duplicate_job(
     bool
         True if the job is a duplicate, False otherwise.
     """
+    # Generate the previous dependency file path based on the inputs.
+    # The descriptor should include a hash of the serialized dependencies.
+    descriptor = (
+        f"{descriptor}-"
+        f"{hashlib.sha256(serialized_dependencies.encode('utf-8')).hexdigest()}"
+    )
     previous_dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,
@@ -331,24 +339,16 @@ def duplicate_job(
         version=previous_version,
         extension="json",
     )
-    previous_dependency_path = previous_dependency_file.construct_path()
-    # Get the dependency s3 path
-    relative_path = previous_dependency_path.relative_to(
-        imap_data_access.config["DATA_DIR"]
+    previous_dep_path = previous_dependency_file.construct_path()
+    # Strip off the data directory to get the upload path + name
+    # Must be posix style for the URL
+    s3_key_path_str = str(
+        previous_dep_path.relative_to(imap_data_access.config["DATA_DIR"]).as_posix()
     )
-    previous_dependency_str = get_previous_dependency_str(relative_path)
-    if previous_dependency_str is None:
-        logger.error(
-            f"Failed to download previous dependency file: {previous_dependency_path}. "
-            f"Skipping duplicate job check."
-        )
-        return False
-    # If the previous dependency string is the same as the current, this is a duplicate
-    # job.
-    if previous_dependency_str == serialized_dependencies:
-        return True
-
-    return False
+    # If the file already exists, then we know that an exact duplicate job has been
+    # run with the same dependencies, start date, descriptor, instrument, data level,
+    # and version.
+    return _file_exists(s3_key_path_str)
 
 
 def try_to_submit_job(
@@ -434,6 +434,12 @@ def try_to_submit_job(
     # processing code will read the JSON file and deserialize the dependencies. This is
     # to avoid passing a large string through the batch job command line.
     # release
+    # The descriptor should include a hash of the serialized dependencies.
+    # This makes it unique for this file and set of dependencies.
+    descriptor = (
+        f"{descriptor}-"
+        f"{hashlib.sha256(serialized_dependencies.encode('utf-8')).hexdigest()}"
+    )
     dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,
@@ -956,45 +962,6 @@ def bulk_reprocessing_event(session, events):
             submit_all_jobs(session, job, start_date, end_date)
 
 
-def get_previous_dependency_str(dependency_file_path: Path):
-    """Download a JSON file containing a dependencies from S3 and return its contents.
-
-    Parameters
-    ----------
-    dependency_file_path : Path
-        The dependency JSON file to download.
-
-    Returns
-    -------
-    str or None
-        The contents of the dependency file if successful, otherwise None.
-    """
-    response = download_api.lambda_handler(
-        {"pathParameters": {"proxy": dependency_file_path.as_posix()}}, None
-    )
-    if response["statusCode"] != 302:
-        logger.error(
-            f"Failed to get S3 pre-signed URL for file: {dependency_file_path}. "
-            f"Error message: {response['body']}, "
-            f"with status code: {response['statusCode']}."
-        )
-        return None
-    try:
-        download_url = json.loads(response["body"])["download_url"]
-        response = requests.get(download_url, timeout=60.0)
-        logger.info(
-            f"Dependency file downloaded successfully from s3 with status code: "
-            f"{response.status_code}"
-        )
-        return response.text
-    except Exception as e:
-        logger.error(
-            f"Unexpected error during dependency file download: {e}. "
-            f"Dependency file download failed."
-        )
-        return None
-
-
 def upload_dependency_file(dependency_file_path: Path, serialized_dependencies: str):
     """Upload a JSON file containing a job's dependencies to S3.
 
@@ -1014,7 +981,12 @@ def upload_dependency_file(dependency_file_path: Path, serialized_dependencies: 
     signed_url = upload_api.lambda_handler(
         {"pathParameters": {"proxy": dependency_file_path.as_posix()}}, None
     )
-    if signed_url["statusCode"] != 200:
+    if signed_url["statusCode"] == 409:
+        logger.info(
+            f"Dependency file already exists in S3: {dependency_file_path}. Reusing"
+            f"file."
+        )
+    elif signed_url["statusCode"] != 200:
         logger.error(
             f"Failed to get S3 pre-signed URL for file: {dependency_file_path}. "
             f"As a result, failed to kick off job. "

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -327,10 +327,7 @@ def duplicate_job(
     """
     # Generate the previous dependency file path based on the inputs.
     # The descriptor should include a hash of the serialized dependencies.
-    dep_descriptor = (
-        f"{descriptor}-"
-        f"{hashlib.sha256(serialized_dependencies.encode('utf-8')).hexdigest()}"
-    )
+    dep_descriptor = f"{descriptor}-{dependency_hash(serialized_dependencies)}"
     previous_dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,
@@ -353,6 +350,22 @@ def duplicate_job(
     #   We need to somehow track if we are reprocessing due to a manual trigger
     #   or not.
     return _file_exists(s3_key_path_str)
+
+
+def dependency_hash(serialized_dependencies):
+    """Generate a hash for the serialized dependencies. Use only the first 8 characters.
+
+    Parameters
+    ----------
+    serialized_dependencies : str
+        The serialized dependencies string.
+
+    Returns
+    -------
+    str
+        The first 8 characters of the SHA-256 hash of the serialized dependencies.
+    """
+    return hashlib.sha256(serialized_dependencies.encode("utf-8")).hexdigest()[:8]
 
 
 def try_to_submit_job(
@@ -415,10 +428,7 @@ def try_to_submit_job(
     # release
     # The descriptor should include a hash of the serialized dependencies.
     # This makes it unique for this file and set of dependencies.
-    dep_descriptor = (
-        f"{descriptor}-"
-        f"{hashlib.sha256(serialized_dependencies.encode('utf-8')).hexdigest()}"
-    )
+    dep_descriptor = f"{descriptor}-{dependency_hash(serialized_dependencies)}"
     dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -393,41 +393,16 @@ def try_to_submit_job(
             previous_version,
             serialized_dependencies,
         ):
-            filepath = ScienceFilePath.generate_from_inputs(
-                instrument=instrument,
-                data_level=data_level,
-                descriptor=descriptor,
-                start_time=start_date_str,
-                version=previous_version,
-            )
             logger.info(
-                f"This job is a duplicate of the previous job. See file: "
-                f"{filepath.filename!s}. Skipping submission."
+                f"This job is a duplicate of the previous one for: "
+                f"{instrument=},"
+                f" {data_level=},"
+                f" {descriptor=},"
+                f" {start_date_str=},"
+                f" and {previous_version=}. "
+                f"Skipping submission."
             )
             return
-
-    # All of our upstream requirements have been met.
-    # Try to insert a record into the Processing Jobs table
-    # If this job already exists, then we will get an integrity error
-    # and know that some other process has already taken care of it
-    processing_job = models.ProcessingJob(
-        status=models.Status.INPROGRESS,
-        instrument=instrument,
-        data_level=data_level,
-        descriptor=descriptor,
-        start_date=start_date,
-        version=version,
-    )
-    try:
-        session.add(processing_job)
-        session.commit()
-    except IntegrityError:
-        logger.info(f"Job already completed or in progress: {processing_job}")
-        return
-
-    logger.info(
-        f"Wrote job INPROGRESS to Processing Jobs Table with id: {processing_job.id}"
-    )
     # TODO: do we need a reprocessing column to indicate if this is a reprocessing job?
 
     # Serialize the upstream dependencies and write them to a JSON file. The Imap
@@ -453,6 +428,29 @@ def try_to_submit_job(
     # If response is None, then the upload failed and we should skip submitting the job.
     if not response:
         return
+
+    # All of our upstream requirements have been met.
+    # Try to insert a record into the Processing Jobs table
+    # If this job already exists, then we will get an integrity error
+    # and know that some other process has already taken care of it
+    processing_job = models.ProcessingJob(
+        status=models.Status.INPROGRESS,
+        instrument=instrument,
+        data_level=data_level,
+        descriptor=descriptor,
+        start_date=start_date,
+        version=version,
+    )
+    try:
+        session.add(processing_job)
+        session.commit()
+    except IntegrityError:
+        logger.info(f"Job already completed or in progress: {processing_job}")
+        return
+
+    logger.info(
+        f"Wrote job INPROGRESS to Processing Jobs Table with id: {processing_job.id}"
+    )
 
     batch_command = [
         "--instrument",
@@ -986,6 +984,7 @@ def upload_dependency_file(dependency_file_path: Path, serialized_dependencies: 
             f"Dependency file already exists in S3: {dependency_file_path}. Reusing"
             f"file."
         )
+        return {"statusCode": 200, "body": signed_url["body"]}
     elif signed_url["statusCode"] != 200:
         logger.error(
             f"Failed to get S3 pre-signed URL for file: {dependency_file_path}. "

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -327,14 +327,14 @@ def duplicate_job(
     """
     # Generate the previous dependency file path based on the inputs.
     # The descriptor should include a hash of the serialized dependencies.
-    descriptor = (
+    dep_descriptor = (
         f"{descriptor}-"
         f"{hashlib.sha256(serialized_dependencies.encode('utf-8')).hexdigest()}"
     )
     previous_dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,
-        descriptor=descriptor,
+        descriptor=dep_descriptor,
         start_time=start_date,
         version=previous_version,
         extension="json",
@@ -436,14 +436,14 @@ def try_to_submit_job(
     # release
     # The descriptor should include a hash of the serialized dependencies.
     # This makes it unique for this file and set of dependencies.
-    descriptor = (
+    dep_descriptor = (
         f"{descriptor}-"
         f"{hashlib.sha256(serialized_dependencies.encode('utf-8')).hexdigest()}"
     )
     dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,
-        descriptor=descriptor,
+        descriptor=dep_descriptor,
         start_time=start_date.strftime("%Y%m%d"),
         version=version,
         extension="json",

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -468,7 +468,7 @@ planetary_ephemeris, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, D
 imap_frames, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 
 idex, l1b, sci-1week, idex, l2a, sci-1week, HARD, DOWNSTREAM
-idex, l2a, sci-1week, idex, l2b, all-1mo, HARD, DOWNSTREAM
+idex, l2a, sci-1week, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 idex, l1b, evt, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM

--- a/tests/lambda_endpoints/conftest.py
+++ b/tests/lambda_endpoints/conftest.py
@@ -77,7 +77,7 @@ def dependency_file():
     """Path to a valid dependency file."""
     return (
         "imap/dependency/ultra/l2/2025/03/imap_ultra_l2_u45-ena-h-hf-nsp-test-hae-6deg"
-        "-3mo_20250301_v001.json"
+        "-3mo-4d649e314e8ac32e3fb76fe5d5aad46f_20250301_v001.json"
     )
 
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -115,7 +115,7 @@ def test_lambda_handler(session, s3_client):
         lambda_handler(events, context)
         mock_batch_client.submit_job.assert_called_once()
         mock_batch_client.submit_job.assert_called_with(
-            jobName="swe-l1a-sci-a798194b08e95fa322dea1cfba1089ed-job-1",
+            jobName="swe-l1a-sci-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-swe",
             containerOverrides={
@@ -125,13 +125,13 @@ def test_lambda_handler(session, s3_client):
                     "--data-level",
                     "l1a",
                     "--descriptor",
-                    "sci-a798194b08e95fa322dea1cfba1089ed",
+                    "sci",
                     "--start-date",
                     "20240101",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_swe_l1a_sci-a798194b08e95fa322dea1cfba1089ed_20240101_v001.json",
+                    "imap_swe_l1a_sci-c685cc1958539fee3c4724e5655c36d2b9b4c8fe99835905b448f7bd93468ab5_20240101_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -396,7 +396,7 @@ def test_lambda_handler_ancillary_event(session):
             },
         ]
         mock_batch_client.submit_job.assert_called_with(
-            jobName="swe-l1b-sci-04e19f89136d5c163174a2977acab130-job-1",
+            jobName="swe-l1b-sci-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-swe",
             containerOverrides={
@@ -406,13 +406,13 @@ def test_lambda_handler_ancillary_event(session):
                     "--data-level",
                     "l1b",
                     "--descriptor",
-                    "sci-04e19f89136d5c163174a2977acab130",
+                    "sci",
                     "--start-date",
                     "20260303",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_swe_l1b_sci-04e19f89136d5c163174a2977acab130_20260303_v001.json",
+                    "imap_swe_l1b_sci-6a22366cd7a617e3d86a5f9e0f4eeaf8711d5c4b46266b79358619fc42a8309a_20260303_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -901,7 +901,7 @@ def test_ultra_l3_map(session, caplog):
         lambda_handler(events, context)
         # Verify the function was called
         mock_batch_client.submit_job.assert_called_with(
-            jobName="ultra-l3-u90-ena-h-sf-sp-full-hae-4deg-3mo-8de3878e8f291a026c6f328a4135aa97-job-1",
+            jobName="ultra-l3-u90-ena-h-sf-sp-full-hae-4deg-3mo-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-ultra-l3",
             containerOverrides={
@@ -911,13 +911,13 @@ def test_ultra_l3_map(session, caplog):
                     "--data-level",
                     "l3",
                     "--descriptor",
-                    "u90-ena-h-sf-sp-full-hae-4deg-3mo-8de3878e8f291a026c6f328a4135aa97",
+                    "u90-ena-h-sf-sp-full-hae-4deg-3mo",
                     "--start-date",
                     "20240201",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_ultra_l3_u90-ena-h-sf-sp-full-hae-4deg-3mo-8de3878e8f291a026c6f328a4135aa97_20240201_v001.json",
+                    "imap_ultra_l3_u90-ena-h-sf-sp-full-hae-4deg-3mo-27005a05f059d26588e175889fe6e8bcd3cbc45b1e7f00c6773785a9fff56538_20240201_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1077,7 +1077,7 @@ def test_lambda_handler_mag_l1c_case(session):
         lambda_handler(events, context)
         # Verify the function was called
         mock_batch_client.submit_job.assert_called_with(
-            jobName="mag-l1c-norm-mago-9df4ad30d8e5c1419ca77301df76846f-job-1",
+            jobName="mag-l1c-norm-mago-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-mag",
             containerOverrides={
@@ -1087,13 +1087,13 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--data-level",
                     "l1c",
                     "--descriptor",
-                    "norm-mago-9df4ad30d8e5c1419ca77301df76846f",
+                    "norm-mago",
                     "--start-date",
                     "20240101",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_mag_l1c_norm-mago-9df4ad30d8e5c1419ca77301df76846f_20240101_v001.json",
+                    "imap_mag_l1c_norm-mago-7f10196662789f7653d3e55e3ccb4eb4a1bb4a6f6b90193c64f8ce75a846679f_20240101_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1145,7 +1145,7 @@ def test_lambda_handler_mag_l1c_case(session):
         lambda_handler(events, context)
         # Verify the function was called
         mock_batch_client.submit_job.assert_called_with(
-            jobName="mag-l1c-norm-mago-4d649e314e8ac32e3fb76fe5d5aad46f-job-2",
+            jobName="mag-l1c-norm-mago-job-2",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-mag",
             containerOverrides={
@@ -1155,13 +1155,13 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--data-level",
                     "l1c",
                     "--descriptor",
-                    "norm-mago-4d649e314e8ac32e3fb76fe5d5aad46f",
+                    "norm-mago",
                     "--start-date",
                     "20240101",
                     "--version",
                     "v002",
                     "--dependency",
-                    "imap_mag_l1c_norm-mago-4d649e314e8ac32e3fb76fe5d5aad46f_20240101_v002.json",
+                    "imap_mag_l1c_norm-mago-2ae6d6feecb9c00015881bc67ab7b10e29783732468a5e0b635adfe4326fc96c_20240101_v002.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1352,7 +1352,7 @@ def test_def_cadence_map_event(setup_s3, session, tmp_path):
         assert mock_batch_client.submit_job.call_count == 12
         # Assert that the function was called with the cadence json file path
         mock_batch_client.submit_job.assert_called_with(
-            jobName="ultra-l2-u90-ena-h-sf-nsp-full-hae-6deg-3mo-73e7829640a9d96aaa9f8e043888201e-job-12",
+            jobName="ultra-l2-u90-ena-h-sf-nsp-full-hae-6deg-3mo-job-12",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-ultra",
             containerOverrides={
@@ -1362,13 +1362,13 @@ def test_def_cadence_map_event(setup_s3, session, tmp_path):
                     "--data-level",
                     "l2",
                     "--descriptor",
-                    "u90-ena-h-sf-nsp-full-hae-6deg-3mo-73e7829640a9d96aaa9f8e043888201e",
+                    "u90-ena-h-sf-nsp-full-hae-6deg-3mo",
                     "--start-date",
                     "20250301",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-6deg-3mo-73e7829640a9d96aaa9f8e043888201e_20250301_v001.json",
+                    "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-6deg-3mo-74f0a45021f58df642c0fae542661f17c0790964182ca62399fd0c4be45aeb0f_20250301_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1470,7 +1470,7 @@ def test_idex_l2b(session):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_idex_l2b_all-1mo-0a9cfa4f10e4f8162a0b5e5cc9df7bda_20230109_v001.json",
+                    "imap_idex_l2b_all-1mo-9de6e4ae33556063213c1528033aadb4a9bd4421fc428dc31303a08876eafd05_20230109_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1975,7 +1975,7 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
         # verify that the function was called once
         mock_batch_client.submit_job.assert_called_once()
         mock_batch_client.submit_job.assert_called_with(
-            jobName="spacecraft-l1a-pointing-attitude-58c20cdbd52c1b788c448fcd7b387355-job-3",
+            jobName="spacecraft-l1a-pointing-attitude-job-3",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-spacecraft",
             containerOverrides={
@@ -1985,13 +1985,13 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
                     "--data-level",
                     "l1a",
                     "--descriptor",
-                    "pointing-attitude-58c20cdbd52c1b788c448fcd7b387355",
+                    "pointing-attitude",
                     "--start-date",
                     "20000224",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_spacecraft_l1a_pointing-attitude-58c20cdbd52c1b788c448fcd7b387355_20000224_v001.json",
+                    "imap_spacecraft_l1a_pointing-attitude-609961590f7a3732fa929e29207ffa14b83dafd107d47b3f1077eded267a9a08_20000224_v001.json",
                     "--upload-to-sdc",
                 ]
             },

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1250,11 +1250,7 @@ def test_lambda_handler_duplicate_mag_l1c_job(session, caplog):
         # Verify the function not called
         assert mock_batch_client.submit_job.call_count == 0
 
-        assert (
-            "This job is a duplicate of the previous job. See file:"
-            " imap_mag_l1c_norm-mago_20240101_v001.cdf."
-            " Skipping submission."
-        ) in caplog.text
+        assert ("This job is a duplicate of the previous one") in caplog.text
 
 
 ### TEST CADENCE EVENT

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -115,7 +115,7 @@ def test_lambda_handler(session, s3_client):
         lambda_handler(events, context)
         mock_batch_client.submit_job.assert_called_once()
         mock_batch_client.submit_job.assert_called_with(
-            jobName="swe-l1a-sci-job-1",
+            jobName="swe-l1a-sci-a798194b08e95fa322dea1cfba1089ed-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-swe",
             containerOverrides={
@@ -125,13 +125,13 @@ def test_lambda_handler(session, s3_client):
                     "--data-level",
                     "l1a",
                     "--descriptor",
-                    "sci",
+                    "sci-a798194b08e95fa322dea1cfba1089ed",
                     "--start-date",
                     "20240101",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_swe_l1a_sci_20240101_v001.json",
+                    "imap_swe_l1a_sci-a798194b08e95fa322dea1cfba1089ed_20240101_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -396,7 +396,7 @@ def test_lambda_handler_ancillary_event(session):
             },
         ]
         mock_batch_client.submit_job.assert_called_with(
-            jobName="swe-l1b-sci-job-1",
+            jobName="swe-l1b-sci-04e19f89136d5c163174a2977acab130-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-swe",
             containerOverrides={
@@ -406,13 +406,13 @@ def test_lambda_handler_ancillary_event(session):
                     "--data-level",
                     "l1b",
                     "--descriptor",
-                    "sci",
+                    "sci-04e19f89136d5c163174a2977acab130",
                     "--start-date",
                     "20260303",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_swe_l1b_sci_20260303_v001.json",
+                    "imap_swe_l1b_sci-04e19f89136d5c163174a2977acab130_20260303_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -901,7 +901,7 @@ def test_ultra_l3_map(session, caplog):
         lambda_handler(events, context)
         # Verify the function was called
         mock_batch_client.submit_job.assert_called_with(
-            jobName="ultra-l3-u90-ena-h-sf-sp-full-hae-4deg-3mo-job-1",
+            jobName="ultra-l3-u90-ena-h-sf-sp-full-hae-4deg-3mo-8de3878e8f291a026c6f328a4135aa97-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-ultra-l3",
             containerOverrides={
@@ -911,13 +911,13 @@ def test_ultra_l3_map(session, caplog):
                     "--data-level",
                     "l3",
                     "--descriptor",
-                    "u90-ena-h-sf-sp-full-hae-4deg-3mo",
+                    "u90-ena-h-sf-sp-full-hae-4deg-3mo-8de3878e8f291a026c6f328a4135aa97",
                     "--start-date",
                     "20240201",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_ultra_l3_u90-ena-h-sf-sp-full-hae-4deg-3mo_20240201_v001.json",
+                    "imap_ultra_l3_u90-ena-h-sf-sp-full-hae-4deg-3mo-8de3878e8f291a026c6f328a4135aa97_20240201_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1077,7 +1077,7 @@ def test_lambda_handler_mag_l1c_case(session):
         lambda_handler(events, context)
         # Verify the function was called
         mock_batch_client.submit_job.assert_called_with(
-            jobName="mag-l1c-norm-mago-job-1",
+            jobName="mag-l1c-norm-mago-9df4ad30d8e5c1419ca77301df76846f-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-mag",
             containerOverrides={
@@ -1087,13 +1087,13 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--data-level",
                     "l1c",
                     "--descriptor",
-                    "norm-mago",
+                    "norm-mago-9df4ad30d8e5c1419ca77301df76846f",
                     "--start-date",
                     "20240101",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_mag_l1c_norm-mago_20240101_v001.json",
+                    "imap_mag_l1c_norm-mago-9df4ad30d8e5c1419ca77301df76846f_20240101_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1145,7 +1145,7 @@ def test_lambda_handler_mag_l1c_case(session):
         lambda_handler(events, context)
         # Verify the function was called
         mock_batch_client.submit_job.assert_called_with(
-            jobName="mag-l1c-norm-mago-job-2",
+            jobName="mag-l1c-norm-mago-4d649e314e8ac32e3fb76fe5d5aad46f-job-2",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-mag",
             containerOverrides={
@@ -1155,13 +1155,13 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--data-level",
                     "l1c",
                     "--descriptor",
-                    "norm-mago",
+                    "norm-mago-4d649e314e8ac32e3fb76fe5d5aad46f",
                     "--start-date",
                     "20240101",
                     "--version",
                     "v002",
                     "--dependency",
-                    "imap_mag_l1c_norm-mago_20240101_v002.json",
+                    "imap_mag_l1c_norm-mago-4d649e314e8ac32e3fb76fe5d5aad46f_20240101_v002.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1352,7 +1352,7 @@ def test_def_cadence_map_event(setup_s3, session, tmp_path):
         assert mock_batch_client.submit_job.call_count == 12
         # Assert that the function was called with the cadence json file path
         mock_batch_client.submit_job.assert_called_with(
-            jobName="ultra-l2-u90-ena-h-sf-nsp-full-hae-6deg-3mo-job-12",
+            jobName="ultra-l2-u90-ena-h-sf-nsp-full-hae-6deg-3mo-73e7829640a9d96aaa9f8e043888201e-job-12",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-ultra",
             containerOverrides={
@@ -1362,13 +1362,13 @@ def test_def_cadence_map_event(setup_s3, session, tmp_path):
                     "--data-level",
                     "l2",
                     "--descriptor",
-                    "u90-ena-h-sf-nsp-full-hae-6deg-3mo",
+                    "u90-ena-h-sf-nsp-full-hae-6deg-3mo-73e7829640a9d96aaa9f8e043888201e",
                     "--start-date",
                     "20250301",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-6deg-3mo_20250301_v001.json",
+                    "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-6deg-3mo-73e7829640a9d96aaa9f8e043888201e_20250301_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1470,7 +1470,7 @@ def test_idex_l2b(session):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_idex_l2b_all-1mo_20230109_v001.json",
+                    "imap_idex_l2b_all-1mo-0a9cfa4f10e4f8162a0b5e5cc9df7bda_20230109_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1975,7 +1975,7 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
         # verify that the function was called once
         mock_batch_client.submit_job.assert_called_once()
         mock_batch_client.submit_job.assert_called_with(
-            jobName="spacecraft-l1a-pointing-attitude-job-3",
+            jobName="spacecraft-l1a-pointing-attitude-58c20cdbd52c1b788c448fcd7b387355-job-3",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-spacecraft",
             containerOverrides={
@@ -1985,13 +1985,13 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
                     "--data-level",
                     "l1a",
                     "--descriptor",
-                    "pointing-attitude",
+                    "pointing-attitude-58c20cdbd52c1b788c448fcd7b387355",
                     "--start-date",
                     "20000224",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_spacecraft_l1a_pointing-attitude_20000224_v001.json",
+                    "imap_spacecraft_l1a_pointing-attitude-58c20cdbd52c1b788c448fcd7b387355_20000224_v001.json",
                     "--upload-to-sdc",
                 ]
             },

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -131,7 +131,7 @@ def test_lambda_handler(session, s3_client):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_swe_l1a_sci-c685cc1958539fee3c4724e5655c36d2b9b4c8fe99835905b448f7bd93468ab5_20240101_v001.json",
+                    "imap_swe_l1a_sci-c685cc19_20240101_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -412,7 +412,7 @@ def test_lambda_handler_ancillary_event(session):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_swe_l1b_sci-6a22366cd7a617e3d86a5f9e0f4eeaf8711d5c4b46266b79358619fc42a8309a_20260303_v001.json",
+                    "imap_swe_l1b_sci-6a22366c_20260303_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -917,7 +917,7 @@ def test_ultra_l3_map(session, caplog):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_ultra_l3_u90-ena-h-sf-sp-full-hae-4deg-3mo-27005a05f059d26588e175889fe6e8bcd3cbc45b1e7f00c6773785a9fff56538_20240201_v001.json",
+                    "imap_ultra_l3_u90-ena-h-sf-sp-full-hae-4deg-3mo-27005a05_20240201_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1093,7 +1093,7 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_mag_l1c_norm-mago-7f10196662789f7653d3e55e3ccb4eb4a1bb4a6f6b90193c64f8ce75a846679f_20240101_v001.json",
+                    "imap_mag_l1c_norm-mago-7f101966_20240101_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1161,7 +1161,7 @@ def test_lambda_handler_mag_l1c_case(session):
                     "--version",
                     "v002",
                     "--dependency",
-                    "imap_mag_l1c_norm-mago-2ae6d6feecb9c00015881bc67ab7b10e29783732468a5e0b635adfe4326fc96c_20240101_v002.json",
+                    "imap_mag_l1c_norm-mago-2ae6d6fe_20240101_v002.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1364,7 +1364,7 @@ def test_def_cadence_map_event(setup_s3, session, tmp_path):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-6deg-3mo-74f0a45021f58df642c0fae542661f17c0790964182ca62399fd0c4be45aeb0f_20250301_v001.json",
+                    "imap_ultra_l2_u90-ena-h-sf-nsp-full-hae-6deg-3mo-74f0a450_20250301_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1466,7 +1466,7 @@ def test_idex_l2b(session):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_idex_l2b_all-1mo-9de6e4ae33556063213c1528033aadb4a9bd4421fc428dc31303a08876eafd05_20230109_v001.json",
+                    "imap_idex_l2b_all-1mo-9de6e4ae_20230109_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1987,7 +1987,7 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_spacecraft_l1a_pointing-attitude-609961590f7a3732fa929e29207ffa14b83dafd107d47b3f1077eded267a9a08_20000224_v001.json",
+                    "imap_spacecraft_l1a_pointing-attitude-60996159_20000224_v001.json",
                     "--upload-to-sdc",
                 ]
             },


### PR DESCRIPTION
# Change Summary

## Overview
Add a hash of the upstream dependencies to the dependency file descriptor. 

There is currently a bug in sds-data-manager that @maxinelasp discovered. The dependency file is uploaded to s3 in batch_starter.py for a new processing run with the same version as the file that is to be produced. The issue is that if that processing run fails, that dependency file is kept ( this is desired behavior because we need to be able to download this for debugging purposes). Since that file is never deleted, when that processing job rerun gets kicked off, it will try to write a file with the same name to s3 and cause the batch starter to error out. Greg suggested we add a hash to the dependency filename. The hash contains the contents of the file so this way we can:

- Reuse any dependency JSON files if the filename is exactly the same
         - A matching hash ensures that none of the upstream dependencies are changed
- Produce different files if the contents have changed while still matching them to the file version.
          - the version number will still be the same as the CDF file.
- Save any dependency files for debugging if processing has failed.
- BONUS! - In batch_starter.py we no longer need to download and extract the contents of a JSON file to determine if the job is a duplicate. We can just check to see if the hashes match.


## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Add a hash to the descriptor of the dependency file 
   - Move uploading the cadence file to before adding an entry in the processing job table just in case the cadence file upload errors out
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - I was testing with IDEX l2b and realized that this trigger should be a HARD_NO_TRIGGER

## Testing
Fix expected calls. 