### PR TITLE
Added Lo L1B DE and L1C PSET anc, repoint, spin dependencies

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -402,6 +402,10 @@ spacecraft_clock, spice, historical, lo, l1a, all, HARD_NO_TRIGGER, DOWNSTREAM
 
 lo, l1a, de, lo, l1b, de, HARD, DOWNSTREAM
 lo, l1a, spin, lo, l1b, de, HARD, DOWNSTREAM
+lo, ancillary, bad-times, lo, l1b, de, HARD, DOWNSTREAM
+lo, ancillary, sweep-table, lo, l1b, de, HARD, DOWNSTREAM
+spin, spin, historical, lo, l1b, de, HARD, DOWNSTREAM
+repoint, repoint, historical, lo, l1b, de, HARD, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1b, de, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, lo, l1b, de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, lo, l1b, de, HARD_NO_TRIGGER, DOWNSTREAM
@@ -423,7 +427,11 @@ lo, l1a, hk, lo, l1b, hk, HARD, DOWNSTREAM
 
 # TODO: add more dependencies for pset
 lo, l1b, de, lo, l1c, pset, HARD, DOWNSTREAM
-lo, ancillary, goodtimes, lo, l1c, pset, HARD, DOWNSTREAM
+lo, ancillary, good-times, lo, l1c, pset, HARD, DOWNSTREAM
+lo, ancillary, hydrogen-background, lo, l1c, pset, HARD, DOWNSTREAM
+lo, ancillary, oxygen-background, lo, l1c, pset, HARD, DOWNSTREAM
+spin, spin, historical, lo, l1b, de, HARD, DOWNSTREAM
+repoint, repoint, historical, lo, l1b, de, HARD, DOWNSTREAM
 leapseconds, spice, historical, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -26,6 +26,7 @@ from sds_data_manager.lambda_code.SDSCode.database.models import (
     RepointFiles,
     ScienceFiles,
     SPICEFiles,
+    SpinFiles,
 )
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import (
     batch_starter,
@@ -2262,6 +2263,45 @@ def test_lambda_skip_processing_due_to_crid_check(session, caplog):
             sclk_kernel="/mnt/data/imap/spice/sclk/imap_sclk_0001.tsc",
             lsk_kernel="/mnt/data/imap/spice/lsk/naif0012.tls",
             version=1,
+        ),
+        AncillaryFiles(
+            file_path="/path/to/imap_lo_bad-times_20240101_v002.csv",
+            instrument="lo",
+            descriptor="bad-times",
+            start_date=datetime(2024, 1, 1),
+            version="v002",
+            extension="csv",
+            ingestion_date=datetime.strptime(
+                "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+            ),
+        ),
+        AncillaryFiles(
+            file_path="/path/to/imap_lo_sweep-table_20240101_v002.csv",
+            instrument="lo",
+            descriptor="sweep-table",
+            start_date=datetime(2024, 1, 1),
+            version="v002",
+            extension="csv",
+            ingestion_date=datetime.strptime(
+                "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+            ),
+        ),
+        RepointFiles(
+            file_path="/path/to/imap_2024_002_01.repoint.csv",
+            end_date=datetime(2024, 1, 2),
+            version="01",
+            ingestion_date=datetime.strptime(
+                "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+            ),
+        ),
+        SpinFiles(
+            file_path="imap_2024_001_2024_001_01.spin.csv",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 2),
+            version="01",
+            ingestion_date=datetime.strptime(
+                "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+            ),
         ),
     ]
     session.add_all(records)


### PR DESCRIPTION
# Change Summary

## Overview

Added ancillary dependencies for Lo L1B DE and L1C PSET:

L1B DE
- bad-times
- sweep-table
- repoint
- spin

L1C PSET
- good-times
- oxygen-background
- hydrogen-background
- repoint
- spin
