### PR TITLE
Update api-key instructions and increase tier size

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ For example from the command line with the proper AWS credentials:
 
 ```bash
 python sds_data_manager/lambda_code/authorization/manage_api_keys.py list
-python sds_data_manager/lambda_code/authorization/manage_api_keys.py add <owner> <email>
+python sds_data_manager/lambda_code/authorization/manage_api_keys.py add <owner> <email> <scope>
 python sds_data_manager/lambda_code/authorization/manage_api_keys.py remove <key>
 AWS_PROFILE=imap-sdc-dev AWS_DEFAULT_REGION=us-west-2 \
   python sds_data_manager/lambda_code/authorization/manage_api_keys.py \
-      add "First Last" "user@example.com"
+      add "First Last" "user@example.com" "full"
 ```

--- a/sds_data_manager/lambda_code/authorization/manage_api_keys.py
+++ b/sds_data_manager/lambda_code/authorization/manage_api_keys.py
@@ -47,6 +47,7 @@ def put_keys(keys):
             Value=value,
             Type="SecureString",
             Overwrite=True,
+            Tier="Advanced",
         )
         print(f"Updated {PARAM_NAME} with {len(keys)} key(s).")
     except Exception as e:


### PR DESCRIPTION
# Change Summary

## Overview
We ran out of space when adding names to parameter store so this increases our tier size and also updates instructions based on recent changes.

## Updated Files
- README.md
   - update instructions
- manage_api_keys.py
   - increase tier for Param Store
