### PR TITLE
FIX: Add APIGateway CORS headers allow list

### DIFF
--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -153,6 +153,7 @@ class ApiGateway(Construct):
             default_domain_mapping=domain_mapping,
             description="HTTP API Gateway for lambda function endpoints.",
             cors_preflight={
+                "allow_headers": ["*"],
                 "allow_origins": ["*"],
                 "allow_methods": [
                     apigwv2.CorsHttpMethod.GET,


### PR DESCRIPTION
We don't care what headers get sent our way, so keep it wide open.

This causes an error in the current dev deployment website because they add an "Authorization Header"