### PR TITLE
MNT: Add HEAD route to the download API endpoint

### DIFF
--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -155,11 +155,7 @@ class ApiGateway(Construct):
             cors_preflight={
                 "allow_headers": ["*"],
                 "allow_origins": ["*"],
-                "allow_methods": [
-                    apigwv2.CorsHttpMethod.GET,
-                    apigwv2.CorsHttpMethod.POST,
-                    apigwv2.CorsHttpMethod.OPTIONS,
-                ],
+                "allow_methods": [apigwv2.CorsHttpMethod.ANY],
             },
         )
 

--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -158,6 +158,9 @@ class IalirtApiManager(Construct):
         add_stable_route(
             api, "/ialirt-download", "GET", download_api, restricted_route_prefixes
         )
+        add_stable_route(
+            api, "/ialirt-download", "HEAD", download_api, restricted_route_prefixes
+        )
 
         # catalog API lambda
         catalog_api = lambda_.Function(

--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -274,6 +274,11 @@ class SdsApiManager(Construct):
         add_stable_route(
             api, "/download", "GET", download_api_lambda, auth_route_prefixes
         )
+        # NOTE: The frontend wants to be able to make a HEAD request to be able to
+        #       get the result without needing to follow the redirect.
+        add_stable_route(
+            api, "/download", "HEAD", download_api_lambda, auth_route_prefixes
+        )
 
         universal_spin_table_handler = lambda_.Function(
             self,

--- a/tests/infrastructure/test_apigateway.py
+++ b/tests/infrastructure/test_apigateway.py
@@ -40,7 +40,7 @@ def test_apigw_routes(template):
         "AWS::ApiGatewayV2::Api",
         props={
             "CorsConfiguration": {
-                "AllowMethods": ["GET", "POST", "OPTIONS"],
+                "AllowMethods": ["*"],
                 "AllowOrigins": ["*"],
             },
         },


### PR DESCRIPTION
# Change Summary

## Overview

The frontend team has requested a HEAD request option to the download endpoint. This adds that route in without doing any different handling on our end.

closes #864 