### PR TITLE
Add scope to authorizer - NOT NEEDED PRIOR TO LAUNCH

### DIFF
--- a/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
+++ b/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
@@ -1,8 +1,12 @@
 """Authorization for API Keys within the SDS."""
 
 import json
+import logging
 
 import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # Retrieve the API keys from AWS Systems Manager Parameter Store
 # Do this outside of the lambda handler body to cache the keys
@@ -19,7 +23,15 @@ except Exception:
 
 def lambda_handler(event, context):
     """Get the API Key from the request header and check if it is valid."""
+    logger.info("Received event: %s", json.dumps(event))
+
     api_key = event.get("headers", {}).get("x-api-key", None)
+    metadata = key_dict.get(api_key, {})
+    scope = metadata.get("scope", "")
+    path = event.get("rawPath") or event.get("path", "")
+
+    if path.startswith("/ialirt-db-query") and scope not in ("ialirt_db", "full"):
+        return {"isAuthorized": False}
 
     if api_key and api_key in valid_keys:
         return {"isAuthorized": True, "context": {"apiKey": api_key}}

--- a/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
+++ b/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
@@ -23,8 +23,6 @@ except Exception:
 
 def lambda_handler(event, context):
     """Get the API Key from the request header and check if it is valid."""
-    logger.info("Received event: %s", json.dumps(event))
-
     api_key = event.get("headers", {}).get("x-api-key", None)
     metadata = key_dict.get(api_key, {})
     scope = metadata.get("scope", "")

--- a/sds_data_manager/lambda_code/authorization/manage_api_keys.py
+++ b/sds_data_manager/lambda_code/authorization/manage_api_keys.py
@@ -6,11 +6,11 @@ for the account and region where the SSM parameter is stored.
 
 Usage:
   python manage_api_keys.py list
-  python manage_api_keys.py add <owner> <email>
+  python manage_api_keys.py add <owner> <email> <scope>
   python manage_api_keys.py remove <key>
   AWS_PROFILE=imap-sdc-dev AWS_DEFAULT_REGION=us-west-2 \
     python sds_data_manager/lambda_code/authorization/manage_api_keys.py \
-        add "First Last" "user@example.com"
+        add "First Last" "user@example.com" "full"
 
 Requires AWS credentials with SSM permissions.
 """
@@ -61,11 +61,14 @@ def list_keys():
     for k, meta in keys.items():
         owner = meta.get("owner", "?")
         email = meta.get("email", "?")
+        scope = meta.get("scope", "?")
         created = meta.get("created", "?")
-        print(f"- {k}\n    owner={owner}, email={email}, created={created}")
+        print(
+            f"- {k}\n    owner={owner}, email={email}, scope={scope}, created={created}"
+        )
 
 
-def add_key(owner, email):
+def add_key(owner, email, scope="full"):
     """Generate and add a new API key with owner and email metadata."""
     keys = get_keys()
     # Generate a secure random 32-byte hex key
@@ -76,6 +79,7 @@ def add_key(owner, email):
         "owner": owner,
         "email": email,
         "created": datetime.now().isoformat(),
+        "scope": scope,
     }
     put_keys(keys)
     print(f"Added key: {new_key}")
@@ -97,19 +101,21 @@ def main():
     """CLI entry point."""
     if len(sys.argv) < 2:
         print(
-            "Usage: python manage_api_keys.py [list|add|remove] <key> [owner] [email]"
+            "Usage: python manage_api_keys.py [list|add|remove] "
+            "<key> [owner] [email] [scope]"
         )
         sys.exit(1)
     cmd = sys.argv[1]
     if cmd == "list":
         list_keys()
-    elif cmd == "add" and len(sys.argv) == 4:
-        add_key(sys.argv[2], sys.argv[3])
+    elif cmd == "add" and len(sys.argv) == 5:
+        add_key(sys.argv[2], sys.argv[3], sys.argv[4])
     elif cmd == "remove" and len(sys.argv) == 3:
         remove_key(sys.argv[2])
     else:
         print(
-            "Usage: python manage_api_keys.py [list|add|remove] <key> [owner] [email]"
+            "Usage: python manage_api_keys.py [list|add|remove] "
+            "<key> [owner] [email] [scope]"
         )
         sys.exit(1)
 


### PR DESCRIPTION
# Change Summary

## Overview
A heads up: this is not needed prior to launch, but will be needed shortly afterwards when scientists start to review their data.

Many scientists will need to view the DynamoDB for I-ALiRT, but not need (and we won't want them) to have credentials for other things, such as uploading files. In the future we also may want to separate out credentials for downloading vs uploading, for example. This PR addresses the need for different permissions, but using the same api-key.

## Updated Files
- lambda_api_key_authorizer.py
   - handles path of lambda and compares the scope of the credentials to determine if the call is authorized.
- manage_api_keys.py
   - adds the ability to create a scope in which different permissions scopes are set
