### PR TITLE
I-ALiRT - add db layer to alirt api manager

### DIFF
--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -311,6 +311,11 @@ def build_sds(
         id="IAlirtSpiceDependencies",
         layer_dependencies_dir=str(layer_code_directory / "spice"),
     )
+    ialirt_db_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
+        scope=ialirt_stack,
+        id="IAlirtDatabaseDependencies",
+        layer_dependencies_dir=str(layer_code_directory / "database"),
+    )
 
     ialirt_root_certificate = None
     if domain is not None:
@@ -396,7 +401,7 @@ def build_sds(
         env=env,
         data_bucket=ialirt_bucket.ialirt_bucket,
         vpc=networking.vpc,
-        layers=[ialirt_spice_lambda_layer],
+        layers=[ialirt_spice_lambda_layer, ialirt_db_lambda_layer],
         algorithm_table=ingest.algorithm_data_table,
         account_name=account_name,
     )


### PR DESCRIPTION
# Change Summary

## Overview
When I went to download a file I had this error for the ialirt download api handler (which relies on the sds download handler):
[ERROR] Runtime.ImportModuleError: Unable to import module 'SDSCode.api_lambdas.download_api': No module named 'sqlalchemy'
Traceback (most recent call last):

This wasn't a problem before but I realized that the download_api.py was changed last week and I now need to update the libraries that the IalirtApiManager was using so that they match the regular ApiManager construct.

## Updated Files
- stackbuilder.py
   - Update the library inputs to IalirtApiManager