### PR TITLE
MNT: add timeout on batch jobs

### DIFF
--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -137,4 +137,5 @@ class ProcessingConstruct(Construct):
             f"ProcessingJob-{job_name}",
             job_definition_name=f"ProcessingJob-{job_name}",
             container=container_definition,
+            timeout=cdk.Duration.hours(2),
         )


### PR DESCRIPTION
# Change Summary
closes #768 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
I believe this should enable timeout on batch job to 2 hrs. I can test that next week since I will be out rest of this week.


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- sds_data_manager/constructs/processing_construct.py
   - add timeout to batch job definition

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
