### PR TITLE
MNT/FIX: Get batch logs from the head

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/batch_logs_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/batch_logs_api.py
@@ -46,6 +46,8 @@ def lambda_handler(event, context):
         response = LOGS_CLIENT.get_log_events(
             logGroupName=batch_log_group_name,
             logStreamName=job_log_stream_id,
+            # We need to start from the beginning to get all logs
+            startFromHead=True,
         )
         logs = [event["message"] for event in response.get("events", [])]
         logger.info(f"Fetched logs for {job_log_stream_id}.")


### PR DESCRIPTION
Previously the log events could have started from the end and therefore after a day, they seem to have rolled off the end and no longer got the initial log events.