### PR TITLE
ENH: Add API Key and data access url to packet downloader

### DIFF
--- a/sds_data_manager/constructs/packet_downloader_lambda_construct.py
+++ b/sds_data_manager/constructs/packet_downloader_lambda_construct.py
@@ -21,6 +21,7 @@ class PacketDownloaderLambda(Construct):
         layers: list,
         data_bucket: s3.Bucket,
         vpc: ec2.Vpc,
+        data_access_url: str = "",
         **kwargs,
     ) -> None:
         """MonitoringLambda Construct.
@@ -39,6 +40,10 @@ class PacketDownloaderLambda(Construct):
             The S3 bucket to which the lambda will listen for events
         vpc : ec2.Vpc
             VPC into which to put the resources that require networking.
+        data_access_url : str
+            The data access URL to use for this job, by default the empty string.
+            You should set this to the appropriate API endpoint, e.g.
+            https://api.dev.imap-mission.com
         kwargs : dict
             Keyword arguments
 
@@ -61,6 +66,12 @@ class PacketDownloaderLambda(Construct):
             # We are downloading data, so make sure we have a longer timeout here
             timeout=cdk.Duration.minutes(15),
             memory_size=2048,
+            # Add environment variable with IMAP API key using CloudFormation
+            # dynamic reference. This keeps the actual value out of the template.
+            environment={
+                "IMAP_API_KEY": "{{resolve:ssm-secure:/imap-sdc/batch-jobs/api-key}}",
+                "IMAP_DATA_ACCESS_URL": data_access_url,
+            },
         )
 
         # Allow the function to read/write from our bucket

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -221,16 +221,6 @@ def build_sds(
         account_name=account_name,
     )
 
-    # Packet Downloader Lambda
-    packet_downloader_lambda_construct.PacketDownloaderLambda(
-        scope=sdc_stack,
-        construct_id="PacketDownloaderLambda",
-        code=lambda_code,
-        data_bucket=data_bucket.data_bucket,
-        vpc=networking.vpc,
-        layers=[db_lambda_layer],
-    )
-
     account_name = sdc_stack.node.get_context("account_name")
     # once we have the account_name, get that section out of cdk.json
     account_config = sdc_stack.node.get_context(account_name)
@@ -241,6 +231,17 @@ def build_sds(
     # to access the data and upload results as necessary.
     general_data_access_url = f"https://api.{domain_name}"
     api_key_data_access_url = f"{general_data_access_url}/api-key"
+
+    # Packet Downloader Lambda
+    packet_downloader_lambda_construct.PacketDownloaderLambda(
+        scope=sdc_stack,
+        construct_id="PacketDownloaderLambda",
+        code=lambda_code,
+        data_bucket=data_bucket.data_bucket,
+        vpc=networking.vpc,
+        layers=[db_lambda_layer],
+        data_access_url=api_key_data_access_url,
+    )
 
     # This valid instrument list is from imap-data-access package
     processing = processing_construct.ProcessingConstruct(


### PR DESCRIPTION
The packet downloader needs to upload the data to our endpoints, so we need to inject the proper permissions.
