### PR TITLE
FIX: Update the packet_downloader_lambda trigger for new location

### DIFF
--- a/sds_data_manager/constructs/packet_downloader_lambda_construct.py
+++ b/sds_data_manager/constructs/packet_downloader_lambda_construct.py
@@ -83,6 +83,5 @@ class PacketDownloaderLambda(Construct):
             s3n.LambdaDestination(packet_lambda),  # Lambda notification
             s3.NotificationKeyFilter(
                 prefix=f"{SPICEFilePath._dir_prefix}/repoint/imap_",
-                suffix=".repoint.csv",
             ),
         )

--- a/sds_data_manager/constructs/packet_downloader_lambda_construct.py
+++ b/sds_data_manager/constructs/packet_downloader_lambda_construct.py
@@ -7,6 +7,7 @@ from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_s3_notifications as s3n
 from aws_cdk import aws_secretsmanager as secretsmanager
 from constructs import Construct
+from imap_data_access import SPICEFilePath
 
 
 class PacketDownloaderLambda(Construct):
@@ -81,6 +82,7 @@ class PacketDownloaderLambda(Construct):
             s3.EventType.OBJECT_CREATED,
             s3n.LambdaDestination(packet_lambda),  # Lambda notification
             s3.NotificationKeyFilter(
-                prefix="spice/repoint/imap_", suffix=".repoint.csv"
+                prefix=f"{SPICEFilePath._dir_prefix}/repoint/imap_",
+                suffix=".repoint.csv",
             ),
         )

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import boto3
 import imap_data_access
-from imap_data_access import webpoda
+from imap_data_access import SPICEFilePath, webpoda
 
 S3_CLIENT = boto3.client("s3")
 # We need to access the webpoda-api-key
@@ -39,7 +39,9 @@ def get_two_most_recent_contact_times(bucket):
     """
     paginator = S3_CLIENT.get_paginator("list_objects_v2")
     # In case we have more than 1000 of these files (~3 years)
-    pages = paginator.paginate(Bucket=bucket, Prefix="spice/repoint/imap_")
+    pages = paginator.paginate(
+        Bucket=bucket, Prefix=f"{SPICEFilePath._dir_prefix}/repoint/imap_"
+    )
 
     repointing_file_times = []
     for page in pages:
@@ -118,7 +120,6 @@ def lambda_handler(event, context):
                 start_time=start_time,
                 end_time=end_time,
                 repointing_file=repointing_file,
-                version="v001",
                 upload_to_server=True,
             )
         else:
@@ -127,7 +128,6 @@ def lambda_handler(event, context):
                 instrument=instrument,
                 start_time=start_time,
                 end_time=end_time,
-                version="v001",
                 upload_to_server=True,
             )
 


### PR DESCRIPTION
We updated the spice location to be in /imap/spice instead of the root /spice, so we need to update that here. Import imap-data-access to get the location from there, since that is what is used to populate the filepaths.