### PR TITLE
Updates to the start date and to pass repoint into CLI call

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -82,6 +82,7 @@ class ProcessingJob(Base):
     descriptor = Column(String, nullable=False)
     start_date = Column(DateTime, nullable=False)
     version = Column(String(8), nullable=False)
+    repointing = Column(Integer, nullable=True)
     # TODO:
     # Didn't make it required field yet. Revisit this
     # post discussion
@@ -96,6 +97,7 @@ class ProcessingJob(Base):
         # Partial unique index to ensure only one INPROGRESS or COMPLETED for a record
         # We do want to allow multiple FAILED records
         # NOTE: This does not work with sqllite (testing) DBs, only postgres
+        # if any columns are null, they are ignored (such as repointing)
         Index(
             "idx_unique_status",
             "instrument",
@@ -103,6 +105,7 @@ class ProcessingJob(Base):
             "descriptor",
             "start_date",
             "version",
+            "repointing",
             unique=True,
             postgresql_where=and_(status.in_(["INPROGRESS", "SUCCEEDED"])),
         ),

--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -120,6 +120,7 @@ class ProcessingJob(Base):
             "descriptor": self.descriptor,
             "start_date": self.start_date.isoformat() if self.start_date else None,
             "version": self.version,
+            "repointing": self.repointing,
             # These parameters could be None when the batch job is in progress
             "job_definition": self.job_definition if self.job_definition else None,
             "job_log_stream_id": self.job_log_stream_id

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -204,9 +205,16 @@ def determine_job_version(
         # we should bump the version number and continue with processing.
         if max_version_record.status == models.Status.INPROGRESS:
             command = max_version_record.container_command
-            if current_dependency_hash in command:
+            # Extract the dependency hash from the existing job's command
+            dependency_pattern = r"--dependency\s+\S*-([a-f0-9]{8})_\d{8}_v\d{3}\.json"
+            match = re.search(dependency_pattern, command)
+            if match and match.group(1) == current_dependency_hash:
                 # Return the current max version and this job will not proceed if
                 # everything else is the same.
+                logger.info(
+                    "Job already completed or in progress: duplicate dependency hash "
+                    "found"
+                )
                 return max_version
             logger.info(
                 f"Job with id: {max_version_record.id} is in progress, but the "

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -7,16 +7,19 @@ import logging
 import os
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 import boto3
 import imap_data_access
 import requests
 from imap_data_access import (
+    VALID_INSTRUMENTS,
     AncillaryFilePath,
     DependencyFilePath,
     ScienceFilePath,
     SPICEFilePath,
 )
+from imap_data_access.processing_input import ProcessingInputType
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
@@ -377,9 +380,10 @@ def dependency_hash(serialized_dependencies):
 def try_to_submit_job(
     session: db.Session,
     job_info: dict,
-    start_date: datetime,
+    start_date: str,
     version: str,
     serialized_dependencies: str,
+    repoint: Optional[int] = None,
 ):
     """Try to submit a batch job with the given job information.
 
@@ -389,18 +393,20 @@ def try_to_submit_job(
         Database session.
     job_info : dict
         Dictionary containing components with dates and versions appended.
-    start_date : datetime
-        Start date of the data.
+    start_date : str
+        Start date of the data in the format 'YYYYMMDD'.
     version : str
         Version of the job.
     serialized_dependencies : str
         The serialized ProcessingInputCollection of the upstream
         dependencies.
+    repoint : int, optional
+        The repointing number for the job, if applicable. Default is None. Should
+        be just an integer, no "repoint" prefix.
     """
     instrument = job_info["data_source"]
     data_level = job_info["data_type"]
     descriptor = job_info["descriptor"]
-    start_date_str = datetime.datetime.strftime(start_date, "%Y%m%d")
 
     # Search for any duplicate jobs that have the same exact dependencies for this
     # instrument, data level, descriptor, and start date by checking the CRID.
@@ -412,7 +418,7 @@ def try_to_submit_job(
             instrument,
             data_level,
             descriptor,
-            start_date_str,
+            start_date,
             previous_version,
             serialized_dependencies,
         ):
@@ -421,7 +427,7 @@ def try_to_submit_job(
                 f"{instrument=},"
                 f" {data_level=},"
                 f" {descriptor=},"
-                f" {start_date_str=},"
+                f" {start_date=},"
                 f" and {previous_version=}. "
                 f"Skipping submission."
             )
@@ -439,9 +445,10 @@ def try_to_submit_job(
         instrument=instrument,
         data_level=data_level,
         descriptor=dep_descriptor,
-        start_time=start_date.strftime("%Y%m%d"),
+        start_time=start_date,
         version=version,
         extension="json",
+        repointing=repoint,  # since we can have different repointings on the same day
     )
     dependency_file_path = dependency_file.construct_path()
     response = upload_dependency_file(dependency_file_path, serialized_dependencies)
@@ -458,8 +465,9 @@ def try_to_submit_job(
         instrument=instrument,
         data_level=data_level,
         descriptor=descriptor,
-        start_date=start_date,
+        start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
         version=version,
+        repointing=repoint,
     )
     try:
         session.add(processing_job)
@@ -480,13 +488,16 @@ def try_to_submit_job(
         "--descriptor",
         descriptor,
         "--start-date",
-        start_date_str,
+        start_date,
         "--version",
         version,
         "--dependency",
         dependency_file_path.name,
         "--upload-to-sdc",
     ]
+
+    if repoint is not None:
+        batch_command.extend(["--repointing", f"repoint{repoint}"])
 
     # NOTE: The batch job name should contain only alphanumeric characters and hyphens
     # E.g. "codice-l1a-sci-job-1"
@@ -512,8 +523,8 @@ def try_to_submit_job(
 def submit_all_jobs(
     session,
     job_node,
-    start_date,
-    end_date,
+    trigger_start_date,
+    trigger_end_date,
     calculate_crids=False,
     filter_dependencies=True,
 ):
@@ -524,11 +535,13 @@ def submit_all_jobs(
     session : orm session
         Database session.
     job_node : dict
-        job node to get the potential jobs from.
-    start_date : str
-        Start date to query the data.
-    end_date : str
-        End date to query the data.
+        job node to get the potential jobs from. This is a dictionary with the
+        keys: data_source, data_type, and descriptor. This can ONLY be a science job.
+    trigger_start_date : str
+        The start date of the file that triggered the job in the format 'YYYYMMDD'. This
+        determines the range of potential jobs.
+    trigger_end_date : str
+        The end date of the file that triggered the job in the format 'YYYYMMDD'.
     calculate_crids : bool
         True if the file that triggered the job is a science file, False if it is SPICE
         or ancillary.
@@ -538,10 +551,9 @@ def submit_all_jobs(
         not want to filter any dependencies out, for example, ULTRA l3
         "u90-ena-h-sf-sp-full-hae-4deg-3mo" needs all the psets in the collection.
         Default is set to True.
-
-
     """
     logger.info(f"Finding dependencies for the job node: {job_node}")
+
     # Submit downstream jobs for each upstream primary science dependency file.
     # Find the files that this job depends on
     upstream_dependencies = dependency.get_jobs(
@@ -550,8 +562,8 @@ def submit_all_jobs(
         descriptor=job_node["descriptor"],
         dependency_type="UPSTREAM",
         relationship="ALL",
-        start_date=start_date,
-        end_date=end_date,
+        start_date=trigger_start_date,
+        end_date=trigger_end_date,
         calculate_crids=calculate_crids,
     )
     if not upstream_dependencies:
@@ -571,22 +583,24 @@ def submit_all_jobs(
             session=session,
             instrument=job_node["data_source"],
             descriptor=job_node["descriptor"],
-            start_date=start_date,
+            start_date=datetime.datetime.strptime(trigger_start_date, "%Y%m%d"),
             data_level=job_node["data_type"],
         )
         try_to_submit_job(
             session,
             job_node,
-            datetime.datetime.strptime(start_date, "%Y%m%d"),
+            trigger_start_date,
             job_version,
             upstream_dependencies.serialize(),
         )
         return
 
-    # Find the first science processingInput that has the same source as the
+    # For jobs, we need to use the start date from the primary science file.
+    # this is not necessarily the same as the start date of the trigger file.
+    # Find the first science processingInput that has the same instrument as the
     # potential job. Use this to determine the start date.
-    primary_science_inputs = upstream_dependencies.get_science_inputs(
-        job_node["data_source"]
+    primary_science_inputs = upstream_dependencies.get_processing_inputs(
+        input_type=ProcessingInputType.SCIENCE_FILE, source=job_node["data_source"]
     )
     if not primary_science_inputs:
         logger.info(
@@ -594,18 +608,26 @@ def submit_all_jobs(
             f"primary science files found."
         )
         return
+    # find the primary science
     primary_science = primary_science_inputs[0]
     num_jobs = len(primary_science.imap_file_paths)
     logger.info(f"Found {num_jobs} jobs to process.")
-    for filepath in primary_science.imap_file_paths:
-        job_start_date = datetime.datetime.strptime(filepath.start_date, "%Y%m%d")
+    for filename in primary_science.filename_list:
+        science_file = ScienceFilePath(filename)
+        start_date, end_date = determine_date_range(session, science_file)
+
         job_version = determine_job_version(
             session=session,
             instrument=job_node["data_source"],
             descriptor=job_node["descriptor"],
-            start_date=job_start_date,
+            start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
             data_level=job_node["data_type"],
         )
+
+        # Get the repointing number from the same spot as the time range
+        # Is either a number or None
+        job_repointing = science_file.repointing
+
         # If there is only one file to process, then we can use upstream dependencies
         # that have already been queried.
         if num_jobs > 1 or filter_dependencies:
@@ -617,8 +639,8 @@ def submit_all_jobs(
                 descriptor=job_node["descriptor"],
                 dependency_type="UPSTREAM",
                 relationship="ALL",
-                start_date=filepath.start_date,
-                end_date=filepath.start_date,
+                start_date=start_date,
+                end_date=end_date,
                 calculate_crids=False,
             )
             if not upstream_deps_for_job:
@@ -632,9 +654,10 @@ def submit_all_jobs(
         try_to_submit_job(
             session,
             job_node,
-            job_start_date,
+            start_date,
             job_version,
             upstream_deps_for_job.serialize(),
+            repoint=job_repointing,
         )
 
 
@@ -788,6 +811,8 @@ def s3_processing_event(session, events):
         file_obj = imap_data_access.file_validation.generate_imap_file_path(filename)
         input_obj = imap_data_access.processing_input.generate_imap_input(filename)
 
+        trigger_start_time, trigger_end_time = determine_date_range(session, file_obj)
+
         if input_obj.source == "glows" and input_obj.data_type == "l3e":
             if triggered_from_glows_l3e:
                 logger.info(
@@ -797,9 +822,6 @@ def s3_processing_event(session, events):
                 continue
             else:
                 triggered_from_glows_l3e = True
-
-        # Determine the start and end dates for the upstream query.
-        start_date, end_date = determine_date_range(session, file_obj)
 
         potential_jobs = dependency.get_jobs(
             data_source=input_obj.source,
@@ -833,25 +855,31 @@ def s3_processing_event(session, events):
         # and we want to avoid multiple reprocessing of the same file.
         calculate_crids = isinstance(file_obj, ScienceFilePath)
         for job in potential_jobs + potential_soft_jobs:
+            if job["data_source"] not in VALID_INSTRUMENTS:
+                raise ValueError(
+                    f"Unable to submit job for invalid instrument {job['data_source']}."
+                    f" Downstream dependencies must be science files."
+                )
+
             job.pop("relationship")
-            if job in SPECIAL_CASE_JOBS:
-                start_date, end_date = get_special_case_date_range(
-                    session, job, start_date
+            is_special_case = job in SPECIAL_CASE_JOBS
+
+            if is_special_case:
+                trigger_start_time, trigger_end_time = get_special_case_date_range(
+                    session, job, trigger_start_time
                 )
                 logger.info(
-                    f"Found a special case job: {job}. Using start_date: {start_date}"
+                    f"Using special case date range: "
+                    f"{trigger_start_time} to {trigger_end_time}"
                 )
-                filter_dependencies = False
-            else:
-                filter_dependencies = True
 
             submit_all_jobs(
                 session,
                 job,
-                start_date,
-                end_date,
+                trigger_start_time,
+                trigger_end_time,
                 calculate_crids,
-                filter_dependencies,
+                not is_special_case,  # filter_dependency is determined by special cases
             )
 
         if sqs_queue_url:
@@ -1124,7 +1152,7 @@ def cadence_processing_event(session, events):
             instrument=job_node[0],
             data_level=job_node[1],
             descriptor=job_node[2],
-            start_date=start_date,
+            start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
         )
         # Submit the map job with all of the upstream dependencies in the date range
         node = {
@@ -1135,7 +1163,7 @@ def cadence_processing_event(session, events):
         try_to_submit_job(
             session,
             node,
-            datetime.datetime.strptime(start_date, "%Y%m%d"),
+            start_date,
             job_version,
             upstream_dependencies.serialize(),
         )

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -563,8 +563,7 @@ def submit_all_jobs(
         science_file = ScienceFilePath(filename)
         start_date, end_date = determine_date_range(session, science_file)
 
-        # Get the repointing number from the same spot as the time range
-        # Is either a number or None
+        # Get the repointing number from the science file object
         job_repointing = science_file.repointing
 
         # If there is only one file to process, then we can use upstream dependencies
@@ -810,9 +809,8 @@ def s3_processing_event(session, events):
                 )
 
             job.pop("relationship")
-            is_special_case = job in SPECIAL_CASE_JOBS
 
-            if is_special_case:
+            if job in SPECIAL_CASE_JOBS:
                 trigger_start_time, trigger_end_time = get_special_case_date_range(
                     session, job, trigger_start_time
                 )
@@ -820,6 +818,9 @@ def s3_processing_event(session, events):
                     f"Using special case date range: "
                     f"{trigger_start_time} to {trigger_end_time}"
                 )
+                filter_dependencies = False
+            else:
+                filter_dependencies = True
 
             submit_all_jobs(
                 session,
@@ -827,7 +828,7 @@ def s3_processing_event(session, events):
                 trigger_start_time,
                 trigger_end_time,
                 calculate_crids,
-                not is_special_case,  # filter_dependency is determined by special cases
+                filter_dependencies,
             )
 
         if sqs_queue_url:

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -410,6 +410,9 @@ def try_to_submit_job(
         "--upload-to-sdc",
     ]
 
+    if repoint is not None:
+        batch_command.extend(["--repointing", f"repoint{repoint}"])
+
     # All of our upstream requirements have been met.
     # Try to insert a record into the Processing Jobs table
     # If this job already exists, then we will get an integrity error
@@ -584,7 +587,7 @@ def submit_all_jobs(
             session=session,
             instrument=job_node["data_source"],
             descriptor=job_node["descriptor"],
-            start_date=start_date,
+            start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
             data_level=job_node["data_type"],
             current_dependency_hash=dependency_hash(serialized_deps),
         )
@@ -1091,7 +1094,7 @@ def cadence_processing_event(session, events):
             data_level=job_node[1],
             descriptor=job_node[2],
             start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
-            current_dependency_hash=serialized_deps,
+            current_dependency_hash=dependency_hash(serialized_deps),
         )
         # Submit the map job with all of the upstream dependencies in the date range
         node = {

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1231,9 +1231,40 @@ def test_lambda_handler_duplicate_mag_l1c_job(session, caplog):
         ]
     }
     context = {"context": "sample_context"}
+
+    # Mock the database constraint that prevents duplicate ProcessingJob records
+    # The real database uses PostgreSQL constraints, but tests use SQLite which doesn't
+    # support them
+    original_add = session.add
+
+    def mock_add(obj):
+        if isinstance(obj, ProcessingJob):
+            # Check for duplicate based on unique constraint fields in the actual
+            # session
+            existing_jobs = (
+                session.query(ProcessingJob)
+                .filter(
+                    ProcessingJob.instrument == obj.instrument,
+                    ProcessingJob.data_level == obj.data_level,
+                    ProcessingJob.descriptor == obj.descriptor,
+                    ProcessingJob.start_date == obj.start_date,
+                    ProcessingJob.version == obj.version,
+                    ProcessingJob.repointing == obj.repointing,
+                    ProcessingJob.status.in_(["INPROGRESS", "SUCCEEDED"]),
+                )
+                .all()
+            )
+
+            if existing_jobs:
+                raise IntegrityError(
+                    "duplicate key value violates unique constraint", None, None
+                )
+        return original_add(obj)
+
     with (
         patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client,
         patch.object(batch_starter, "generate_queue_url", return_value=False),
+        patch.object(session, "add", side_effect=mock_add),
     ):
         lambda_handler(events, context)
         # Verify the function was called

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -153,9 +153,10 @@ def test_lambda_handler(session, s3_client):
         mock_submit.assert_called_with(
             session,
             {"data_source": "swe", "data_type": "l1a", "descriptor": "sci"},
-            dt.datetime(2024, 1, 1, 0, 0),
+            "20240101",
             "v002",
             processing_input.serialize(),
+            repoint=None,
         )
 
 
@@ -428,9 +429,10 @@ def test_lambda_handler_ancillary_event(session):
         mock_submit.assert_called_with(
             session,
             {"data_source": "swe", "data_type": "l1b", "descriptor": "sci"},
-            dt.datetime(2026, 3, 3, 0, 0),
+            "20260303",
             "v002",
             json.dumps(inputs),
+            repoint=None,
         )
 
 
@@ -624,7 +626,7 @@ def test_lambda_handler_missing_dependency_for_start_date(session, caplog):
     # Check that the expected message was logged.
     expected_log = (
         "Skipping job submission for {'data_source': 'mag', 'data_type': "
-        "'l2', 'descriptor': 'norm-srf'} with start_date: 20250117 because"
+        "'l2', 'descriptor': 'norm-srf'} with start_date: 20250418 because"
         " of a missing upstream dependency."
     )
     assert expected_log in caplog.text
@@ -941,9 +943,10 @@ def test_ultra_l3_map(session, caplog):
                     "data_type": "l3",
                     "descriptor": "u90-ena-h-sf-sp-full-hae-4deg-3mo",
                 },
-                dt.datetime(2024, 2, 1, 0, 0),
+                "20240201",
                 "v002",
                 expected_processing_input.serialize(),
+                repoint=None,
             )
 
 
@@ -1177,9 +1180,10 @@ def test_lambda_handler_mag_l1c_case(session):
         mock_submit.assert_called_with(
             session,
             {"data_source": "mag", "data_type": "l1c", "descriptor": "norm-mago"},
-            dt.datetime(2024, 1, 1, 0, 0),
+            "20240101",
             "v003",
             expected_processing_input.serialize(),
+            repoint=None,
         )
 
 
@@ -1485,8 +1489,8 @@ def test_idex_l2b(session):
         mock_submit.assert_called_with(
             session,
             {"data_source": "idex", "data_type": "l2b", "descriptor": "all-1mo"},
-            dt.datetime(2023, 1, 9, 0, 0),
-            "v001",
+            "20230109",
+            "v002",
             expected_processing_input.serialize(),
         )
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1231,9 +1231,40 @@ def test_lambda_handler_duplicate_mag_l1c_job(session, caplog):
         ]
     }
     context = {"context": "sample_context"}
+
+    # Mock the database constraint that prevents duplicate ProcessingJob records
+    # The real database uses PostgreSQL constraints, but tests use SQLite which doesn't
+    # support them
+    original_add = session.add
+
+    def mock_add(obj):
+        if isinstance(obj, ProcessingJob):
+            # Check for duplicate based on unique constraint fields in the actual
+            # session
+            existing_jobs = (
+                session.query(ProcessingJob)
+                .filter(
+                    ProcessingJob.instrument == obj.instrument,
+                    ProcessingJob.data_level == obj.data_level,
+                    ProcessingJob.descriptor == obj.descriptor,
+                    ProcessingJob.start_date == obj.start_date,
+                    ProcessingJob.version == obj.version,
+                    ProcessingJob.repointing == obj.repointing,
+                    ProcessingJob.status.in_(["INPROGRESS", "SUCCEEDED"]),
+                )
+                .all()
+            )
+
+            if existing_jobs:
+                raise IntegrityError(
+                    "duplicate key value violates unique constraint", None, None
+                )
+        return original_add(obj)
+
     with (
         patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client,
         patch.object(batch_starter, "generate_queue_url", return_value=False),
+        patch.object(session, "add", side_effect=mock_add),
     ):
         lambda_handler(events, context)
         # Verify the function was called
@@ -1490,7 +1521,7 @@ def test_idex_l2b(session):
             session,
             {"data_source": "idex", "data_type": "l2b", "descriptor": "all-1mo"},
             "20230109",
-            "v002",
+            "v001",
             expected_processing_input.serialize(),
         )
 


### PR DESCRIPTION
# Change Summary
These changes are to clean up and unify the way start_date is handled in sds-data-manager and to pass repoint all the way through to the CLI call correctly.

NOTE: This adds a column to the database, so that will need to be manually updated after merging.

## Updated Files

- sds_data_manager/lambda_code/SDSCode/database/models.py
  - Added repointing column to ProcessingJob model
  - Updated unique constraint to include repointing field
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
  - Added repointing parameter to try_to_submit_job function
  - Added repointing field to ProcessingJob creation
  - Added repointing to dependency file path generation
  - Added repointing extraction from science files in job processing loop
- tests/lambda_endpoints/test_batch_starter.py
  - Updated test expectations to include repoint=None parameter in function calls
  - Updated date format expectations from datetime objects to strings
  - Updated version number expectations for test cases

##  Testing

Updated existing unit tests to handle new repointing parameter. All tests maintain existing functionality while
supporting the new repointing feature.