### PR TITLE
FIX: Packet downloader lambda needs to get SSM during runtime not cdk deploy

### DIFF
--- a/sds_data_manager/constructs/packet_downloader_lambda_construct.py
+++ b/sds_data_manager/constructs/packet_downloader_lambda_construct.py
@@ -6,6 +6,7 @@ from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_s3_notifications as s3n
 from aws_cdk import aws_secretsmanager as secretsmanager
+from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 from imap_data_access import SPICEFilePath
 
@@ -66,11 +67,10 @@ class PacketDownloaderLambda(Construct):
             # We are downloading data, so make sure we have a longer timeout here
             timeout=cdk.Duration.minutes(15),
             memory_size=2048,
-            # Add environment variable with IMAP API key using CloudFormation
-            # dynamic reference. This keeps the actual value out of the template.
+            # Environment variables - API key will be retrieved from SSM at runtime
             environment={
-                "IMAP_API_KEY": "{{resolve:ssm-secure:/imap-sdc/batch-jobs/api-key}}",
                 "IMAP_DATA_ACCESS_URL": data_access_url,
+                "SSM_API_KEY_PARAMETER": "/imap-sdc/batch-jobs/api-key",
             },
         )
 
@@ -87,6 +87,14 @@ class PacketDownloaderLambda(Construct):
             self, "WebpodaSecret", "webpoda-token"
         )
         secret.grant_read(packet_lambda)
+
+        # Grant permission to read the API key from SSM Parameter Store
+        api_key_parameter = ssm.StringParameter.from_secure_string_parameter_attributes(
+            self,
+            "ApiKeyParameter",
+            parameter_name="/imap-sdc/batch-jobs/api-key",
+        )
+        api_key_parameter.grant_read(packet_lambda)
 
         # Notify the lambda whenever a new file matching our repoint filename is added
         data_bucket.add_event_notification(

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
@@ -1,6 +1,7 @@
 """Lambda function to automate packet downloads and L0 file creation."""
 
 import logging
+import os
 from pathlib import Path
 
 import boto3
@@ -10,6 +11,8 @@ from imap_data_access import SPICEFilePath, webpoda
 S3_CLIENT = boto3.client("s3")
 # We need to access the webpoda-api-key
 SECRETS_MANAGER = boto3.client("secretsmanager")
+# We need to access the IMAP API key from SSM
+SSM_CLIENT = boto3.client("ssm")
 
 # Logger setup
 # Set default logging level to INFO, to also capture INFO for the underlying downloaders
@@ -106,6 +109,19 @@ def lambda_handler(event, context):
         }
     # Update the token to be used for use in subsequent requests
     imap_data_access.config["WEBPODA_TOKEN"] = response["SecretString"]
+
+    # Get the IMAP API key from SSM Parameter Store
+    ssm_parameter_name = os.environ.get(
+        "SSM_API_KEY_PARAMETER", "/imap-sdc/batch-jobs/api-key"
+    )
+    try:
+        ssm_response = SSM_CLIENT.get_parameter(
+            Name=ssm_parameter_name, WithDecryption=True
+        )
+        imap_data_access.config["API_KEY"] = ssm_response["Parameter"]["Value"]
+    except Exception as e:
+        logger.warning(f"Could not retrieve API key from SSM: {e}")
+        # Continue without API key - some operations might still work
 
     imap_data_access.config["DATA_DIR"] = Path("/tmp")  # noqa: S108
 


### PR DESCRIPTION
The parameter can't be resolved in lambda for this purpose (unlike batch jobs where we took this approach). We need to get it at runtime similar to how we are getting the secretsmanager webpoda token at runtime.