### PR TITLE
Revised Schedule Job Triggering: Now submitting each job with a unique start_date

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_job.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_job.py
@@ -13,7 +13,6 @@ from . import (
     batch_starter,
     dependency,
 )
-from .batch_starter import dependency_hash
 from .scheduled_job_config_reader import read_scheduled_job_config
 
 logger = logging.getLogger(__name__)
@@ -97,7 +96,9 @@ def try_to_submit_job(
     # release
     # The descriptor should include a hash of the serialized dependencies.
     # This makes it unique for this file and set of dependencies.
-    dep_descriptor = f"{descriptor}-{dependency_hash(serialized_dependencies)}"
+    dep_descriptor = (
+        f"{descriptor}-{batch_starter.dependency_hash(serialized_dependencies)}"
+    )
     dependency_file = DependencyFilePath.generate_from_inputs(
         instrument=instrument,
         data_level=data_level,

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_job.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_job.py
@@ -2,13 +2,10 @@
 
 import datetime as dt
 import logging
-from typing import Optional
 
-from imap_data_access import DependencyFilePath, ProcessingInputCollection, RepointInput
-from sqlalchemy.exc import IntegrityError
+from imap_data_access import ProcessingInputCollection, RepointInput
 
 from ..database import database as db
-from ..database import models
 from . import (
     batch_starter,
     dependency,
@@ -47,139 +44,16 @@ def scheduled_processing_event(session, events):
 
     processing_input_collection = ProcessingInputCollection(*processing_inputs)
 
+    version = events.get("version") or 1
+
     for job in triggered_jobs:
-        try_to_submit_job(
+        batch_starter.try_to_submit_job(
             session,
             job,
-            dt.datetime.now(),
-            "v001",
+            dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d"),
+            f"v{version:03}",
             processing_input_collection.serialize(),
         )
-
-
-def try_to_submit_job(
-    session: db.Session,
-    job_info: dict,
-    start_date: dt.datetime,
-    version: str,
-    serialized_dependencies: str,
-    repoint: Optional[int] = None,
-):
-    """Try to submit a batch job with the given job information.
-
-    Parameters
-    ----------
-    session : orm session
-        Database session.
-    job_info : dict
-        Dictionary containing components with dates and versions appended.
-    start_date : datetime
-        Start date of the data.
-    version : str
-        Version of the job.
-    serialized_dependencies : str
-        The serialized ProcessingInputCollection of the upstream
-        dependencies.
-    repoint : int, optional
-        The repointing number for the job, if applicable. Default is None. Should
-        be just an integer, no "repoint" prefix.
-    """
-    instrument = job_info["data_source"]
-    data_level = job_info["data_type"]
-    descriptor = job_info["descriptor"]
-
-    formatted_start_date = start_date.strftime("%Y%m%d")
-
-    # Serialize the upstream dependencies and write them to a JSON file. The Imap
-    # processing code will read the JSON file and deserialize the dependencies. This is
-    # to avoid passing a large string through the batch job command line.
-    # release
-    # The descriptor should include a hash of the serialized dependencies.
-    # This makes it unique for this file and set of dependencies.
-    dep_descriptor = (
-        f"{descriptor}-{batch_starter.dependency_hash(serialized_dependencies)}"
-    )
-    dependency_file = DependencyFilePath.generate_from_inputs(
-        instrument=instrument,
-        data_level=data_level,
-        descriptor=dep_descriptor,
-        start_time=formatted_start_date,
-        version=version,
-        extension="json",
-        repointing=repoint,  # since we can have different repointings on the same day
-    )
-    dependency_file_path = dependency_file.construct_path()
-    response = batch_starter.upload_dependency_file(
-        dependency_file_path, serialized_dependencies
-    )
-    # If response is None, then the upload failed and we should skip submitting the job.
-    if not response:
-        return
-
-    batch_command = [
-        "--instrument",
-        instrument,
-        "--data-level",
-        data_level,
-        "--descriptor",
-        descriptor,
-        "--start-date",
-        formatted_start_date,
-        "--version",
-        version,
-        "--dependency",
-        dependency_file_path.name,
-        "--upload-to-sdc",
-    ]
-
-    if repoint is not None:
-        batch_command.extend(["--repointing", f"repoint{repoint:05d}"])
-
-    # All of our upstream requirements have been met.
-    # Try to insert a record into the Processing Jobs table
-    # If this job already exists, then we will get an integrity error
-    # and know that some other process has already taken care of it
-    processing_job = models.ProcessingJob(
-        status=models.Status.INPROGRESS,
-        instrument=instrument,
-        data_level=data_level,
-        descriptor=descriptor,
-        start_date=start_date,
-        version=version,
-        repointing=repoint,
-        container_command=" ".join(batch_command),
-    )
-    try:
-        session.add(processing_job)
-        session.commit()
-    except IntegrityError:
-        # Rollback the session to clear the failed transaction
-        session.rollback()
-        logger.info(f"Job already completed or in progress: {processing_job}")
-        return
-
-    logger.info(
-        f"Wrote job INPROGRESS to Processing Jobs Table with id: {processing_job.id}"
-    )
-    # NOTE: The batch job name should contain only alphanumeric characters and hyphens
-    # E.g. "codice-l1a-sci-job-1"
-    # The `processing_job.id` is used later for updating the job processing table
-    job_name = f"{instrument}-{data_level}-{descriptor}-job-{processing_job.id}"
-    # Get the necessary AWS information
-    # NOTE: These are here for easier mocking in tests rather than at the module level
-    step = "-l3" if data_level >= "l3" else ""
-    job_definition = f"ProcessingJob-{instrument}{step}"
-    job_queue = "ProcessingJobQueue"
-    batch_starter.BATCH_CLIENT.submit_job(
-        jobName=job_name,
-        jobQueue=job_queue,
-        jobDefinition=job_definition,
-        containerOverrides={
-            "command": batch_command,
-        },
-        retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
-    )
-    logger.info(f"Submitted job {job_name} with this command: {batch_command}")
 
 
 def lambda_handler(events, context):

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_job.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_job.py
@@ -2,14 +2,18 @@
 
 import datetime as dt
 import logging
+from typing import Optional
 
-from imap_data_access import ProcessingInputCollection, RepointInput
+from imap_data_access import DependencyFilePath, ProcessingInputCollection, RepointInput
+from sqlalchemy.exc import IntegrityError
 
 from ..database import database as db
+from ..database import models
 from . import (
     batch_starter,
     dependency,
 )
+from .batch_starter import dependency_hash
 from .scheduled_job_config_reader import read_scheduled_job_config
 
 logger = logging.getLogger(__name__)
@@ -45,13 +49,136 @@ def scheduled_processing_event(session, events):
     processing_input_collection = ProcessingInputCollection(*processing_inputs)
 
     for job in triggered_jobs:
-        batch_starter.try_to_submit_job(
+        try_to_submit_job(
             session,
             job,
-            "20000101",
+            dt.datetime.now(),
             "v001",
             processing_input_collection.serialize(),
         )
+
+
+def try_to_submit_job(
+    session: db.Session,
+    job_info: dict,
+    start_date: dt.datetime,
+    version: str,
+    serialized_dependencies: str,
+    repoint: Optional[int] = None,
+):
+    """Try to submit a batch job with the given job information.
+
+    Parameters
+    ----------
+    session : orm session
+        Database session.
+    job_info : dict
+        Dictionary containing components with dates and versions appended.
+    start_date : datetime
+        Start date of the data.
+    version : str
+        Version of the job.
+    serialized_dependencies : str
+        The serialized ProcessingInputCollection of the upstream
+        dependencies.
+    repoint : int, optional
+        The repointing number for the job, if applicable. Default is None. Should
+        be just an integer, no "repoint" prefix.
+    """
+    instrument = job_info["data_source"]
+    data_level = job_info["data_type"]
+    descriptor = job_info["descriptor"]
+
+    formatted_start_date = start_date.strftime("%Y%m%d")
+
+    # Serialize the upstream dependencies and write them to a JSON file. The Imap
+    # processing code will read the JSON file and deserialize the dependencies. This is
+    # to avoid passing a large string through the batch job command line.
+    # release
+    # The descriptor should include a hash of the serialized dependencies.
+    # This makes it unique for this file and set of dependencies.
+    dep_descriptor = f"{descriptor}-{dependency_hash(serialized_dependencies)}"
+    dependency_file = DependencyFilePath.generate_from_inputs(
+        instrument=instrument,
+        data_level=data_level,
+        descriptor=dep_descriptor,
+        start_time=formatted_start_date,
+        version=version,
+        extension="json",
+        repointing=repoint,  # since we can have different repointings on the same day
+    )
+    dependency_file_path = dependency_file.construct_path()
+    response = batch_starter.upload_dependency_file(
+        dependency_file_path, serialized_dependencies
+    )
+    # If response is None, then the upload failed and we should skip submitting the job.
+    if not response:
+        return
+
+    batch_command = [
+        "--instrument",
+        instrument,
+        "--data-level",
+        data_level,
+        "--descriptor",
+        descriptor,
+        "--start-date",
+        formatted_start_date,
+        "--version",
+        version,
+        "--dependency",
+        dependency_file_path.name,
+        "--upload-to-sdc",
+    ]
+
+    if repoint is not None:
+        batch_command.extend(["--repointing", f"repoint{repoint:05d}"])
+
+    # All of our upstream requirements have been met.
+    # Try to insert a record into the Processing Jobs table
+    # If this job already exists, then we will get an integrity error
+    # and know that some other process has already taken care of it
+    processing_job = models.ProcessingJob(
+        status=models.Status.INPROGRESS,
+        instrument=instrument,
+        data_level=data_level,
+        descriptor=descriptor,
+        start_date=start_date,
+        version=version,
+        repointing=repoint,
+        container_command=" ".join(batch_command),
+    )
+    try:
+        session.add(processing_job)
+        session.commit()
+    except IntegrityError:
+        # Rollback the session to clear the failed transaction
+        session.rollback()
+        logger.info(f"Job already completed or in progress: {processing_job}")
+        return
+
+    logger.info(
+        f"Wrote job INPROGRESS to Processing Jobs Table with id: {processing_job.id}"
+    )
+    # NOTE: The batch job name should contain only alphanumeric characters and hyphens
+    # E.g. "codice-l1a-sci-job-1"
+    # The `processing_job.id` is used later for updating the job processing table
+    job_name = f"{instrument}-{data_level}-{descriptor}-job-{processing_job.id}"
+    # Get the necessary AWS information
+    # NOTE: These are here for easier mocking in tests rather than at the module level
+    step = "-l3" if data_level >= "l3" else ""
+    job_definition = f"ProcessingJob-{instrument}{step}"
+    job_queue = "ProcessingJobQueue"
+    batch_starter.BATCH_CLIENT.submit_job(
+        jobName=job_name,
+        jobQueue=job_queue,
+        jobDefinition=job_definition,
+        containerOverrides={
+            "command": batch_command,
+        },
+        retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
+    )
+    logger.info(f"Submitted job {job_name} with this command: {batch_command}")
 
 
 def lambda_handler(events, context):

--- a/tests/lambda_endpoints/test_scheduled_job.py
+++ b/tests/lambda_endpoints/test_scheduled_job.py
@@ -5,9 +5,11 @@ from unittest.mock import call, patch
 
 from imap_data_access import ProcessingInputCollection, RepointInput
 
+from sds_data_manager.lambda_code.SDSCode.database import models
 from sds_data_manager.lambda_code.SDSCode.database.models import RepointFiles
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import (
     batch_starter,
+    scheduled_job,
 )
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.scheduled_job import (
     lambda_handler,
@@ -43,15 +45,19 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
         ],
     }
 
+    expected_start_date = dt.datetime.now().strftime("%Y%m%d")
+
     with (
         patch.object(batch_starter, "BATCH_CLIENT") as mock_batch_client,
     ):
+        # call twice to ensure we submit a job each time the event is triggered
+        lambda_handler({"scheduled": "cron(20 6 * * ? *)"}, context)
         lambda_handler({"scheduled": "cron(20 6 * * ? *)"}, context)
 
         # Verify we submit the glows daily job
-        assert mock_batch_client.submit_job.call_count == 1
+        assert mock_batch_client.submit_job.call_count == 2
         mock_batch_client.submit_job.assert_called_with(
-            jobName="glows-l3b-ion-rate-profile-job-1",
+            jobName="glows-l3b-ion-rate-profile-job-2",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-glows-l3",
             containerOverrides={
@@ -63,16 +69,25 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
                     "--descriptor",
                     "ion-rate-profile",
                     "--start-date",
-                    "20000101",
+                    expected_start_date,
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_glows_l3b_ion-rate-profile-4f53cda1_20000101_v001.json",
+                    f"imap_glows_l3b_ion-rate-profile-4f53cda1_{expected_start_date}_v001.json",
                     "--upload-to-sdc",
                 ]
             },
             retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
+
+        processing_job_1 = session.get(models.ProcessingJob, 1)
+        processing_job_2 = session.get(models.ProcessingJob, 2)
+
+        # processing jobs should end up with different start dates
+        # even when submitted on the same day
+        # so they don't get excluded from processing
+        # for being duplicate jobs
+        assert processing_job_1.start_date != processing_job_2.start_date
 
         mock_batch_client.submit_job.reset_mock()
 
@@ -82,7 +97,7 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
         mock_batch_client.submit_job.assert_has_calls(
             [
                 call(
-                    jobName="hi-l3-h90-ena-h-sf-sp-full-hae-6deg-3mo-job-2",
+                    jobName="hi-l3-h90-ena-h-sf-sp-full-hae-6deg-3mo-job-3",
                     jobQueue="ProcessingJobQueue",
                     jobDefinition="ProcessingJob-hi-l3",
                     containerOverrides={
@@ -94,18 +109,18 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
                             "--descriptor",
                             "h90-ena-h-sf-sp-full-hae-6deg-3mo",
                             "--start-date",
-                            "20000101",
+                            expected_start_date,
                             "--version",
                             "v001",
                             "--dependency",
-                            "imap_hi_l3_h90-ena-h-sf-sp-full-hae-6deg-3mo-4f53cda1_20000101_v001.json",
+                            f"imap_hi_l3_h90-ena-h-sf-sp-full-hae-6deg-3mo-4f53cda1_{expected_start_date}_v001.json",
                             "--upload-to-sdc",
                         ]
                     },
                     retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
                 ),
                 call(
-                    jobName="lo-l3-ilo-ena-h-sf-sp-full-hae-6deg-3mo-job-3",
+                    jobName="lo-l3-ilo-ena-h-sf-sp-full-hae-6deg-3mo-job-4",
                     jobQueue="ProcessingJobQueue",
                     jobDefinition="ProcessingJob-lo-l3",
                     containerOverrides={
@@ -117,11 +132,11 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
                             "--descriptor",
                             "ilo-ena-h-sf-sp-full-hae-6deg-3mo",
                             "--start-date",
-                            "20000101",
+                            expected_start_date,
                             "--version",
                             "v001",
                             "--dependency",
-                            "imap_lo_l3_ilo-ena-h-sf-sp-full-hae-6deg-3mo-4f53cda1_20000101_v001.json",
+                            f"imap_lo_l3_ilo-ena-h-sf-sp-full-hae-6deg-3mo-4f53cda1_{expected_start_date}_v001.json",
                             "--upload-to-sdc",
                         ]
                     },
@@ -162,17 +177,21 @@ def test_scheduled_job_passes_repointing(mock_read_job_config, session):
     session.add_all(records)
     session.commit()
 
+    expected_start_date = dt.datetime.now().strftime("%Y%m%d")
+
     with (
-        patch.object(batch_starter, "try_to_submit_job") as mock_submit,
+        patch.object(scheduled_job, "try_to_submit_job") as mock_submit,
     ):
         repoint_input = RepointInput(repointing_file_name)
         expected_processing_input = ProcessingInputCollection(repoint_input)
         events = {"scheduled": "cron(21 6 * * ? *)"}
         lambda_handler(events, context)
-        mock_submit.assert_called_with(
-            session,
-            glows_job,
-            "20000101",
-            "v001",
-            expected_processing_input.serialize(),
-        )
+
+        assert 1 == mock_submit.call_count
+        [sess, job, start_date, version, deps] = mock_submit.call_args_list[0].args
+
+        assert session == sess
+        assert glows_job == job
+        assert expected_start_date == start_date.strftime("%Y%m%d")
+        assert "v001" == version
+        assert expected_processing_input.serialize() == deps

--- a/tests/lambda_endpoints/test_scheduled_job.py
+++ b/tests/lambda_endpoints/test_scheduled_job.py
@@ -5,11 +5,9 @@ from unittest.mock import call, patch
 
 from imap_data_access import ProcessingInputCollection, RepointInput
 
-from sds_data_manager.lambda_code.SDSCode.database import models
 from sds_data_manager.lambda_code.SDSCode.database.models import RepointFiles
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import (
     batch_starter,
-    scheduled_job,
 )
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.scheduled_job import (
     lambda_handler,
@@ -52,12 +50,11 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
     ):
         # call twice to ensure we submit a job each time the event is triggered
         lambda_handler({"scheduled": "cron(20 6 * * ? *)"}, context)
-        lambda_handler({"scheduled": "cron(20 6 * * ? *)"}, context)
 
         # Verify we submit the glows daily job
-        assert mock_batch_client.submit_job.call_count == 2
+        assert mock_batch_client.submit_job.call_count == 1
         mock_batch_client.submit_job.assert_called_with(
-            jobName="glows-l3b-ion-rate-profile-job-2",
+            jobName="glows-l3b-ion-rate-profile-job-1",
             jobQueue="ProcessingJobQueue",
             jobDefinition="ProcessingJob-glows-l3",
             containerOverrides={
@@ -80,15 +77,6 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
             retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
 
-        processing_job_1 = session.get(models.ProcessingJob, 1)
-        processing_job_2 = session.get(models.ProcessingJob, 2)
-
-        # processing jobs should end up with different start dates
-        # even when submitted on the same day
-        # so they don't get excluded from processing
-        # for being duplicate jobs
-        assert processing_job_1.start_date != processing_job_2.start_date
-
         mock_batch_client.submit_job.reset_mock()
 
         lambda_handler({"scheduled": "cron(22 6 * * ? *)"}, context)
@@ -97,7 +85,7 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
         mock_batch_client.submit_job.assert_has_calls(
             [
                 call(
-                    jobName="hi-l3-h90-ena-h-sf-sp-full-hae-6deg-3mo-job-3",
+                    jobName="hi-l3-h90-ena-h-sf-sp-full-hae-6deg-3mo-job-2",
                     jobQueue="ProcessingJobQueue",
                     jobDefinition="ProcessingJob-hi-l3",
                     containerOverrides={
@@ -120,7 +108,7 @@ def test_scheduled_processing_event(mock_read_scheduled_job_config, session):
                     retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
                 ),
                 call(
-                    jobName="lo-l3-ilo-ena-h-sf-sp-full-hae-6deg-3mo-job-4",
+                    jobName="lo-l3-ilo-ena-h-sf-sp-full-hae-6deg-3mo-job-3",
                     jobQueue="ProcessingJobQueue",
                     jobDefinition="ProcessingJob-lo-l3",
                     containerOverrides={
@@ -177,14 +165,14 @@ def test_scheduled_job_passes_repointing(mock_read_job_config, session):
     session.add_all(records)
     session.commit()
 
-    expected_start_date = dt.datetime.now().strftime("%Y%m%d")
+    expected_start_date = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d")
 
     with (
-        patch.object(scheduled_job, "try_to_submit_job") as mock_submit,
+        patch.object(batch_starter, "try_to_submit_job") as mock_submit,
     ):
         repoint_input = RepointInput(repointing_file_name)
         expected_processing_input = ProcessingInputCollection(repoint_input)
-        events = {"scheduled": "cron(21 6 * * ? *)"}
+        events = {"scheduled": "cron(21 6 * * ? *)", "version": 5}
         lambda_handler(events, context)
 
         assert 1 == mock_submit.call_count
@@ -192,6 +180,6 @@ def test_scheduled_job_passes_repointing(mock_read_job_config, session):
 
         assert session == sess
         assert glows_job == job
-        assert expected_start_date == start_date.strftime("%Y%m%d")
-        assert "v001" == version
+        assert expected_start_date == start_date
+        assert "v005" == version
         assert expected_processing_input.serialize() == deps


### PR DESCRIPTION
# Change Summary
Updated scheduled job lambda so it passes the current time as the start date of the scheduled job. Made a version of try_submit_job that takes a datetime, so multiple jobs can be submitted on the same day, and they will be recognized as unique.

The original scheduled job PR #787 

## Updated Files
- lambda_code/SDSCode/pipeline_lambdas/scheduled_job.py
- tests/lambda_endpoints/test_scheduled_job.py