### PR TITLE
Add Calibration File for SWAPI

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -11,6 +11,7 @@ import boto3
 import botocore
 import imap_data_access
 import numpy as np
+import pandas as pd
 import requests
 import spiceypy
 import xarray as xr
@@ -284,6 +285,10 @@ def process_algorithms(combined: xr.Dataset, algorithm_table):
             result, _ = process_func(combined)
         elif instrument == "codicehi":
             _, result = process_func(combined)
+        elif instrument == "swapi":
+            download_path = get_ancillary(instrument, "esa-unit-conversion")
+            calibration_data = pd.read_csv(download_path)
+            result = process_func(combined, calibration_data)
         else:
             result = process_func(combined)
 

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -7,6 +7,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 from boto3.dynamodb.conditions import Key
@@ -248,6 +249,7 @@ def test_insert_data(
     return_value=67890.0,
 )
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.load_cdf")
+@mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.pd.read_csv")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.get_ancillary")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.process_hit")
 @mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.process_packet")
@@ -264,6 +266,7 @@ def test_process_algorithms(
     mock_hit,
     mock_get_ancillary,
     mock_load_cdf,
+    mock_read_csv,
     mock_sclkticks,
     mock_sct_to_et,
     mock_imap_state,
@@ -272,6 +275,7 @@ def test_process_algorithms(
     """Tests process_algorithms function."""
     algorithm_table = setup_dynamodb["algorithm_table"]
     mock_load_cdf.return_value = {"mock": "calibration data"}
+    mock_read_csv.return_value = pd.DataFrame({"mock": [1.23]})
 
     mock_hit.return_value = [
         {


### PR DESCRIPTION
# Change Summary

## Overview
Add calibration file download logic for SWAPI.

NOTE: I won't merge this until after imap_processing has been updated and a new version released to contain the corresponding changes shown in this [PR](https://github.com/IMAP-Science-Operations-Center/imap_processing/pull/2090/files#diff-e871d86cfe40e9dd5fcb670682b4f44ac1c04d824f957a775bac38315ccf0f86).

## New Dependencies
<!--List any new dependencies introduced by these changes-->
- Pandas

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- ialirt_ingest.py
   - Added call to `get_ancillary()` for the SWAPI energy values lookup table

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
- test_ialirt_ingest.py
   - Update test to work with addition to swapi processing
