### PR TITLE
FIX: Pad the repointing number with 5 digits

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -418,7 +418,7 @@ def try_to_submit_job(
     ]
 
     if repoint is not None:
-        batch_command.extend(["--repointing", f"repoint{repoint}"])
+        batch_command.extend(["--repointing", f"repoint{repoint:05d}"])
 
     # All of our upstream requirements have been met.
     # Try to insert a record into the Processing Jobs table


### PR DESCRIPTION
The CLI expected `repointXXXXX`, but the value from the database is an integer without 0 padding, so we need to zero pad to get the exact length to be 5 characters.