### PR TITLE
Add triggers in cron-job CSV for mapping products

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_jobs_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_jobs_config.csv
@@ -2,3 +2,7 @@
 # For more information on available values see:
 # https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-scheduled-rule-pattern.html
 cron(20 6 * * ? *), glows, l3b, ion-rate-profile
+
+cron(20 8 * * ? *), lo, l3, all-maps
+cron(20 8 * * ? *), hi, l3, all-maps
+cron(20 8 * * ? *), ultra, l3, all-maps


### PR DESCRIPTION
# Change Summary

We added 3 cron job triggers for each of the Hi/Lo/Ultra instruments. This will kick off processing for all L3 maps. 