### PR TITLE
MNT: Add IMAP_DATA_ACCESS_URL to job definitions

### DIFF
--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -23,6 +23,7 @@ class IalirtIngestLambda(Construct):
         vpc: ec2.Vpc,
         efs_access_point: efs.AccessPoint,
         docker_path: str = "sds_data_manager/lambda_code",
+        data_access_url: str = "",
         **kwargs,
     ) -> None:
         """IalirtIngestLambda Stack.
@@ -41,6 +42,10 @@ class IalirtIngestLambda(Construct):
             EFS access point to mount inside the Lambda function.
         docker_path : str
             Path to the Dockerfile.
+        data_access_url : str, optional
+            The data access URL to use for this job, by default the empty string.
+            You should set this to the appropriate API endpoint, e.g.
+            https://api.dev.imap-mission.com
         kwargs : dict
             Keyword arguments.
 
@@ -53,14 +58,6 @@ class IalirtIngestLambda(Construct):
 
         # Create DynamoDB Table
         self.algorithm_data_table = self.create_algorithm_dynamodb_table()
-
-        account_name = self.node.get_context("account_name")
-        # once we have the account_name, get that section out of cdk.json
-        account_config = self.node.get_context(account_name)
-        domain_name = account_config.get("domain_name", "no-domain-set")
-        # https://api.imap-mission.com
-        # https://api.dev.imap-mission.com
-        data_access_url = f"https://api.{domain_name}"
 
         # Create Lambda Function
         self.ialirt_ingest_lambda = self.create_lambda_function(

--- a/sds_data_manager/constructs/indexer_lambda_construct.py
+++ b/sds_data_manager/constructs/indexer_lambda_construct.py
@@ -158,6 +158,7 @@ class SPICEIndexerLambda(Construct):
         layers: list,
         rds_security_group,
         data_bucket: s3.Bucket,
+        data_access_url: str = "",
         **kwargs,
     ) -> None:
         """Construct the EFS lambdas.
@@ -182,6 +183,10 @@ class SPICEIndexerLambda(Construct):
             The RDS security group
         data_bucket : obj
             The data bucket
+        data_access_url : str, optional
+            The data access URL to use for this job, by default the empty string.
+            You should set this to the appropriate API endpoint, e.g.
+            https://api.dev.imap-mission.com
         kwargs : dict
             Keyword arguments
 
@@ -231,6 +236,7 @@ class SPICEIndexerLambda(Construct):
             security_groups=[rds_security_group],
             environment={
                 "IMAP_DATA_DIR": "/tmp",  # noqa: S108
+                "IMAP_DATA_ACCESS_URL": data_access_url,
                 "SECRET_NAME": db_secret_name,
                 "S3_BUCKET": data_bucket.bucket_name,
             },

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -11,6 +11,7 @@ from aws_cdk import aws_batch as batch
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecr as ecr
 from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
 
@@ -44,6 +45,25 @@ class ProcessingConstruct(Construct):
         """
         super().__init__(scope, construct_id, **kwargs)
 
+        # Set up secure reference to batch API key parameter name
+        # The actual key value is not resolved at synthesis time for security
+        # NOTE: To use this, create the key using the helper script:
+        #
+        #   python sds_data_manager/lambda_code/authorization/manage_api_keys.py \
+        #     add "batch-jobs" "imap-sdc@lists.lasp.colorado.edu"
+        #
+        # Then add that API Key to SSM as a separate parameter the ECS task can look up
+        #
+        #  aws ssm put-parameter --name /imap-sdc/batch-jobs/api-key --value <the-key> \
+        #    --type SecureString
+        #
+        self.batch_api_key_param = ssm.StringParameter.from_string_parameter_name(
+            self,
+            "BatchApiKeyParam",
+            # Location in parameter store where the batch API key is stored
+            "/imap-sdc/batch-jobs/api-key",
+        )
+
         # Create compute environment
         compute_environment = batch.FargateComputeEnvironment(
             self,
@@ -66,13 +86,17 @@ class ProcessingConstruct(Construct):
             ],
         )
 
-    def add_job(self, job_name: str):
+    def add_job(self, job_name: str, data_access_url: str = ""):
         """Create an ECR repo and a job definition for the given job.
 
         Parameters
         ----------
         job_name : str
             Name of the job for which to create the job definition.
+        data_access_url : str, optional
+            The data access URL to use for this job, by default the empty string.
+            You should set this to the appropriate API endpoint, e.g.
+            https://api.dev.imap-mission.com/api-key
         """
         # Create a registry for each job definition (swe-repo)
         container_repo = ecr.Repository(
@@ -83,33 +107,36 @@ class ProcessingConstruct(Construct):
             removal_policy=cdk.RemovalPolicy.DESTROY,
         )
         # Create the job definition
-        account_name = self.node.get_context("account_name")
-        # once we have the account_name, get that section out of cdk.json
-        account_config = self.node.get_context(account_name)
-        domain_name = account_config.get("domain_name", "no-domain-set")
-        # https://api.imap-mission.com
-        # https://api.dev.imap-mission.com
-        data_access_url = f"https://api.{domain_name}"
+        container_definition = batch.EcsFargateContainerDefinition(
+            self,
+            f"FargateContainer-{job_name}",
+            assign_public_ip=True,  # Required to pull ECR images
+            image=ecs.ContainerImage.from_ecr_repository(
+                repository=container_repo, tag="latest"
+            ),
+            memory=cdk.Size.mebibytes(4096),
+            cpu=1,
+            environment={
+                # Useful for switching APIs between dev / prod endpoints
+                "IMAP_DATA_ACCESS_URL": data_access_url,
+            },
+            # Use Batch secrets to securely inject the API key from SSM
+            # This ensures the key is not visible in CloudFormation templates
+            secrets={
+                "IMAP_API_KEY": batch.Secret.from_ssm_parameter(
+                    self.batch_api_key_param
+                )
+            },
+            # TODO: Do we need to explicitly specify architecture and OS family?
+            #       We are building containers in GitHub Actions and need to
+            #       make sure these are aligned.
+            # fargate_cpu_architecture=ecs.CpuArchitecture.ARM64,
+            # fargate_operating_system_family=ecs.OperatingSystemFamily.LINUX
+        )
+
         batch.EcsJobDefinition(
             self,
             f"ProcessingJob-{job_name}",
             job_definition_name=f"ProcessingJob-{job_name}",
-            container=batch.EcsFargateContainerDefinition(
-                self,
-                f"FargateContainer-{job_name}",
-                assign_public_ip=True,  # Required to pull ECR images
-                image=ecs.ContainerImage.from_ecr_repository(
-                    repository=container_repo, tag="latest"
-                ),
-                memory=cdk.Size.mebibytes(4096),
-                cpu=1,
-                environment={
-                    "IMAP_DATA_ACCESS_URL": data_access_url,
-                },
-                # TODO: Do we need to explicitly specify architecture and OS family?
-                #       We are building containers in GitHub Actions and need to
-                #       make sure these are aligned.
-                # fargate_cpu_architecture=ecs.CpuArchitecture.ARM64,
-                # fargate_operating_system_family=ecs.OperatingSystemFamily.LINUX
-            ),
+            container=container_definition,
         )

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -57,11 +57,13 @@ class ProcessingConstruct(Construct):
         #  aws ssm put-parameter --name /imap-sdc/batch-jobs/api-key --value <the-key> \
         #    --type SecureString
         #
-        self.batch_api_key_param = ssm.StringParameter.from_string_parameter_name(
-            self,
-            "BatchApiKeyParam",
-            # Location in parameter store where the batch API key is stored
-            "/imap-sdc/batch-jobs/api-key",
+        self.batch_secret_api_key = batch.Secret.from_ssm_parameter(
+            ssm.StringParameter.from_secure_string_parameter_attributes(
+                self,
+                "BatchApiKeyParam",
+                # Location in parameter store where the batch API key is stored
+                parameter_name="/imap-sdc/batch-jobs/api-key",
+            )
         )
 
         # Create compute environment
@@ -122,11 +124,7 @@ class ProcessingConstruct(Construct):
             },
             # Use Batch secrets to securely inject the API key from SSM
             # This ensures the key is not visible in CloudFormation templates
-            secrets={
-                "IMAP_API_KEY": batch.Secret.from_ssm_parameter(
-                    self.batch_api_key_param
-                )
-            },
+            secrets={"IMAP_API_KEY": self.batch_secret_api_key},
             # TODO: Do we need to explicitly specify architecture and OS family?
             #       We are building containers in GitHub Actions and need to
             #       make sure these are aligned.

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -230,6 +230,17 @@ def build_sds(
         layers=[db_lambda_layer],
     )
 
+    account_name = sdc_stack.node.get_context("account_name")
+    # once we have the account_name, get that section out of cdk.json
+    account_config = sdc_stack.node.get_context(account_name)
+    domain_name = account_config.get("domain_name", "no-domain-set")
+    # https://api.imap-mission.com
+    # https://api.dev.imap-mission.com
+    # Append the /api-key so that these jobs are able to be authenticated
+    # to access the data and upload results as necessary.
+    general_data_access_url = f"https://api.{domain_name}"
+    api_key_data_access_url = f"{general_data_access_url}/api-key"
+
     # This valid instrument list is from imap-data-access package
     processing = processing_construct.ProcessingConstruct(
         sdc_stack, "ProcessingConstruct", vpc=networking.vpc
@@ -237,7 +248,9 @@ def build_sds(
     for instrument in imap_data_access.VALID_INSTRUMENTS:
         for step in ["", "-l3"]:
             # "swe" or "swe-l3"
-            processing.add_job(f"{instrument.lower()}{step}")
+            processing.add_job(
+                f"{instrument.lower()}{step}", data_access_url=api_key_data_access_url
+            )
 
     # Create SQS pipeline for each instrument and add it to instrument_sqs
     file_arrive_sqs_construct = sqs_construct.SqsConstruct(
@@ -286,6 +299,8 @@ def build_sds(
         layers=[db_lambda_layer, spice_lambda_layer],
         rds_security_group=rds_construct.rds_security_group,
         data_bucket=data_bucket.data_bucket,
+        # SPICE files are all public, so no need to use the api-key URL
+        data_access_url=general_data_access_url,
     )
 
     # I-ALiRT Stack
@@ -326,6 +341,7 @@ def build_sds(
         ialirt_bucket=ialirt_bucket.ialirt_bucket,
         vpc=networking.vpc,
         efs_access_point=ialirt_efs_instance.spice_access_point,
+        data_access_url=general_data_access_url,
     )
 
     # I-ALiRT IOIS archive lambda (facilitates dynamodb to s3)


### PR DESCRIPTION
# Change Summary
closes #736 

## Overview

We need to set the `IMAP_DATA_ACCESS_URL` environment variable whenever jobs/tasks are going to be pointing at our HTTP APIs. There are two things going on here:
* dev jobs need to point at our dev urls and production at our production urls
* Anything that needs to access unreleased data or upload (batch jobs) needs to use the api-key routes. For that, we inject the SSM parameter into the container at runtime.

I tried to search for all of the places where this is used. It would be good for someone else to try and sanity check me or mention any other places they see this being used.