### PR TITLE
 Separate lambda for API Redirect

### DIFF
--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -120,6 +120,13 @@ class SdsApiManager(Construct):
             runtime=lambda_.Runtime.PYTHON_3_12,
         )
 
+        # Redirect root '/' to the landing page
+        api.add_route(
+            route="/",
+            http_method="GET",
+            lambda_function=landing_page_lambda,
+        )
+
         # upload API lambda
         upload_api_lambda = lambda_.Function(
             self,
@@ -143,13 +150,6 @@ class SdsApiManager(Construct):
         upload_api_lambda.add_to_role_policy(s3_write_policy)
         upload_api_lambda.add_to_role_policy(s3_read_policy)
         upload_api_lambda.apply_removal_policy(cdk.RemovalPolicy.DESTROY)
-
-        # Redirect root '/' to the landing page
-        api.add_route(
-            route="/",
-            http_method="GET",
-            lambda_function=landing_page_lambda,
-        )
 
         # basic route: /upload/{proxy+}
         # oauth2 JWT authorizer: /authorized/upload/{proxy+}

--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -112,28 +112,12 @@ class SdsApiManager(Construct):
         )
 
         # landing page redirect
-        landing_page_redirect_lambda = lambda_.Function(
+        landing_page_lambda = lambda_.Function(
             self,
-            id="LandingPageRedirectLambda",
-            function_name="landing-page-redirect",
-            code=lambda_.InlineCode(
-                """
-            def lambda_handler(event, context):
-                return {
-                    "statusCode": 302,
-                    "headers": {
-                        "Location": "https://imap-processing.readthedocs.io/en/latest/data-access/index.html"
-                    },
-                "body": ""
-                }
-                """
-            ),
-            handler="index.lambda_handler",
+            id="LandingPageLambda",
+            code=code,
+            handler="SDSCode.api_lambdas.landing_page_api.lambda_handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
-            timeout=cdk.Duration.seconds(5),
-            memory_size=128,
-            allow_public_subnet=True,
-            layers=layers,
         )
 
         # upload API lambda
@@ -164,7 +148,7 @@ class SdsApiManager(Construct):
         api.add_route(
             route="/",
             http_method="GET",
-            lambda_function=landing_page_redirect_lambda,
+            lambda_function=landing_page_lambda,
         )
 
         # basic route: /upload/{proxy+}

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/landing_page_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/landing_page_api.py
@@ -1,0 +1,31 @@
+"""Define lambda to support the home page reroute of the API."""
+
+
+def lambda_handler(event, context):
+    """Entry point to the landing page redirect lambda.
+
+    Redirects incoming requests to the root API path ("/")
+    and sends them to the external landing page URL via HTTP 302 redirect.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process
+    context : LambdaContext
+        This object provides methods and properties that provide information
+        about the invocation, function, and runtime environment.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the HTTP status code (302), headers with the
+        Location field set to the landing page URL, and no body
+    """
+    return {
+        "statusCode": 302,
+        "headers": {
+            "Location": "https://imap-processing.readthedocs.io/en/latest/data-access/index.html"
+        },
+        "body": "",
+    }


### PR DESCRIPTION
# Pulling the Redirect code into a separate lambda

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
After making the changes in the last PR, the https://api.dev.imap-mission.com link results in a `{"message":"Internal Server Error"}`. I am hoping to fix this by putting the redirect code into a separate lambda, similar to how all the other lambdas are invoked. 

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- landing_page_api.py

## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- sds_api_manager_construct.py

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
