### PR TITLE
IDEX l2a calibration curve ancillary files

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -474,6 +474,9 @@ planetary_ephemeris, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, D
 imap_frames, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 
 idex, l1b, sci-1week, idex, l2a, sci-1week, HARD, DOWNSTREAM
+idex, ancillary, l2a-calibration-curve-yield-params, idex, l2a, sci-1week, HARD, DOWNSTREAM
+idex, ancillary, l2a-calibration-curve-t-rise, idex, l2a, sci-1week, HARD, DOWNSTREAM
+
 idex, l2a, sci-1week, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview
Add ancillary file dependencies for idex l2a

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - ancillary file dependencies

