### PR TITLE
Fix initial time kernel indexing 

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -28,10 +28,10 @@ minimum_mission_time = datetime(2010, 1, 1)
 maximum_mission_time = datetime(2145, 1, 1)
 MAXIMUM_DATETIME_INTERVAL = [[minimum_mission_time, maximum_mission_time]]
 MAXIMUM_SCLK_INTERVAL = [
-    ["1/0410227203:00000", "1/4288750963:38093"]
+    ["1/0000000000:00000", "1/4260211203:00000"]
 ]  # Calculated from the above datetimes seperately
 MAXIMUM_J2000_INTERVAL = [
-    [725803269.1839136, 4575787269.183866]
+    [315576066.1839245, 4575787269.183866]
 ]  # Calculated from the above datetimes seperately
 
 # Set constants for the time interval calculations


### PR DESCRIPTION
# Change Summary

## Overview
Updates `MAXIMUM_SCLK_INTERVAL` and `MAXIMUM_J2000_INTERVAL` to match `MAXIMUM_DATETIME_INTERVAL`. These constants are used during the initial indexing of the spacecraft time and leapsecond kernel. The default minimum j2000 time used to be a date in 2023 which was causing issues. 

after furnishing the correct time kernels, I used spiceypy.utc2et to convert the datetimes to J2000 and then spiceypy.sce2s to convert from J2000 to sclk @bryan-harter is that what you did initially? 

After this is approved I will reindex the time kernels 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
   - Fix all the maximum interval constants to match the max datetime interval 