### PR TITLE
Spice download s3

### DIFF
--- a/sds_data_manager/constructs/indexer_lambda_construct.py
+++ b/sds_data_manager/constructs/indexer_lambda_construct.py
@@ -158,7 +158,6 @@ class SPICEIndexerLambda(Construct):
         layers: list,
         rds_security_group,
         data_bucket: s3.Bucket,
-        data_access_url: str = "",
         **kwargs,
     ) -> None:
         """Construct the EFS lambdas.
@@ -236,7 +235,6 @@ class SPICEIndexerLambda(Construct):
             security_groups=[rds_security_group],
             environment={
                 "IMAP_DATA_DIR": "/tmp",  # noqa: S108
-                "IMAP_DATA_ACCESS_URL": data_access_url,
                 "SECRET_NAME": db_secret_name,
                 "S3_BUCKET": data_bucket.bucket_name,
             },

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -126,7 +126,7 @@ def furnish_best_spice_file(kernel_type: str):
     logger.info(f"Furnishing the latest {kernel_type} kernel: {kernel_filename}")
     # Download the latest kernel file
     # Convert this into an s3 key
-    # Relative to our base directory to trim off the innitial path
+    # Relative to our base directory to trim off the initial path
     s3_key = str(
         SPICEFilePath(kernel_filename)
         .construct_path()

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -4,12 +4,14 @@ import csv
 import json
 import logging
 import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 import boto3
 import spiceypy
-from imap_data_access import SPICEFilePath, download
+from imap_data_access import SPICEFilePath
 from sqlalchemy.dialects.postgresql import insert
 
 from ..api_lambdas import spice_metakernel_api
@@ -20,6 +22,52 @@ from .lambda_custom_events import IMAPLambdaPutEvent
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+def download_from_s3(s3_key: str, bucket_name: Optional[str] = None) -> Path:
+    """Download a file from S3 to a local temporary path.
+
+    Parameters
+    ----------
+    s3_key : str
+        The S3 key (path) of the file to download.
+    bucket_name : Optional[str], optional
+        The S3 bucket name. If not provided, will use the S3_BUCKET
+        environment variable.
+
+    Returns
+    -------
+    Path
+        The local path where the file was downloaded.
+
+    Raises
+    ------
+    ValueError
+        If bucket_name is not provided and S3_BUCKET environment variable is
+        not set.
+    """
+    if bucket_name is None:
+        bucket_name = os.environ.get("S3_BUCKET")
+        if bucket_name is None:
+            raise ValueError(
+                "bucket_name must be provided or S3_BUCKET environment "
+                "variable must be set"
+            )
+
+    # Create a temporary file path
+    filename = os.path.basename(s3_key)
+    temp_dir = tempfile.gettempdir()
+    local_path = Path(temp_dir) / filename
+
+    # Download from S3
+    s3_client = boto3.client("s3")
+    try:
+        s3_client.download_file(bucket_name, s3_key, str(local_path))
+        logger.info(f"Downloaded {s3_key} from bucket {bucket_name} to {local_path}")
+        return local_path
+    except Exception as e:
+        logger.error(f"Failed to download {s3_key} from bucket {bucket_name}: {e}")
+        raise
 
 
 # Define constants needed in the file
@@ -76,7 +124,7 @@ def furnish_best_spice_file(kernel_type: str):
     kernel_filename = json.loads(metakernel_response["body"])[0]
     logger.info(f"Furnishing the latest {kernel_type} kernel: {kernel_filename}")
     # Download the latest kernel file
-    highest_version_spice_file = download(kernel_filename)
+    highest_version_spice_file = download_from_s3(kernel_filename)
     logger.info(f"Downloaded SPICE file: {highest_version_spice_file}")
     # Furnish the SPICE file
     spiceypy.furnsh(str(highest_version_spice_file))
@@ -250,7 +298,7 @@ def index_spice_file(s3_key: str):
     spice_metadata = spice_object.spice_metadata
     # Download the ingested SPICE file from S3
     try:
-        spice_file = download(s3_key)
+        spice_file = download_from_s3(s3_key)
     except Exception as e:
         logger.error(f"Failed to download SPICE file {s3_key}: {e}")
         raise ValueError(f"Error downloading file {s3_key}") from e
@@ -421,7 +469,7 @@ def index_pointing_data(s3_key: str):
     """
     logger.info(f"Indexing {s3_key} to pointing table")
     # Download repoint file
-    repoint_file_path = download(s3_key)
+    repoint_file_path = download_from_s3(s3_key)
     repoind_data = []
     repoint_db_records = []
     # Read CSV file using Python's native csv module

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 import boto3
+import imap_data_access
 import spiceypy
 from imap_data_access import SPICEFilePath
 from sqlalchemy.dialects.postgresql import insert
@@ -124,7 +125,14 @@ def furnish_best_spice_file(kernel_type: str):
     kernel_filename = json.loads(metakernel_response["body"])[0]
     logger.info(f"Furnishing the latest {kernel_type} kernel: {kernel_filename}")
     # Download the latest kernel file
-    highest_version_spice_file = download_from_s3(kernel_filename)
+    # Convert this into an s3 key
+    # Relative to our base directory to trim off the innitial path
+    s3_key = str(
+        SPICEFilePath(kernel_filename)
+        .construct_path()
+        .relative_to(imap_data_access.config["DATA_DIR"])
+    )
+    highest_version_spice_file = download_from_s3(s3_key)
     logger.info(f"Downloaded SPICE file: {highest_version_spice_file}")
     # Furnish the SPICE file
     spiceypy.furnsh(str(highest_version_spice_file))

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -299,8 +299,6 @@ def build_sds(
         layers=[db_lambda_layer, spice_lambda_layer],
         rds_security_group=rds_construct.rds_security_group,
         data_bucket=data_bucket.data_bucket,
-        # SPICE files are all public, so no need to use the api-key URL
-        data_access_url=general_data_access_url,
     )
 
     # I-ALiRT Stack

--- a/tests/lambda_endpoints/test_spice_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_spice_indexer_lambda.py
@@ -80,7 +80,9 @@ def _insert_test_file(session, filename, s3_path, intervals, upload_time=0):
     session.commit()
 
 
-@patch("sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.download")
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.download_from_s3"
+)
 def test_s3_spice_files(mock_download, session, events_client, s3_client):
     """Test s3 event.
 
@@ -237,7 +239,9 @@ def test_s3_spin_files(session, s3_client, events_client):
     assert spin_table_rows[1].version == "02"
 
 
-@patch("sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.download")
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.download_from_s3"
+)
 def test_s3_repoint_files(mock_download, session, s3_client, events_client):
     """Test s3 event for repoint files."""
     current_path = os.path.dirname(os.path.abspath(__file__))
@@ -317,7 +321,9 @@ def test_send_spice_event(session, events_client, s3_client):
         spice_indexer.lambda_handler(event, None)
 
 
-@patch("sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.download")
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.download_from_s3"
+)
 def test_index_pointing_data_updates_null_values(mock_download, session, tmpdir):
     """Test that Null values in the pointing table are updated."""
     new_repoint_file = os.path.join(tmpdir, "test_repoint.csv")


### PR DESCRIPTION
# Change Summary

## Overview

Previously we used imap-data-access to download the SPICE files. This caused issues because the file was in s3 but wasn't indexed yet and therefore wasn't "released". We can get the file directly from s3 instead, so create the function here.