### PR TITLE
Update SWAPI energy-gf lookup table to have SW and PUI versions

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -638,7 +638,7 @@ swapi, l2, sci, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, clock-angle-and-flow-deflection-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, proton-density-temperature-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, alpha-density-temperature-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
-swapi, ancillary, energy-gf-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
+swapi, ancillary, energy-gf-pui-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, instrument-response-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
@@ -650,7 +650,7 @@ science_frames, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTRE
 
 swapi, l2, sci, swapi, l3b, combined, HARD, DOWNSTREAM
 swapi, ancillary, efficiency-lut, swapi, l3b, combined, HARD, DOWNSTREAM
-swapi, ancillary, energy-gf-lut, swapi, l3b, combined, HARD, DOWNSTREAM
+swapi, ancillary, energy-gf-sw-lut, swapi, l3b, combined, HARD, DOWNSTREAM
 
 # <---- SWE Dependencies ---->
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -645,6 +645,7 @@ swapi, ancillary, instrument-response-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, efficiency-lut, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
+planetary_ephemeris, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -612,20 +612,22 @@ swapi, ancillary, esa-unit-conversion, swapi, l2, sci, HARD, DOWNSTREAM
 swapi, ancillary, lut-notes, swapi, l2, sci, HARD, DOWNSTREAM
 
 swapi, l2, sci, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
-swapi, ancillary, clock-angle-and-flow-deflection-lut, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
-swapi, ancillary, proton-density-temperature-lut, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
+swapi, ancillary, clock-angle-and-flow-deflection-lut, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, proton-density-temperature-lut, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, alpha-density-temperature-lut, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
-swapi, ancillary, energy-gf-lut, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
-swapi, ancillary, instrument-response-lut, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
-swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
+swapi, ancillary, energy-gf-pui-lut, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, instrument-response-lut, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, efficiency-lut, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
 
 swapi, l2, sci, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 swapi, ancillary, clock-angle-and-flow-deflection-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 swapi, ancillary, proton-density-temperature-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
-swapi, ancillary, alpha-density-temperature-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
-swapi, ancillary, energy-gf-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
-swapi, ancillary, instrument-response-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
-swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
+swapi, ancillary, alpha-density-temperature-lut, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, energy-gf-pui-lut, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, instrument-response-lut, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, efficiency-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
@@ -636,17 +638,19 @@ pointing_attitude, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DO
 
 swapi, l2, sci, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, clock-angle-and-flow-deflection-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
-swapi, ancillary, proton-density-temperature-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
-swapi, ancillary, alpha-density-temperature-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
+swapi, ancillary, proton-density-temperature-lut, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, alpha-density-temperature-lut, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, energy-gf-pui-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, instrument-response-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
+swapi, ancillary, efficiency-lut, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 
 swapi, l2, sci, swapi, l3b, combined, HARD, DOWNSTREAM
 swapi, ancillary, efficiency-lut, swapi, l3b, combined, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview
Splitting out Geometric Factor lookup table into two tables based on instrument team requests

## Updated Files
- dependency_config.csv
   - updated SWAPI L3a and L3b ancillary deps
