### PR TITLE
I-ALiRT - adding cors

### DIFF
--- a/sds_data_manager/constructs/data_bucket_construct.py
+++ b/sds_data_manager/constructs/data_bucket_construct.py
@@ -45,6 +45,17 @@ class DataBucketConstruct(Construct):
             removal_policy=RemovalPolicy.RETAIN,
             auto_delete_objects=False,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            cors=[
+                s3.CorsRule(
+                    allowed_methods=[
+                        s3.HttpMethods.GET,  # For downloading JSON files
+                        s3.HttpMethods.HEAD,  # For metadata requests
+                    ],
+                    allowed_origins=["*"],
+                    allowed_headers=["*"],  # Required for presigned URLs
+                    max_age=86400,  # Cache CORS preflight for 24 hours
+                )
+            ],
         )
 
         s3_write_policy = iam.PolicyStatement(

--- a/sds_data_manager/constructs/ialirt_bucket_construct.py
+++ b/sds_data_manager/constructs/ialirt_bucket_construct.py
@@ -44,4 +44,16 @@ class IAlirtBucketConstruct(Construct):
             removal_policy=RemovalPolicy.DESTROY,
             auto_delete_objects=True,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            cors=[
+                s3.CorsRule(
+                    allowed_methods=[
+                        s3.HttpMethods.GET,  # For downloading JSON files
+                        s3.HttpMethods.HEAD,  # For metadata requests
+                        s3.HttpMethods.OPTIONS,  # Required for presigned URLs
+                    ],
+                    allowed_origins=["*"],
+                    allowed_headers=["*"],  # Required for presigned URLs
+                    max_age=86400,  # Cache CORS preflight for 24 hours
+                )
+            ],
         )

--- a/sds_data_manager/constructs/ialirt_bucket_construct.py
+++ b/sds_data_manager/constructs/ialirt_bucket_construct.py
@@ -49,7 +49,6 @@ class IAlirtBucketConstruct(Construct):
                     allowed_methods=[
                         s3.HttpMethods.GET,  # For downloading JSON files
                         s3.HttpMethods.HEAD,  # For metadata requests
-                        s3.HttpMethods.OPTIONS,  # Required for presigned URLs
                     ],
                     allowed_origins=["*"],
                     allowed_headers=["*"],  # Required for presigned URLs


### PR DESCRIPTION
# Change Summary

## Overview
The webteam needs CORS permissions assigned to s3. The reason for this is that we use a presigned url. This is what happens:

1. We hit the I-ALiRT API
2. API Gateway calls download_api.py lambda
3. That lambda does not send back a file directly. Instead it sends back a presigned url for the file in s3.
4.  At this point the browser is not talking to the api gateway anymore it is talking directly to s3.

## Updated Files
- ialirt_bucket_construct.py
   - Add CORS permissions
