### PR TITLE
MNT/FIX: Switch API key storage from SSM Parameter to DynamoDB

### DIFF
--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -9,14 +9,14 @@ https://ialirt.prod.imap-mission.com/ialirt-log-query
 
 from typing import Optional
 
-from aws_cdk import Duration, aws_sns
+from aws_cdk import Duration, RemovalPolicy, aws_sns
 from aws_cdk import aws_apigatewayv2 as apigwv2
 from aws_cdk import aws_apigatewayv2_authorizers as apigwv2_authorizers
 from aws_cdk import aws_apigatewayv2_integrations as apigwv2_integrations
 from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_cloudwatch as cloudwatch
 from aws_cdk import aws_cloudwatch_actions as cloudwatch_actions
-from aws_cdk import aws_iam as iam
+from aws_cdk import aws_dynamodb as dynamodb
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_route53 as route53
 from aws_cdk import aws_route53_targets as targets
@@ -36,6 +36,7 @@ class ApiGateway(Construct):
         domain_construct: Optional[DomainConstruct] = None,
         certificate: Optional[acm.Certificate] = None,
         ialirt_prefix: Optional[str] = None,
+        create_api_keys_table: bool = True,
         **kwargs,
     ) -> None:
         """Construct the API Gateway Construct.
@@ -52,6 +53,8 @@ class ApiGateway(Construct):
             SSL certificate for the custom domain (in the same region)
         ialirt_prefix : str
             Prefix for ialirt domain, Optional
+        create_api_keys_table : bool
+            Whether to create a new API keys table or reference existing one
         kwargs : dict
             Keyword arguments
         """
@@ -103,12 +106,18 @@ class ApiGateway(Construct):
             code=lambda_.Code.from_asset("sds_data_manager/lambda_code/authorization"),
             timeout=Duration.seconds(10),
         )
-        self.api_key_authorizer_lambda.add_to_role_policy(
-            iam.PolicyStatement(
-                actions=["ssm:GetParameter"],
-                resources=["arn:aws:ssm:*:*:parameter/imap-sdc-api-keys"],
+
+        # Create or reference the API Keys DynamoDB table
+        if create_api_keys_table:
+            self.api_keys_table = self._create_api_keys_table()
+        else:
+            # Reference existing table by name
+            self.api_keys_table = dynamodb.Table.from_table_name(
+                self, "ExistingApiKeysTable", table_name="imap-sdc-api-keys"
             )
-        )
+
+        # Grant the API key authorizer lambda permission to read from DynamoDB
+        self.api_keys_table.grant_read_data(self.api_key_authorizer_lambda)
 
         self.api_key_authorizer = apigwv2_authorizers.HttpLambdaAuthorizer(
             id=f"{self.lowercase_prefix}ApiKeyAuthorizer",
@@ -157,6 +166,28 @@ class ApiGateway(Construct):
                 "allow_origins": ["*"],
                 "allow_methods": [apigwv2.CorsHttpMethod.ANY],
             },
+        )
+
+    def _create_api_keys_table(self) -> dynamodb.Table:
+        """Create the DynamoDB table for API keys.
+
+        The partion key is the api_key to enable O(1) lookups of API keys for
+        quick verification in the lambda authorizer.
+
+        Returns
+        -------
+        dynamodb.Table
+            The created DynamoDB table for API keys
+        """
+        return dynamodb.Table(
+            self,
+            "ApiKeysTable",
+            table_name="imap-sdc-api-keys",
+            partition_key=dynamodb.Attribute(
+                name="api_key", type=dynamodb.AttributeType.STRING
+            ),
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+            removal_policy=RemovalPolicy.RETAIN,
         )
 
     def deliver_to_sns(self, sns_topic: aws_sns.Topic):

--- a/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
+++ b/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
@@ -1,6 +1,5 @@
 """Authorization for API Keys within the SDS."""
 
-import json
 import logging
 
 import boto3
@@ -8,30 +7,39 @@ import boto3
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# Retrieve the API keys from AWS Systems Manager Parameter Store
-# Do this outside of the lambda handler body to cache the keys
-# to avoid unnecessary calls to SSM
-ssm = boto3.client("ssm")
-try:
-    response = ssm.get_parameter(Name="imap-sdc-api-keys", WithDecryption=True)
-    key_dict = json.loads(response["Parameter"]["Value"])
-    valid_keys = set(key_dict.keys())
-except Exception:
-    # Could not load keys, deny access
-    valid_keys = set()
+# Initialize DynamoDB resource
+TABLE_NAME = "imap-sdc-api-keys"
+
+
+def get_api_key_metadata(api_key):
+    """Retrieve API key metadata from DynamoDB."""
+    try:
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(TABLE_NAME)
+        response = table.get_item(Key={"api_key": api_key})
+        return response.get("Item")
+    except Exception as e:
+        logger.error(f"Error retrieving API key metadata: {e}")
+        return None
 
 
 def lambda_handler(event, context):
     """Get the API Key from the request header and check if it is valid."""
     api_key = event.get("headers", {}).get("x-api-key", None)
-    metadata = key_dict.get(api_key, {})
+
+    if not api_key:
+        return {"isAuthorized": False}
+
+    # Retrieve metadata from DynamoDB
+    metadata = get_api_key_metadata(api_key)
+    if not metadata:
+        return {"isAuthorized": False}
+
     scope = metadata.get("scope", "")
     path = event.get("rawPath") or event.get("path", "")
 
+    # Check scope-based authorization for specific endpoints
     if path.startswith("/ialirt-db-query") and scope not in ("ialirt_db", "full"):
         return {"isAuthorized": False}
 
-    if api_key and api_key in valid_keys:
-        return {"isAuthorized": True, "context": {"apiKey": api_key}}
-    else:
-        return {"isAuthorized": False}
+    return {"isAuthorized": True, "context": {"apiKey": api_key}}

--- a/sds_data_manager/lambda_code/authorization/manage_api_keys.py
+++ b/sds_data_manager/lambda_code/authorization/manage_api_keys.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Simple script to manage API keys in AWS SSM Parameter Store (SecureString).
+"""Simple script to manage API keys in AWS DynamoDB.
 
 AWS_PROFILE and AWS_REGION environment variables should be set to the appropriate values
-for the account and region where the SSM parameter is stored.
+for the account and region where the DynamoDB table is located.
 
 Usage:
   python manage_api_keys.py list
@@ -12,45 +12,82 @@ Usage:
     python sds_data_manager/lambda_code/authorization/manage_api_keys.py \
         add "First Last" "user@example.com" "full"
 
-Requires AWS credentials with SSM permissions.
+Requires AWS credentials with DynamoDB permissions.
 """
 
-import json
 import secrets
 import sys
 from datetime import datetime
 
 import boto3
+from botocore.exceptions import ClientError
 
-PARAM_NAME = "imap-sdc-api-keys"
-ssm = boto3.client("ssm")
+TABLE_NAME = "imap-sdc-api-keys"
+
+
+def get_table():
+    """Get the DynamoDB table resource."""
+    dynamodb = boto3.resource("dynamodb")
+    return dynamodb.Table(TABLE_NAME)
 
 
 def get_keys():
-    """Retrieve API keys and metadata from SSM Parameter Store as a dict."""
+    """Retrieve API keys and metadata from DynamoDB as a dict."""
     try:
-        resp = ssm.get_parameter(Name=PARAM_NAME, WithDecryption=True)
-        return json.loads(resp["Parameter"]["Value"])
-    except ssm.exceptions.ParameterNotFound:
-        return {}
+        table = get_table()
+        response = table.scan()
+        keys = {}
+        for item in response["Items"]:
+            api_key = item["api_key"]
+            # Convert DynamoDB item to the expected format
+            keys[api_key] = {
+                "owner": item.get("owner", ""),
+                "email": item.get("email", ""),
+                "scope": item.get("scope", "full"),
+                "created": item.get("created", ""),
+            }
+        return keys
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            print(
+                f"DynamoDB table '{TABLE_NAME}' not found. "
+                "Please create the table first."
+            )
+            print("Table should have 'api_key' as the primary key (string).")
+            sys.exit(1)
+        else:
+            print(f"Error retrieving keys from DynamoDB: {e}")
+            sys.exit(1)
     except Exception as e:
-        print(f"Error retrieving parameter: {e}")
+        print(f"Error retrieving keys: {e}")
         sys.exit(1)
 
 
-def put_keys(keys):
-    """Store API keys and metadata in SSM Parameter Store as JSON."""
-    value = json.dumps(keys, indent=2)
+def add_key_to_db(api_key, owner, email, scope, created):
+    """Add a single API key to DynamoDB."""
     try:
-        ssm.put_parameter(
-            Name=PARAM_NAME,
-            Value=value,
-            Type="SecureString",
-            Overwrite=True,
+        table = get_table()
+        table.put_item(
+            Item={
+                "api_key": api_key,
+                "owner": owner,
+                "email": email,
+                "scope": scope,
+                "created": created,
+            }
         )
-        print(f"Updated {PARAM_NAME} with {len(keys)} key(s).")
     except Exception as e:
-        print(f"Error updating parameter: {e}")
+        print(f"Error adding key to DynamoDB: {e}")
+        sys.exit(1)
+
+
+def remove_key_from_db(api_key):
+    """Remove a single API key from DynamoDB."""
+    try:
+        table = get_table()
+        table.delete_item(Key={"api_key": api_key})
+    except Exception as e:
+        print(f"Error removing key from DynamoDB: {e}")
         sys.exit(1)
 
 
@@ -75,13 +112,9 @@ def add_key(owner, email, scope="full"):
     new_key = secrets.token_hex(32)
     while new_key in keys:
         new_key = secrets.token_hex(32)
-    keys[new_key] = {
-        "owner": owner,
-        "email": email,
-        "created": datetime.now().isoformat(),
-        "scope": scope,
-    }
-    put_keys(keys)
+
+    created = datetime.now().isoformat()
+    add_key_to_db(new_key, owner, email, scope, created)
     print(f"Added key: {new_key}")
     print("Share this key securely with the user.")
 
@@ -92,8 +125,7 @@ def remove_key(key):
     if key not in keys:
         print("Key not found.")
         return
-    del keys[key]
-    put_keys(keys)
+    remove_key_from_db(key)
     print(f"Removed key: {key}")
 
 

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -140,6 +140,7 @@ def build_sds(
         construct_id="ApiGateway",
         domain_construct=domain,
         certificate=root_certificate,
+        create_api_keys_table=True,  # Create the API keys table in SDC stack
     )
     api.deliver_to_sns(monitoring.sns_topic_notifications)
 
@@ -390,6 +391,7 @@ def build_sds(
         domain_construct=domain,
         certificate=ialirt_root_certificate,
         ialirt_prefix="IAlirt",
+        create_api_keys_table=False,  # Reference existing table from SDC stack
     )
     ialirt_api.deliver_to_sns(ialirt_monitoring.sns_topic_notifications)
 

--- a/tests/infrastructure/test_api_key_dynamodb.py
+++ b/tests/infrastructure/test_api_key_dynamodb.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Test script to verify API key functionality with DynamoDB.
+
+This script tests both the management operations and authorization logic
+without requiring deployment to AWS Lambda.
+
+Usage:
+    python test_api_key_dynamodb.py
+"""
+
+import os
+
+import boto3
+import pytest
+from moto import mock_dynamodb
+
+from sds_data_manager.lambda_code.authorization.lambda_api_key_authorizer import (
+    get_api_key_metadata,
+    lambda_handler,
+)
+from sds_data_manager.lambda_code.authorization.manage_api_keys import (
+    add_key_to_db,
+    get_keys,
+    remove_key_from_db,
+)
+
+TABLE_NAME = "imap-sdc-api-keys"
+
+
+@pytest.fixture
+def dynamodb_table():
+    """Create a mock DynamoDB table for testing."""
+    # Set AWS region for boto3
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
+    with mock_dynamodb():
+        dynamodb = boto3.resource("dynamodb", region_name="us-west-2")
+        table = dynamodb.create_table(
+            TableName=TABLE_NAME,
+            KeySchema=[{"AttributeName": "api_key", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "api_key", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield table
+
+
+def test_api_key_management(dynamodb_table):
+    """Test API key management operations."""
+    # Test adding a key
+    test_key = "test123456789abcdef"
+    add_key_to_db(
+        test_key, "Test User", "test@example.com", "full", "2024-01-01T00:00:00"
+    )
+
+    # Test retrieving keys
+    keys = get_keys()
+    assert test_key in keys
+    assert keys[test_key]["owner"] == "Test User"
+    assert keys[test_key]["email"] == "test@example.com"
+    assert keys[test_key]["scope"] == "full"
+
+    # Test getting metadata for authorization
+    metadata = get_api_key_metadata(test_key)
+    assert metadata is not None
+    assert metadata["owner"] == "Test User"
+
+    # Test authorization logic
+    event = {"headers": {"x-api-key": test_key}, "rawPath": "/test-endpoint"}
+    result = lambda_handler(event, {})
+    assert result["isAuthorized"] is True
+    assert result["context"]["apiKey"] == test_key
+
+    # Test authorization with invalid key
+    event["headers"]["x-api-key"] = "invalid-key"
+    result = lambda_handler(event, {})
+    assert result["isAuthorized"] is False
+
+    # Test scope-based authorization
+    event["headers"]["x-api-key"] = test_key
+    event["rawPath"] = "/ialirt-db-query/test"
+    result = lambda_handler(event, {})
+    assert result["isAuthorized"] is True  # "full" scope should allow access
+
+    # Test removing a key
+    remove_key_from_db(test_key)
+    keys = get_keys()
+    assert test_key not in keys
+
+
+def test_scope_restrictions(dynamodb_table):
+    """Test scope-based access restrictions."""
+    # Add a key with limited scope
+    limited_key = "limited123456789abc"
+    add_key_to_db(
+        limited_key,
+        "Limited User",
+        "limited@example.com",
+        "read_only",
+        "2024-01-01T00:00:00",
+    )
+
+    # Test access to ialirt-db-query with limited scope
+    event = {"headers": {"x-api-key": limited_key}, "rawPath": "/ialirt-db-query/test"}
+    result = lambda_handler(event, {})
+    assert result["isAuthorized"] is False  # Should be denied
+
+    # Test access to regular endpoint with limited scope
+    event["rawPath"] = "/regular-endpoint"
+    result = lambda_handler(event, {})
+    assert result["isAuthorized"] is True  # Should be allowed


### PR DESCRIPTION
We are running out of space in SSM Parameter when adding many API Keys to a single parameter. Switching to a DynamoDB table allows us fast lookups still along with much larger storage capability.

closes #902 