### PR TITLE
Create pointing schedule lambda

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -19,12 +19,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-KERNELS = {
-    "planetary_ephemeris",  # e.g., de440s.bsp
-    "planetary_constants",  # e.g. pck00011.tpc
-}
-
-
 def get_dsn(download_dir: Path):
     """Query and download DSN data.
 
@@ -96,8 +90,13 @@ def get_dsn(download_dir: Path):
     return download_path, dsn_dict
 
 
-def get_latest_spice_kernels() -> ProcessingInputCollection:
+def get_latest_spice_kernels(kernels: list[str]) -> ProcessingInputCollection:
     """Query the SPICE metakernel API for latest SPICE kernel filenames.
+
+    Parameters
+    ----------
+    kernels : list[str]
+        List of SPICE kernel categories to collect.
 
     Returns
     -------
@@ -115,7 +114,7 @@ def get_latest_spice_kernels() -> ProcessingInputCollection:
     et_end_time = (now - j2000).total_seconds()
     et_start_time = (one_week_ago - j2000).total_seconds()
 
-    file_types = ",".join(KERNELS)
+    file_types = ",".join(kernels)
     # TODO: replace this url with the endpoint from imap-data-access.
     url = "https://ylxiee1ond.execute-api.us-west-2.amazonaws.com/metakernel"
 
@@ -302,7 +301,12 @@ def lambda_handler(event, context):
     _, dsn = get_dsn(Path("/tmp"))  # noqa: S108
 
     # Download latest SPICE kernels
-    dependency_inputs = get_latest_spice_kernels()
+    dependency_inputs = get_latest_spice_kernels(
+        [
+            "planetary_ephemeris",  # e.g., de440s.bsp
+            "planetary_constants",  # e.g. pck00011.tpc
+        ]
+    )
     logger.info("dependency_inputs: %s", dependency_inputs)
     setup_spice_file(dependency_inputs)
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
@@ -17,15 +17,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-KERNELS = [
-    "planetary_ephemeris",  # e.g., de440s.bsp
-    "planetary_constants",  # e.g. pck00011.tpc
-    "leapseconds",  # e.g., naif0012.tls
-    "spacecraft_ephemeris",  # e.g., imap_spk_demo.bsp
-    "earth_attitude",  # e.g., earth_latest_high_prec.bpc
-]
-
-
 def generate_and_upload_schedule(bucket: str, region: str, station: str, day: str):
     """Generate and upload pointing schedule files to S3.
 
@@ -76,7 +67,8 @@ def lambda_handler(event, context):
             "planetary_ephemeris",  # e.g., de440s.bsp
             "planetary_constants",  # e.g. pck00011.tpc
             "leapseconds",  # e.g., naif0012.tls
-            "spacecraft_ephemeris",  # e.g., imap_spk_demo.bsp
+            "ephemeris_predicted",  # e.g., imap_spk_demo.bsp
+            "ephemeris_90days",  # e.g., imap_spk_demo.bsp
             "earth_attitude",  # e.g., earth_latest_high_prec.bpc
         ]
     )

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
@@ -1,0 +1,89 @@
+"""Lambda to generate and upload antenna pointing schedule files to s3."""
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import imap_processing.ialirt.constants
+
+from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import (
+    get_latest_spice_kernels,
+    setup_spice_file,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+KERNELS = {
+    "planetary_ephemeris",  # e.g., de440s.bsp
+    "planetary_constants",  # e.g. pck00011.tpc
+    "leapseconds",  # e.g., naif0012.tls
+    "spacecraft_ephemeris",  # e.g., imap_spk_demo.bsp
+    "earth_attitude",  # e.g., earth_latest_high_prec.bpc
+}
+
+
+def generate_and_upload_schedule(bucket: str, region: str, station: str, day: str):
+    """Generate and upload pointing schedule files to S3.
+
+    Parameters
+    ----------
+    bucket : str
+        The name of the S3 bucket.
+    region : str
+        The region in which the s3 bucket resides.
+    station : str
+        The ground station for which the pointing schedule file should be generated.
+    day : str
+        The day for which to generate a pointing schedule, in ISO format.
+        Ex: "20250811".
+    """
+    file_name = f"{day}_{station}.txt"
+    s3_path = f"pointing_schedules/{station}/{day}/{file_name}"
+    local_file_path = ".."
+
+    # generate_text_files(station, day, local_file_path)
+
+    # Placeholder for generate_text_files
+    with open(f"{local_file_path}/{file_name}", "w") as file:
+        file.writelines([f"Station: {station}\n", "Target: IMAP\n"])
+
+    try:
+        s3_client = boto3.client("s3", region_name=region)
+
+        with open(f"{local_file_path}/{file_name}", "rb") as f:
+            # Upload the file content to S3
+            s3_client.put_object(Bucket=bucket, Key=s3_path, Body=f)
+        print(
+            f"Pointing schedule '{day}_{station}.txt' uploaded to "
+            f"s3://{bucket}/{s3_path}"
+        )
+    except Exception as e:
+        print(f"Error uploading file: {e}")
+
+    # Remove the file after it's been uploaded to s3
+    os.remove(f"{local_file_path}/{day}_{station}.txt")
+
+
+def lambda_handler(event, context):
+    """Create pointing schedule files."""
+    logger.info("Received event: %s", json.dumps(event))
+
+    bucket = event["detail"]["bucket"]["name"]
+    region = event["region"]
+
+    # Download latest SPICE kernels
+    dependency_inputs = get_latest_spice_kernels()
+    logger.info("dependency_inputs: %s", dependency_inputs)
+    setup_spice_file(dependency_inputs)
+
+    # Generate schedule for the day that is 30 days from now
+    day = (datetime.now(timezone.utc) + timedelta(days=30)).strftime("%Y%m%d")
+
+    # Stations to generate schedules for
+    stations = imap_processing.ialirt.constants.STATIONS
+    for station, _ in stations.items():
+        generate_and_upload_schedule(bucket, region, station, day)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
@@ -71,7 +71,15 @@ def lambda_handler(event, context):
     region = event["region"]
 
     # Download latest SPICE kernels
-    dependency_inputs = get_latest_spice_kernels()
+    dependency_inputs = get_latest_spice_kernels(
+        [
+            "planetary_ephemeris",  # e.g., de440s.bsp
+            "planetary_constants",  # e.g. pck00011.tpc
+            "leapseconds",  # e.g., naif0012.tls
+            "spacecraft_ephemeris",  # e.g., imap_spk_demo.bsp
+            "earth_attitude",  # e.g., earth_latest_high_prec.bpc
+        ]
+    )
     logger.info("dependency_inputs: %s", dependency_inputs)
     setup_spice_file(dependency_inputs)
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
@@ -2,11 +2,11 @@
 
 import json
 import logging
-import os
 from datetime import datetime, timedelta, timezone
 
 import boto3
 import imap_processing.ialirt.constants
+from imap_processing.ialirt.process_ephemeris import generate_text_files
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import (
     get_latest_spice_kernels,
@@ -17,13 +17,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-KERNELS = {
+KERNELS = [
     "planetary_ephemeris",  # e.g., de440s.bsp
     "planetary_constants",  # e.g. pck00011.tpc
     "leapseconds",  # e.g., naif0012.tls
     "spacecraft_ephemeris",  # e.g., imap_spk_demo.bsp
     "earth_attitude",  # e.g., earth_latest_high_prec.bpc
-}
+]
 
 
 def generate_and_upload_schedule(bucket: str, region: str, station: str, day: str):
@@ -39,33 +39,28 @@ def generate_and_upload_schedule(bucket: str, region: str, station: str, day: st
         The ground station for which the pointing schedule file should be generated.
     day : str
         The day for which to generate a pointing schedule, in ISO format.
-        Ex: "20250811".
+        Ex: "2025-08-11".
     """
     file_name = f"{day}_{station}.txt"
     s3_path = f"pointing_schedules/{station}/{day}/{file_name}"
-    local_file_path = ".."
 
-    # generate_text_files(station, day, local_file_path)
-
-    # Placeholder for generate_text_files
-    with open(f"{local_file_path}/{file_name}", "w") as file:
-        file.writelines([f"Station: {station}\n", "Target: IMAP\n"])
+    output = generate_text_files(station, day)
 
     try:
         s3_client = boto3.client("s3", region_name=region)
 
-        with open(f"{local_file_path}/{file_name}", "rb") as f:
-            # Upload the file content to S3
-            s3_client.put_object(Bucket=bucket, Key=s3_path, Body=f)
-        print(
+        # Upload the file content to S3
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=s3_path,
+            Body="".join(output),
+        )
+        logger.info(
             f"Pointing schedule '{day}_{station}.txt' uploaded to "
             f"s3://{bucket}/{s3_path}"
         )
     except Exception as e:
-        print(f"Error uploading file: {e}")
-
-    # Remove the file after it's been uploaded to s3
-    os.remove(f"{local_file_path}/{day}_{station}.txt")
+        logger.error(f"Error uploading file: {e}")
 
 
 def lambda_handler(event, context):
@@ -81,7 +76,7 @@ def lambda_handler(event, context):
     setup_spice_file(dependency_inputs)
 
     # Generate schedule for the day that is 30 days from now
-    day = (datetime.now(timezone.utc) + timedelta(days=30)).strftime("%Y%m%d")
+    day = (datetime.now(timezone.utc) + timedelta(days=30)).strftime("%Y-%m-%d")
 
     # Stations to generate schedules for
     stations = imap_processing.ialirt.constants.STATIONS

--- a/tests/lambda_endpoints/test_ialirt_coverage.py
+++ b/tests/lambda_endpoints/test_ialirt_coverage.py
@@ -153,7 +153,7 @@ def test_get_latest_spice_kernels(mock_get):
     mock_response.json.return_value = mock_files
     mock_get.return_value = mock_response
 
-    result = get_latest_spice_kernels()
+    result = get_latest_spice_kernels(["planetary_ephemeris", "planetary_constants"])
     assert result.processing_input[0].filename_list == mock_files
 
 

--- a/tests/lambda_endpoints/test_ialirt_pointing_schedule.py
+++ b/tests/lambda_endpoints/test_ialirt_pointing_schedule.py
@@ -1,0 +1,104 @@
+"""Test the I-Alirt pointing schedule lambda function."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from imap_processing.ialirt.constants import StationProperties
+
+from sds_data_manager.lambda_code.IAlirtCode.ialirt_pointing_schedule import (
+    generate_and_upload_schedule,
+    lambda_handler,
+)
+
+
+@patch("spiceypy.furnsh")
+@patch("imap_data_access.processing_input.ProcessingInputCollection.download_all_files")
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.requests.get")
+@patch("imap_processing.ialirt.constants.STATIONS")
+def test_lambda_handler(
+    mock_stations,
+    mock_requests_get,
+    mock_download,
+    mock_furnsh,
+    s3_client,
+):
+    """Test the lambda_handler function."""
+    bucket = "test-data-bucket"
+    region = "us-west-2"
+
+    s3_client.create_bucket(Bucket=bucket)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        "de440.bsp",
+        "naif0012.tls",
+        "pck00011.tpc",
+        "imap_pred_20250826_20251001_v00.bsp",
+        "earth_000101_250826_251001.bpc",
+    ]
+    mock_requests_get.return_value = mock_response
+
+    mock_download.return_value = None
+    mock_furnsh.return_value = None
+
+    # Mock the Stations dictionary to have more than one item
+    mock_stations.items.return_value = [
+        (
+            "Kiel",
+            StationProperties(
+                longitude=10.1808,
+                latitude=54.2632,
+                altitude=0.1,
+                min_elevation_deg=5,
+            ),
+        ),
+        (
+            "Korea",
+            StationProperties(
+                longitude=1,
+                latitude=1,
+                altitude=1,
+                min_elevation_deg=5,
+            ),
+        ),
+    ]
+
+    event = {
+        "region": region,
+        "detail": {
+            "bucket": {"name": bucket},
+        },
+    }
+
+    lambda_handler(event, {})
+
+    objects = s3_client.list_objects_v2(Bucket=bucket)
+    keys = [obj["Key"] for obj in objects.get("Contents", [])]
+
+    # Check the naming pattern
+    assert keys[0].startswith("pointing_schedules/Kiel/")
+    assert keys[1].startswith("pointing_schedules/Korea/")
+
+
+def test_generate_and_upload_schedule(s3_client):
+    """Test the generate_and_upload_30_days function."""
+    bucket = "test-data-bucket"
+    region = "us-west-2"
+    s3_client.create_bucket(Bucket=bucket)
+
+    day = (datetime.now(timezone.utc) + timedelta(days=10)).strftime("%Y%m%d")
+
+    generate_and_upload_schedule(bucket, region, "Kiel", day)
+
+    objects = s3_client.list_objects_v2(Bucket=bucket)
+    keys = [obj["Key"] for obj in objects.get("Contents", [])]
+
+    # Check the naming pattern
+    assert keys[0].startswith("pointing_schedules/Kiel/")
+
+    # Download and verify one file's content
+    response = s3_client.get_object(Bucket=bucket, Key=keys[0])
+    content = response["Body"].read().decode("utf-8")
+
+    assert "Station: Kiel" in content
+    assert "Target: IMAP" in content

--- a/tests/lambda_endpoints/test_ialirt_pointing_schedule.py
+++ b/tests/lambda_endpoints/test_ialirt_pointing_schedule.py
@@ -15,7 +15,12 @@ from sds_data_manager.lambda_code.IAlirtCode.ialirt_pointing_schedule import (
 @patch("imap_data_access.processing_input.ProcessingInputCollection.download_all_files")
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.requests.get")
 @patch("imap_processing.ialirt.constants.STATIONS")
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_pointing_schedule."
+    "generate_text_files"
+)
 def test_lambda_handler(
+    mock_generate_text_files,
     mock_stations,
     mock_requests_get,
     mock_download,
@@ -70,6 +75,22 @@ def test_lambda_handler(
         },
     }
 
+    first_generate_text_files_response = [
+        "Station: Kiel\n",
+        "Target: IMAP\n",
+        "Creation date (UTC): \n",
+    ]
+
+    second_generate_text_files_response = [
+        "Station: Korea\n",
+        "Target: IMAP\n",
+        "Creation date (UTC): \n",
+    ]
+
+    mock_generate_text_files.side_effect = [
+        first_generate_text_files_response,
+        second_generate_text_files_response,
+    ]
     lambda_handler(event, {})
 
     objects = s3_client.list_objects_v2(Bucket=bucket)
@@ -80,13 +101,32 @@ def test_lambda_handler(
     assert keys[1].startswith("pointing_schedules/Korea/")
 
 
-def test_generate_and_upload_schedule(s3_client):
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_pointing_schedule."
+    "generate_text_files"
+)
+def test_generate_and_upload_schedule(mock_generate_text_files, s3_client):
     """Test the generate_and_upload_30_days function."""
     bucket = "test-data-bucket"
     region = "us-west-2"
     s3_client.create_bucket(Bucket=bucket)
 
-    day = (datetime.now(timezone.utc) + timedelta(days=10)).strftime("%Y%m%d")
+    mock_generate_text_files.return_value = [
+        "Station: Kiel\n",
+        "Target: IMAP\n",
+        "Creation date (UTC): \n",
+        "Start time: \n",
+        "End time: \n",
+        "Cadence (sec): 60\n\n",
+        "Date/Time"
+        + "Azimuth".rjust(29)
+        + "Elevation".rjust(17)
+        + "Doppler".rjust(15)
+        + "\n",
+        "(UTC)" + "(deg.)".rjust(33) + "(deg.)".rjust(16) + "(km/s)".rjust(16) + "\n",
+    ]
+
+    day = (datetime.now(timezone.utc) + timedelta(days=10)).strftime("%Y-%m-%d")
 
     generate_and_upload_schedule(bucket, region, "Kiel", day)
 
@@ -102,3 +142,4 @@ def test_generate_and_upload_schedule(s3_client):
 
     assert "Station: Kiel" in content
     assert "Target: IMAP" in content
+    assert "(km/s)" in content


### PR DESCRIPTION
# Change Summary

## Overview
Create a lambda function that generates and uploads the ground station pointing schedule text files.

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- ialirt_pointing_schedule.py
   - Wraps the `generate_text_files()` function from imap_processing to upload pointing schedules to s3
- test_ialirt_pointing_schedule.py
   - Tests the pointing_schedule lambda

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
New tests found in test_ialirt_pointing_schedule.py for both the lambda handler and the generate_and_upload_schedule function.

## Note
This PR goes hand-in-hand with the [imap_processing PR that adds the generate_text_files() function](https://github.com/IMAP-Science-Operations-Center/imap_processing/pull/2045). I will wait until that PR is merged to test & merge this one.