### PR TITLE
Update L1D dependencies for MAG

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -735,8 +735,8 @@ mag, l1b, burst-magi, mag, l1c, norm-magi, SOFT_TRIGGER, DOWNSTREAM
 mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
 mag, l1c, norm-mago, mag, l1d, norm-srf, HARD, DOWNSTREAM
 mag, l1c, norm-magi, mag, l1d, norm-srf, HARD, DOWNSTREAM
-mag, l1b, burst-mago, mag, l1d, norm-srf, SOFT, DOWNSTREAM
-mag, l1b, burst-magi, mag, l1d, norm-srf, SOFT, DOWNSTREAM
+mag, l1b, burst-mago, mag, l1d, norm-srf, SOFT_TRIGGER, DOWNSTREAM
+mag, l1b, burst-magi, mag, l1d, norm-srf, SOFT_TRIGGER, DOWNSTREAM
 mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
 
 imap_frames, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -735,8 +735,8 @@ mag, l1b, burst-magi, mag, l1c, norm-magi, SOFT_TRIGGER, DOWNSTREAM
 mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
 mag, l1c, norm-mago, mag, l1d, norm-srf, HARD, DOWNSTREAM
 mag, l1c, norm-magi, mag, l1d, norm-srf, HARD, DOWNSTREAM
-mag, l1b, burst-mago, mag, l1d, norm-srf, HARD, DOWNSTREAM
-mag, l1b, burst-magi, mag, l1d, norm-srf, HARD, DOWNSTREAM
+mag, l1b, burst-mago, mag, l1d, norm-srf, SOFT, DOWNSTREAM
+mag, l1b, burst-magi, mag, l1d, norm-srf, SOFT, DOWNSTREAM
 mag, ancillary, l1d-calibration, mag, l1d, norm-srf, HARD, DOWNSTREAM
 
 imap_frames, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM


### PR DESCRIPTION
# Change Summary
Turns out MAG L1D does not need burst mode data and the team is expecting to have normal mode only data. 

The processing code handles this case gracefully, just need to fix the triggers to move to soft for L1B. 

Since there is a strong dependency between L1B and L1C we shouldn't see any race conditions with this one.

Sorry for the very last second update!
