### PR TITLE
Update hit l1b dependencies

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -413,7 +413,7 @@ spacecraft_clock, spice, historical, hit, l1b, hk, HARD_NO_TRIGGER, DOWNSTREAM
 
 hit, l1a, counts-standard, hit, l1b, standard-rates, HARD, DOWNSTREAM
 hit, l1a, counts-standard, hit, l1b, summed-rates, HARD, DOWNSTREAM
-hit, l1a, counts-sectored, hit, l1b, sectored_rates, HARD, DOWNSTREAM
+hit, l1a, counts-sectored, hit, l1b, sectored-rates, HARD, DOWNSTREAM
 
 hit, l1b, standard-rates, hit, l2, standard-intensity, HARD, DOWNSTREAM
 hit, l1b, summed-rates, hit, l2, summed-intensity, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -411,7 +411,9 @@ hit, l0, raw, hit, l1b, hk, HARD, DOWNSTREAM
 leapseconds, spice, historical, hit, l1b, hk, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, hit, l1b, hk, HARD_NO_TRIGGER, DOWNSTREAM
 
-hit, l1a, counts, hit, l1b, all, HARD, DOWNSTREAM
+hit, l1a, counts-standard, hit, l1b, standard-rates, HARD, DOWNSTREAM
+hit, l1a, counts-standard, hit, l1b, summed-rates, HARD, DOWNSTREAM
+hit, l1a, counts-sectored, hit, l1b, sectored_rates, HARD, DOWNSTREAM
 
 hit, l1b, standard-rates, hit, l2, standard-intensity, HARD, DOWNSTREAM
 hit, l1b, summed-rates, hit, l2, summed-intensity, HARD, DOWNSTREAM

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -194,7 +194,7 @@ def test_get_downstream_dependencies():
     dependency_response = dependency.get_jobs(
         data_source="hit",
         data_type="l1a",
-        descriptor="counts",
+        descriptor="counts-sectored",
         relationship="HARD",
         dependency_type="DOWNSTREAM",
     )
@@ -203,7 +203,7 @@ def test_get_downstream_dependencies():
         {
             "data_source": "hit",
             "data_type": "l1b",
-            "descriptor": "all",
+            "descriptor": "sectored-rates",
             "relationship": "HARD",
         }
     ]


### PR DESCRIPTION
This PR updates dependencies for HIT L1B processing to match a recent change to HIT processing that split up the L1A counts product into two products. 

Now the l1a counts-standard product produces two l1b products and the l1a counts-sectored product produces one l1b product for a total of 3 l1b products.