### PR TITLE
I-ALiRT - Pointing schedule completion

### DIFF
--- a/sds_data_manager/constructs/ialirt_pointing_schedule_construct.py
+++ b/sds_data_manager/constructs/ialirt_pointing_schedule_construct.py
@@ -1,0 +1,95 @@
+"""Cron job to created pointing schedule."""
+
+from aws_cdk import Duration, RemovalPolicy, aws_s3
+from aws_cdk import aws_events as events
+from aws_cdk import aws_events_targets as targets
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda as lambda_
+from constructs import Construct
+
+
+class IalirtPointingConstruct(Construct):
+    """Construct for ialirt pointing schedule."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        ialirt_bucket: aws_s3.Bucket,
+        docker_path: str = "sds_data_manager/lambda_code",
+        **kwargs,
+    ) -> None:
+        """Create ialirt pointing schedule.
+
+        Parameters
+        ----------
+        scope : Construct
+            Parent construct.
+        construct_id : str
+            A unique string identifier for this construct.
+        ialirt_bucket : aws_s3.Bucket
+            The data bucket.
+        docker_path : str
+            Path to the Dockerfile.
+        kwargs : dict
+            Keyword arguments.
+
+        """
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Create Lambda Function
+        ialirt_pointing_lambda = self.create_pointing_lambda(ialirt_bucket, docker_path)
+        self.create_event_rule(ialirt_pointing_lambda)
+
+    def create_pointing_lambda(
+        self,
+        ialirt_bucket: aws_s3.Bucket,
+        docker_path: str,
+    ) -> lambda_.DockerImageFunction:
+        """Create and return the Lambda function."""
+        lambda_role = iam.Role(
+            self,
+            "IalirtPointingConstructRole",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AWSLambdaBasicExecutionRole"
+                ),
+            ],
+        )
+
+        # Lambda function
+        ialirt_pointing_lambda = lambda_.DockerImageFunction(
+            self,
+            id="IalirtPointingLambda",
+            code=lambda_.DockerImageCode.from_image_asset(
+                docker_path,
+                file="IAlirtCode/Dockerfile.pointing",
+            ),
+            function_name="ialirt-pointing-schedule",
+            timeout=Duration.minutes(1),
+            memory_size=1000,
+            role=lambda_role,
+            environment={
+                "S3_BUCKET": ialirt_bucket.bucket_name,
+            },
+        )
+
+        ialirt_bucket.grant_put(ialirt_pointing_lambda)
+
+        # The resource is deleted when the stack is deleted.
+        ialirt_pointing_lambda.apply_removal_policy(RemovalPolicy.DESTROY)
+
+        return ialirt_pointing_lambda
+
+    def create_event_rule(
+        self, ialirt_pointing_lambda: lambda_.DockerImageFunction
+    ) -> None:
+        """Create the event rule to trigger Lambda once per day."""
+        # Scheduled rule - daily at 00:00 UTC
+        rule = events.Rule(
+            self,
+            "IalirtDailyPointingRule",
+            schedule=events.Schedule.cron(minute="0", hour="0"),
+        )
+        rule.add_target(targets.LambdaFunction(ialirt_pointing_lambda))

--- a/sds_data_manager/constructs/ialirt_pointing_schedule_construct.py
+++ b/sds_data_manager/constructs/ialirt_pointing_schedule_construct.py
@@ -49,7 +49,7 @@ class IalirtPointingConstruct(Construct):
         """Create and return the Lambda function."""
         lambda_role = iam.Role(
             self,
-            "IalirtPointingConstructRole",
+            "IalirtPointingLambdaRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name(
@@ -67,7 +67,7 @@ class IalirtPointingConstruct(Construct):
                 file="IAlirtCode/Dockerfile.pointing",
             ),
             function_name="ialirt-pointing-schedule",
-            timeout=Duration.minutes(1),
+            timeout=Duration.minutes(5),
             memory_size=1000,
             role=lambda_role,
             environment={

--- a/sds_data_manager/constructs/ialirt_pointing_schedule_construct.py
+++ b/sds_data_manager/constructs/ialirt_pointing_schedule_construct.py
@@ -1,4 +1,4 @@
-"""Cron job to created pointing schedule."""
+"""Cron job to create pointing schedules."""
 
 from aws_cdk import Duration, RemovalPolicy, aws_s3
 from aws_cdk import aws_events as events

--- a/sds_data_manager/lambda_code/IAlirtCode/Dockerfile.pointing
+++ b/sds_data_manager/lambda_code/IAlirtCode/Dockerfile.pointing
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+COPY processing/requirements.txt ./requirements.txt
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY IAlirtCode/ialirt_pointing_schedule.py .
+
+CMD ["ialirt_pointing_schedule.lambda_handler"]

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 
 import boto3
@@ -58,8 +59,8 @@ def lambda_handler(event, context):
     """Create pointing schedule files."""
     logger.info("Received event: %s", json.dumps(event))
 
-    bucket = event["detail"]["bucket"]["name"]
-    region = event["region"]
+    bucket = os.environ.get("S3_BUCKET")
+    region = os.environ.get("AWS_REGION")
 
     # Download latest SPICE kernels
     dependency_inputs = get_latest_spice_kernels(

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -21,6 +21,7 @@ from sds_data_manager.constructs import (
     ialirt_coverage_construct,
     ialirt_efs_construct,
     ialirt_ingest_lambda_construct,
+    ialirt_pointing_schedule_construct,
     ialirt_processing_construct,
     ialirt_realtime_construct,
     indexer_lambda_construct,
@@ -357,6 +358,13 @@ def build_sds(
         construct_id="IalirtArchive",
         ialirt_bucket=ialirt_bucket.ialirt_bucket,
         algorithm_data_table=ingest.algorithm_data_table,
+    )
+
+    # I-ALiRT IOIS pointing schedule lambda
+    ialirt_pointing_schedule_construct.IalirtPointingConstruct(
+        scope=ialirt_stack,
+        construct_id="IalirtPointingConstruct",
+        ialirt_bucket=ialirt_bucket.ialirt_bucket,
     )
 
     # I-ALiRT IOIS coverage lambda (facilitates creating coverage json in s3)


### PR DESCRIPTION
# Change Summary

## Overview
Create a construct to run the lambda that creates the pointing schedule for the ground stations.

## New Files
- ialirt_pointing_schedule_construct.py
   - Construct to run the lambda
   - Put it on a cron job
- Dockerfile.pointing
   - Dockerfile for the construct

## Updated Files
- stackbuilder.py
   - Deploy pointing schedule construct
- ialirt_pointing_schedule.py
   - Update environment