### PR TITLE
Rollback commit when sqlalchemy Integrity error is raised

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -438,6 +438,8 @@ def try_to_submit_job(
         session.add(processing_job)
         session.commit()
     except IntegrityError:
+        # Rollback the session to clear the failed transaction
+        session.rollback()
         logger.info(f"Job already completed or in progress: {processing_job}")
         return
 


### PR DESCRIPTION
# Change Summary

## Overview
Handle Integrity error properly. When we try to submit a duplicate job, because we have a unique partial index, an integrity error should be raised when we try to commit the insert command. The documentation states that when this happens you should rollback that commit: 

https://docs.sqlalchemy.org/en/13/faq/sessions.html#this-session-s-transaction-has-been-rolled-back-due-to-a-previous-exception-during-flush-or-similar

I am not sure how to test this because you need postgres running to use unique partial indices and therefore to get the integrity error. 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Rollback failed commit
