### PR TITLE
Add s3 tags to reprocessed files

### DIFF
--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -62,6 +62,13 @@ class SdsApiManager(Construct):
                 f"{data_bucket.bucket_arn}/*",
             ],
         )
+        s3_tag_policy = iam.PolicyStatement(
+            effect=iam.Effect.ALLOW,
+            actions=["s3:PutObjectTagging"],
+            resources=[
+                f"{data_bucket.bucket_arn}/*",
+            ],
+        )
         s3_read_policy = iam.PolicyStatement(
             effect=iam.Effect.ALLOW,
             actions=["s3:GetObject"],
@@ -91,6 +98,7 @@ class SdsApiManager(Construct):
             layers=layers,
         )
         upload_api_lambda.add_to_role_policy(s3_write_policy)
+        upload_api_lambda.add_to_role_policy(s3_tag_policy)
         upload_api_lambda.add_to_role_policy(s3_read_policy)
         upload_api_lambda.apply_removal_policy(cdk.RemovalPolicy.DESTROY)
 

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
@@ -77,7 +77,7 @@ def _generate_signed_upload_response(s3_key_path, tags=None):
         Params={
             "Bucket": BUCKET_NAME,
             "Key": s3_key_path,
-            "Metadata": tags or dict(),
+            "Tagging": "&".join(f"{k}={v}" for k, v in (tags or {}).items()),
         },
         ExpiresIn=3600,
     )
@@ -96,6 +96,9 @@ def lambda_handler(event, context):
     event : dict
         Specifically looking at the event['pathParameters']['proxy'], which
         specifies the filename to upload.
+        If event['pathParameters']['manually_reprocessed'] == "true", the file will be
+        uploaded with the "manually_reprocessed=true" S3 tag. This tag indicates that
+        the file was reprocessed due to a manual reprocessing API request.
     context : None
         Currently not used
 
@@ -106,6 +109,12 @@ def lambda_handler(event, context):
 
     """
     path_params = event.get("pathParameters", {}).get("proxy", None)
+    manually_reprocessed = (
+        event.get("queryStringParameters", {})
+        .get("manually_reprocessed", "false")
+        .lower()
+        == "true"
+    )
     logger.info("Parsing path parameters=[%s] from event=[%s]", path_params, event)
 
     if not path_params:
@@ -152,5 +161,7 @@ def lambda_handler(event, context):
     s3_key_path_str = str(
         s3_key_path.relative_to(imap_data_access.config["DATA_DIR"]).as_posix()
     )
-
-    return _generate_signed_upload_response(s3_key_path_str)
+    s3tags = {"manually_reprocessed": "true"} if manually_reprocessed else None
+    if s3tags:
+        logger.info(f"Uploading file with S3 tags: {s3tags}.")
+    return _generate_signed_upload_response(s3_key_path_str, tags=s3tags)

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -433,11 +433,11 @@ def try_to_submit_job(
                     f"Skipping submission."
                 )
                 return
-        else:
-            logger.info(
-                "This is a manually triggered reprocessing job. Not checking"
-                "for duplicate jobs."
-            )
+    else:
+        logger.info(
+            "This is a manually triggered reprocessing job. Skipping check for "
+            "duplicate jobs."
+        )
 
     # Serialize the upstream dependencies and write them to a JSON file. The Imap
     # processing code will read the JSON file and deserialize the dependencies. This is

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -380,6 +380,7 @@ def try_to_submit_job(
     start_date: datetime,
     version: str,
     serialized_dependencies: str,
+    skip_duplicate_jobs: bool = True,
 ):
     """Try to submit a batch job with the given job information.
 
@@ -396,6 +397,11 @@ def try_to_submit_job(
     serialized_dependencies : str
         The serialized ProcessingInputCollection of the upstream
         dependencies.
+    skip_duplicate_jobs : bool
+        In normal reprocessing (due to a new file upload) duplicate jobs should be
+        skipped to avoid redundant products. In cases where a user has manually
+        triggered reprocessing, we want to reprocess even if the job looks like a
+        duplicate. Default is True.
     """
     instrument = job_info["data_source"]
     data_level = job_info["data_type"]
@@ -406,27 +412,32 @@ def try_to_submit_job(
     # instrument, data level, descriptor, and start date by checking the CRID.
     # Only check for duplicates if this is a reprocessing job.
     # We know this is a reprocessing job if the version is not "v001".
-    if version != "v001":
-        previous_version = f"v{int(version[1:]) - 1:03d}"
-        if duplicate_job(
-            instrument,
-            data_level,
-            descriptor,
-            start_date_str,
-            previous_version,
-            serialized_dependencies,
-        ):
+    if skip_duplicate_jobs:
+        if version != "v001":
+            previous_version = f"v{int(version[1:]) - 1:03d}"
+            if duplicate_job(
+                instrument,
+                data_level,
+                descriptor,
+                start_date_str,
+                previous_version,
+                serialized_dependencies,
+            ):
+                logger.info(
+                    f"This job is a duplicate of the previous one for: "
+                    f"{instrument=},"
+                    f" {data_level=},"
+                    f" {descriptor=},"
+                    f" {start_date_str=},"
+                    f" and {previous_version=}. "
+                    f"Skipping submission."
+                )
+                return
+        else:
             logger.info(
-                f"This job is a duplicate of the previous one for: "
-                f"{instrument=},"
-                f" {data_level=},"
-                f" {descriptor=},"
-                f" {start_date_str=},"
-                f" and {previous_version=}. "
-                f"Skipping submission."
+                "This is a manually triggered reprocessing job. Not checking"
+                "for duplicate jobs."
             )
-            return
-    # TODO: do we need a reprocessing column to indicate if this is a reprocessing job?
 
     # Serialize the upstream dependencies and write them to a JSON file. The Imap
     # processing code will read the JSON file and deserialize the dependencies. This is
@@ -516,6 +527,7 @@ def submit_all_jobs(
     end_date,
     calculate_crids=False,
     filter_dependencies=True,
+    skip_duplicate_jobs=True,
 ):
     """Submit all jobs for the given job and upstream dependencies.
 
@@ -538,6 +550,11 @@ def submit_all_jobs(
         not want to filter any dependencies out, for example, ULTRA l3
         "u90-ena-h-sf-sp-full-hae-4deg-3mo" needs all the psets in the collection.
         Default is set to True.
+    skip_duplicate_jobs : bool
+        In normal reprocessing (due to a new file upload) duplicate jobs should be
+        skipped to avoid redundant products. In cases where a user has manually
+        triggered reprocessing, we want to reprocess even if the job looks like a
+        duplicate. Default is True.
 
 
     """
@@ -580,6 +597,7 @@ def submit_all_jobs(
             datetime.datetime.strptime(start_date, "%Y%m%d"),
             job_version,
             upstream_dependencies.serialize(),
+            skip_duplicate_jobs,
         )
         return
 
@@ -635,6 +653,7 @@ def submit_all_jobs(
             job_start_date,
             job_version,
             upstream_deps_for_job.serialize(),
+            skip_duplicate_jobs,
         )
 
 
@@ -784,6 +803,25 @@ def s3_processing_event(session, events):
         logger.info("Individual event: " + json.dumps(event, indent=2))
         body = json.loads(event["body"])
         filename = body["detail"]["object"]["key"]
+        # Determine if the file is a manually reprocessed file. E.g. the file was
+        # reprocessed due to a bulk reprocessing api event.
+        # This bool is necessary to avoid skipping duplicate jobs in a
+        # "bulk reprocessing" or "manual reprocessing" run. In normal processing or
+        # reprocessing due to a new file version, duplicate jobs are found by seeing if
+        # a dependency file already exists in S3. Since the dependency file contains a
+        # hash of the serialized dependencies, it's unique to that job. Sometimes,
+        # reprocessing is desired for a job that has already been run with the same
+        # dependencies — for example, if the software has been updated.
+        try:
+            manually_reprocessed = body["detail"]["object"]["manually_reprocessed"]
+            # Invert for clarity
+            skip_duplicate_jobs = not manually_reprocessed
+        except KeyError as e:
+            logger.warning(
+                f"manually_reprocessed key not found in event body: {e}. "
+                f"Assuming this is not a manually reprocessed file."
+            )
+            skip_duplicate_jobs = True
 
         file_obj = imap_data_access.file_validation.generate_imap_file_path(filename)
         input_obj = imap_data_access.processing_input.generate_imap_input(filename)
@@ -852,6 +890,7 @@ def s3_processing_event(session, events):
                 end_date,
                 calculate_crids,
                 filter_dependencies,
+                skip_duplicate_jobs,
             )
 
         if sqs_queue_url:
@@ -910,7 +949,12 @@ def handle_special_case_reprocessing_jobs(session, job_node, start_date, end_dat
             session, job_node, filepath.start_date
         )
         submit_all_jobs(
-            session, job_node, start_date, end_date, filter_dependencies=False
+            session,
+            job_node,
+            start_date,
+            end_date,
+            filter_dependencies=False,
+            skip_duplicate_jobs=False,
         )
 
 
@@ -924,7 +968,6 @@ def bulk_reprocessing_event(session, events):
     events : dict
         Event input.
     """
-    # TODO: We need s3 tag or column in db to track bulk reprocessing
     instrument = events.get("instrument")
     data_level = events.get("data_level")
     descriptor = events.get("descriptor")
@@ -977,7 +1020,9 @@ def bulk_reprocessing_event(session, events):
         if job in SPECIAL_CASE_JOBS:
             handle_special_case_reprocessing_jobs(session, job, start_date, end_date)
         else:
-            submit_all_jobs(session, job, start_date, end_date)
+            submit_all_jobs(
+                session, job, start_date, end_date, skip_duplicate_jobs=False
+            )
 
 
 def upload_dependency_file(dependency_file_path: Path, serialized_dependencies: str):
@@ -1153,7 +1198,7 @@ def lambda_handler(events: dict, context):
                         "body": '{"detail": '
                         '{"object": {"key": '
                         '"imap_swe_l1b-in-flight-cal_20240101_v001.cdf"},
-                        "tags": [{"Key": "manually_reprocessed", "Value": "true"}]}'
+                        "manually_reprocessed": true'
                         "}"
                     }
                 ]

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -1152,7 +1152,8 @@ def lambda_handler(events: dict, context):
                     {
                         "body": '{"detail": '
                         '{"object": {"key": '
-                        '"imap_swe_l1b-in-flight-cal_20240101_v001.cdf"}}'
+                        '"imap_swe_l1b-in-flight-cal_20240101_v001.cdf"},
+                        "tags": [{"Key": "manually_reprocessed", "Value": "true"}]}'
                         "}"
                     }
                 ]

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/indexer.py
@@ -20,8 +20,8 @@ logger.setLevel(logging.INFO)
 s3 = boto3.client("s3")
 
 
-def get_file_tagging(file_path):
-    """Get s3 file tagging.
+def manually_reprocessed_file(file_path):
+    """Check if a file was manually reprocessed triggered by an API event.
 
     Parameters
     ----------
@@ -30,8 +30,9 @@ def get_file_tagging(file_path):
 
     Returns
     -------
-    dict
-        Dictionary of tags for the s3 file.
+    manually_reprocessed : bool
+        True if the file was reprocessed due to a manual reprocessing event, False
+        otherwise.
 
     """
     # Create an S3 client
@@ -41,8 +42,15 @@ def get_file_tagging(file_path):
     bucket_name = os.getenv("S3_BUCKET")
     logger.info(f"looking up tags for {file_path}")
 
-    response = s3_client.get_object_tagging(Bucket=bucket_name, Key=file_path)
-    return response["TagSet"]
+    tags = s3_client.get_object_tagging(Bucket=bucket_name, Key=file_path)["TagSet"]
+    # Tags are a list of dictionaries, each with a Key and Value.
+    # E.g: [{"Key": "manually_reprocessed", "Value": "true"}]
+    return any(
+        [
+            (tag["Key"] == "manually_reprocessed" and tag["Value"] == "true")
+            for tag in tags
+        ]
+    )
 
 
 def get_file_ingestion_date(file_path):
@@ -106,7 +114,7 @@ def http_response(headers=None, status_code=200, body="Success"):
     }
 
 
-def send_event_from_indexer(file_obj, tags):
+def send_event_from_indexer(file_obj, manually_reprocessed=False):
     """Send custom PutEvent to EventBridge.
 
     Example of what PutEvent looks like:
@@ -117,7 +125,7 @@ def send_event_from_indexer(file_obj, tags):
             "object": {
                   "key": filename
                   "instrument": instrument_name
-                  "tags": file_tags
+                  "manually_reprocessed": true
             },
         },
     }
@@ -126,8 +134,9 @@ def send_event_from_indexer(file_obj, tags):
     ----------
     file_obj : AncillaryFilePath, ScienceFilePath
         The filename to use in the PutEvent
-    tags : dict
-        Dictionary of tags for the s3 file.
+    manually_reprocessed : bool
+        True if the file was reprocessed due to a manual reprocessing event, False
+        otherwise.
 
     Returns
     -------
@@ -147,7 +156,7 @@ def send_event_from_indexer(file_obj, tags):
             "key": str(file_obj.filename),
             "instrument": file_obj.instrument,
             "data_level": "ancillary",
-            "tags": tags,
+            "manually_reprocessed": manually_reprocessed,
         }
     }
 
@@ -266,11 +275,11 @@ def s3_event_handler(event):
             msg = "Error: file name does not match ancillary or science file paths."
             return http_response(status_code=400, body=msg)
 
-    # Get any s3 tags for the file
-    tags = get_file_tagging(s3_filepath)
+    # Check if the file was manually reprocessed
+    manually_reprocessed = manually_reprocessed_file(s3_filepath)
     # Send event from this lambda for Batch starter
     # lambda
-    send_event_from_indexer(file_obj, tags)
+    send_event_from_indexer(file_obj, manually_reprocessed)
     logger.debug("S3 event handler complete")
     return http_response(status_code=200, body="Success")
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/indexer.py
@@ -20,6 +20,31 @@ logger.setLevel(logging.INFO)
 s3 = boto3.client("s3")
 
 
+def get_file_tagging(file_path):
+    """Get s3 file tagging.
+
+    Parameters
+    ----------
+    file_path: str
+        S3 object path. Eg. filepath/filename.ext
+
+    Returns
+    -------
+    dict
+        Dictionary of tags for the s3 file.
+
+    """
+    # Create an S3 client
+    s3_client = boto3.client("s3")
+
+    # Retrieve the metadata of the object
+    bucket_name = os.getenv("S3_BUCKET")
+    logger.info(f"looking up tags for {file_path}")
+
+    response = s3_client.get_object_tagging(Bucket=bucket_name, Key=file_path)
+    return response["TagSet"]
+
+
 def get_file_ingestion_date(file_path):
     """Get s3 file ingestion date.
 
@@ -81,7 +106,7 @@ def http_response(headers=None, status_code=200, body="Success"):
     }
 
 
-def send_event_from_indexer(file_obj):
+def send_event_from_indexer(file_obj, tags):
     """Send custom PutEvent to EventBridge.
 
     Example of what PutEvent looks like:
@@ -92,6 +117,7 @@ def send_event_from_indexer(file_obj):
             "object": {
                   "key": filename
                   "instrument": instrument_name
+                  "tags": file_tags
             },
         },
     }
@@ -100,6 +126,8 @@ def send_event_from_indexer(file_obj):
     ----------
     file_obj : AncillaryFilePath, ScienceFilePath
         The filename to use in the PutEvent
+    tags : dict
+        Dictionary of tags for the s3 file.
 
     Returns
     -------
@@ -119,6 +147,7 @@ def send_event_from_indexer(file_obj):
             "key": str(file_obj.filename),
             "instrument": file_obj.instrument,
             "data_level": "ancillary",
+            "tags": tags,
         }
     }
 
@@ -237,9 +266,11 @@ def s3_event_handler(event):
             msg = "Error: file name does not match ancillary or science file paths."
             return http_response(status_code=400, body=msg)
 
+    # Get any s3 tags for the file
+    tags = get_file_tagging(s3_filepath)
     # Send event from this lambda for Batch starter
     # lambda
-    send_event_from_indexer(file_obj)
+    send_event_from_indexer(file_obj, tags)
     logger.debug("S3 event handler complete")
     return http_response(status_code=200, body="Success")
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/lambda_custom_events.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/lambda_custom_events.py
@@ -11,7 +11,6 @@ class IMAPLambdaPutEvent:
     detail_type: str
     detail: dict
     source: str = "imap.lambda"
-    job_id: str = None
 
     def to_event(self):
         """Return the event details."""

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/lambda_custom_events.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/lambda_custom_events.py
@@ -11,6 +11,7 @@ class IMAPLambdaPutEvent:
     detail_type: str
     detail: dict
     source: str = "imap.lambda"
+    job_id: str = None
 
     def to_event(self):
         """Return the event details."""

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -156,6 +156,7 @@ def test_lambda_handler(session, s3_client):
             dt.datetime(2024, 1, 1, 0, 0),
             "v002",
             processing_input.serialize(),
+            True,
         )
 
 
@@ -431,6 +432,7 @@ def test_lambda_handler_ancillary_event(session):
             dt.datetime(2026, 3, 3, 0, 0),
             "v002",
             json.dumps(inputs),
+            True,
         )
 
 
@@ -944,6 +946,7 @@ def test_ultra_l3_map(session, caplog):
                 dt.datetime(2024, 2, 1, 0, 0),
                 "v002",
                 expected_processing_input.serialize(),
+                True,
             )
 
 
@@ -1180,6 +1183,7 @@ def test_lambda_handler_mag_l1c_case(session):
             dt.datetime(2024, 1, 1, 0, 0),
             "v003",
             expected_processing_input.serialize(),
+            True,
         )
 
 

--- a/tests/lambda_endpoints/test_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_indexer_lambda.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sds_data_manager.lambda_code.SDSCode.database import models
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import indexer
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.indexer import (
+    manually_reprocessed_file,
     send_event_from_indexer,
 )
 
@@ -252,3 +253,22 @@ def test_send_lambda_put_event(events_client):
 
     result = send_event_from_indexer(file_obj)
     assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+def test_manually_reprocessed_file(session, s3_client, events_client):
+    """Test that the function returns true when the file has a reprocessed tag."""
+    filepath = "imap/idex/l0/2024/01/imap_index_l0_sci-test_20240101_v001.pkts"
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key=filepath,
+        Body=b"test",
+        Tagging="manually_reprocessed=true",
+    )
+    assert manually_reprocessed_file(filepath)
+    filepath_no_tag = "imap/idex/l0/2024/01/imap_index_l0_sci-test_20240101_v002.pkts"
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key=filepath_no_tag,
+        Body=b"test",
+    )
+    assert not manually_reprocessed_file(filepath_no_tag)

--- a/tests/lambda_endpoints/test_upload_api.py
+++ b/tests/lambda_endpoints/test_upload_api.py
@@ -1,6 +1,7 @@
 """Tests for the Upload API."""
 
 import os
+from urllib.parse import urlparse
 
 from sds_data_manager.lambda_code.SDSCode.api_lambdas import upload_api
 
@@ -89,8 +90,8 @@ def test_ancillary_file_upload(s3_client, ancillary_file):
     assert response["statusCode"] == 409
 
 
-def test_cadence_file_upload(s3_client, dependency_file):
-    """Test cadence files being uploaded."""
+def test_dependency_file_upload(s3_client, dependency_file):
+    """Test dependency files being uploaded."""
     event = {
         "version": "2.0",
         "routeKey": "$default",
@@ -99,7 +100,6 @@ def test_cadence_file_upload(s3_client, dependency_file):
     }
     response = upload_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 200
-
     # Try to upload again and we should get a 409 duplicate error
     s3_client.put_object(
         Bucket=os.getenv("S3_BUCKET"),
@@ -140,3 +140,22 @@ def test_incorrect_file_type(s3_client, invalid_file):
     response = upload_api.lambda_handler(event=event, context=None)
     # It should now go into staging area instead of throwing an error
     assert response["statusCode"] == 400
+
+
+def test_upload_with_reprocessing_tag(s3_client, science_file):
+    """Test that a file can be uploaded with the manually reprocessed tag."""
+    event = {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": "/",
+        "pathParameters": {
+            "proxy": science_file,
+        },
+        "queryStringParameters": {"manually_reprocessed": "true"},
+    }
+    response = upload_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 200
+
+    # Check that the file was uploaded with the correct tag
+    parsed_url = urlparse(response["body"])
+    assert "x-amz-tagging=manually_reprocessed" in parsed_url.query


### PR DESCRIPTION
# Change Summary

## Overview

The issue:
We check for duplicate jobs by seeing if a dependency file already exists in S3. Since the dependency file contains a hash of the serialized dependencies, it’s unique to that job. 

Sometimes, though, we want to reprocess a job that has already been run with the same dependencies — for example, if the software has been updated. We need a way for batch_starter to tell whether a job is a manually triggered reprocessing job or not.

For example: 
imap-data-access reprocess --instrument idex

Solution: 
Add an S3 tag to the file if it has been reprocessed due to a manual reprocessing event. The changes here are to carry this information from the upload api lambda handler to the indexer -> to batch starter. 

The changes necessary for imap-data-access are in this [PR](https://github.com/IMAP-Science-Operations-Center/imap-data-access/pull/255)

## Updated Files
-sds_data_manager/constructs/sds_api_manager_construct.py
   - Add S3 tagging policy to lambda handler
- sds_data_manager/lambda_code/SDSCode/api_lambdas/upload_api.py
   - Add tags to '_generate_signed_upload_response'
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py 
   - DO NOT skip duplicate jobs if in a reprocessing run.
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/indexer.py
   - query for s3 manually_reprocessed tag

## Testing
Fix expected try_to_submit job calls and add tests surrounding s3 tag