### PR TITLE
MNT: Update webpoda downloader to handle single files

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
@@ -53,9 +53,17 @@ def get_two_most_recent_contact_times(bucket):
             # We want last-modified time to know when these files were uploaded
             repointing_file_times.append(obj["LastModified"])
 
-    if len(repointing_file_times) < 2:
-        logger.warning("Less than 2 repointing files found")
+    if len(repointing_file_times) == 0:
+        # Nothing in the bucket yet, query from the start of the mission to right now.
+        logger.warning("No repointing files found")
         return None
+    elif len(repointing_file_times) == 1:
+        # Only one repointing file, so we can't bracket a contact yet.
+        # Use the first launch opportunity as an initial start time,
+        # and the time this repointing file landed as the end time to
+        # brack the queries with.
+        logger.warning("Only one repointing file found, using the start of the mission")
+        return ["2025-09-23T00:00:00.000Z", repointing_file_times[0]]
 
     # We only want the latest two times
     return sorted(repointing_file_times)[-2:]


### PR DESCRIPTION
# Change Summary

We want to download data even on the first event arriving. Set the first launch opportunity as the time to bracket the packet downloads against.

We still do require a repointing file though in this function. So I'm not sure what we'll do if we don't get one of those for multiple days... That is something worth reaching out to the MOC about.