### PR TITLE
I-ALiRT - Db query modifications

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -232,7 +232,7 @@ class IalirtApiManager(Construct):
         )
 
         # Grant the lambda function read/write permissions on the DynamoDB table.
-        algorithm_table.grant_read_write_data(ialirt_db_query_handler)
+        algorithm_table.grant_read_data(ialirt_db_query_handler)
 
         add_stable_route(
             api,
@@ -259,11 +259,11 @@ class IalirtApiManager(Construct):
         )
 
         # Grant the lambda function read/write permissions on the DynamoDB table.
-        algorithm_table.grant_read_write_data(ialirt_db_query_formatted_handler)
+        algorithm_table.grant_read_data(ialirt_db_query_formatted_handler)
 
         add_stable_route(
             api,
-            "/ialirt-db",
+            "/space-weather",
             "GET",
             ialirt_db_query_formatted_handler,
             restricted_route_prefixes,

--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -241,3 +241,30 @@ class IalirtApiManager(Construct):
             ialirt_db_query_handler,
             restricted_route_prefixes,
         )
+
+        ialirt_db_query_formatted_handler = lambda_.Function(
+            self,
+            "IAlirtDbQueryApiFormattedHandler",
+            function_name="ialirt-db-query-formatted-handler",
+            code=code,
+            handler="IAlirtCode.ialirt_db_query_api_formatted.lambda_handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            timeout=cdk.Duration.minutes(1),
+            memory_size=1000,
+            environment={
+                "ALGORITHM_TABLE": algorithm_table.table_name,
+                "REGION": env.region,
+            },
+            layers=layers,
+        )
+
+        # Grant the lambda function read/write permissions on the DynamoDB table.
+        algorithm_table.grant_read_write_data(ialirt_db_query_formatted_handler)
+
+        add_stable_route(
+            api,
+            "/ialirt-db",
+            "GET",
+            ialirt_db_query_formatted_handler,
+            restricted_route_prefixes,
+        )

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -69,7 +69,7 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
 
     Example of result:
     -----------------
-    result = {'he_omni_high_en': [0, None],
+    result = {'he_omni_high_en': [0, "null"],
     'B_GSE': [[-6.382, -1.353, -5.045],
     [-2.058, 3.792, -3.989]],
     'time_tag_utc': ['2025-10-02T07:07:13', '2025-10-02T07:07:17'], ...}
@@ -92,8 +92,8 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     query_kwargs = {"KeyConditionExpression": key_expr}
 
     allowed_params = {
-        "time_start",
-        "time_end",
+        "met_start",
+        "met_end",
         "utc_start",
         "utc_end",
         "last_modified_start",
@@ -109,7 +109,7 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
             ),
         }
 
-    time_prefixes = {"time", "utc", "last_modified"}
+    time_prefixes = {"met", "utc", "last_modified"}
     used_time_prefixes = {
         param.split("_start")[0].split("_end")[0]
         for param in params
@@ -120,20 +120,17 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
         return {
             "statusCode": 400,
             "body": json.dumps(
-                {
-                    "message": "Cannot query multiple time keys "
-                    "(time, utc, last_modified)"
-                }
+                {"message": "Cannot query multiple time keys (met, utc, last_modified)"}
             ),
         }
 
     if (
-        ("time_start" in params and "time_end" in params)
+        ("met_start" in params and "met_end" in params)
         or ("utc_start" in params and "utc_end" in params)
         or ("last_modified_start" in params and "last_modified_end" in params)
     ):
-        if "time_start" in params:
-            params_key = "time"
+        if "met_start" in params:
+            params_key = "met"
             time_key = "met"
         elif "utc_start" in params:
             params_key = "utc"
@@ -144,12 +141,12 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
 
         start_value = (
             int(params[f"{params_key}_start"])
-            if params_key == "time"
+            if params_key == "met"
             else params[f"{params_key}_start"]
         )
         end_value = (
             int(params[f"{params_key}_end"])
-            if params_key == "time"
+            if params_key == "met"
             else params[f"{params_key}_end"]
         )
 
@@ -159,12 +156,12 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
             query_kwargs["IndexName"] = time_key
 
     elif (
-        "time_start" in params
+        "met_start" in params
         or "utc_start" in params
         or "last_modified_start" in params
     ):
-        if "time_start" in params:
-            params_key = "time"
+        if "met_start" in params:
+            params_key = "met"
             time_key = "met"
         elif "utc_start" in params:
             params_key = "utc"
@@ -175,7 +172,7 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
 
         start_value = (
             int(params[f"{params_key}_start"])
-            if params_key == "time"
+            if params_key == "met"
             else params[f"{params_key}_start"]
         )
         key_expr &= Key(time_key).gte(start_value)
@@ -183,7 +180,7 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
         if time_key in {"met_in_utc", "last_modified"}:
             query_kwargs["IndexName"] = time_key
 
-    elif "time_end" in params or "utc_end" in params or "last_modified_end" in params:
+    elif "met_end" in params or "utc_end" in params or "last_modified_end" in params:
         return {
             "statusCode": 400,
             "body": json.dumps(

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -1,0 +1,184 @@
+"""I-ALiRT Database Query lambda."""
+
+import json
+import logging
+import os
+from decimal import Decimal
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def process_item_types(item: dict) -> dict:
+    """Convert Decimal values to int/float for known fields.
+
+    Parameters
+    ----------
+    item : dict
+        The item in the dictionary.
+
+    Returns
+    -------
+    result : dict
+        Properly formatted parameters.
+    """
+    result = {}
+
+    for key, value in item.items():
+        # Vectors fields
+        if isinstance(value, list):
+            result[key] = [int(v) if v % 1 == 0 else float(v) for v in value]
+
+        # Scalar fields
+        elif isinstance(value, Decimal):
+            result[key] = int(value) if value % 1 == 0 else float(value)
+
+        else:
+            result[key] = value
+
+    return result
+
+
+def lambda_handler(event, context):  # noqa: PLR0912
+    """Create metadata and add it to the database.
+
+    This function is an event handler for s3 ingest bucket.
+    It is also used to ingest data to the DynamoDB table.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process
+    context : LambdaContext
+        This object provides methods and properties that provide
+        information about the invocation, function,
+        and runtime environment.
+
+    """
+    table_name = os.environ.get("ALGORITHM_TABLE")
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+    dynamodb = boto3.resource("dynamodb", region_name=region)
+    table = dynamodb.Table(table_name)
+
+    logger.info(f"Received event: {json.dumps(event)}")
+    params = event.get("queryStringParameters", {})
+
+    if not params:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"message": "No query parameters provided"}),
+        }
+
+    key_expr = Key("apid").eq(478)
+    query_kwargs = {"KeyConditionExpression": key_expr}
+
+    allowed_params = {
+        "met_start",
+        "met_end",
+        "met_in_utc_start",
+        "met_in_utc_end",
+        "last_modified_start",
+        "last_modified_end",
+    }
+
+    unexpected_params = set(params.keys()) - allowed_params
+    if unexpected_params:
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                {"message": f"Unexpected parameters: {', '.join(unexpected_params)}"}
+            ),
+        }
+
+    time_prefixes = {"met", "met_in_utc", "last_modified"}
+    used_time_prefixes = {
+        param.split("_start")[0].split("_end")[0]
+        for param in params
+        if any(param.startswith(prefix) for prefix in time_prefixes)
+    }
+
+    if len(used_time_prefixes) > 1:
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                {
+                    "message": "Cannot query multiple time keys "
+                    "(met, met_in_utc, last_modified)"
+                }
+            ),
+        }
+
+    if (
+        ("met_start" in params and "met_end" in params)
+        or ("met_in_utc_start" in params and "met_in_utc_end" in params)
+        or ("last_modified_start" in params and "last_modified_end" in params)
+    ):
+        if "met_start" in params:
+            time_key = "met"
+        elif "met_in_utc_start" in params:
+            time_key = "met_in_utc"
+        else:
+            time_key = "last_modified"
+
+        start_value = (
+            int(params[f"{time_key}_start"])
+            if time_key == "met"
+            else params[f"{time_key}_start"]
+        )
+        end_value = (
+            int(params[f"{time_key}_end"])
+            if time_key == "met"
+            else params[f"{time_key}_end"]
+        )
+
+        key_expr &= Key(time_key).between(start_value, end_value)
+
+        if time_key in {"met_in_utc", "last_modified"}:
+            query_kwargs["IndexName"] = time_key
+
+    elif (
+        "met_start" in params
+        or "met_in_utc_start" in params
+        or "last_modified_start" in params
+    ):
+        if "met_start" in params:
+            time_key = "met"
+        elif "met_in_utc_start" in params:
+            time_key = "met_in_utc"
+        else:
+            time_key = "last_modified"
+
+        start_value = (
+            int(params[f"{time_key}_start"])
+            if time_key == "met"
+            else params[f"{time_key}_start"]
+        )
+        key_expr &= Key(time_key).gte(start_value)
+
+        if time_key in {"met_in_utc", "last_modified"}:
+            query_kwargs["IndexName"] = time_key
+
+    elif (
+        "met_end" in params
+        or "met_in_utc_end" in params
+        or "last_modified_end" in params
+    ):
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                {"message": "Cannot query by end time without start time"}
+            ),
+        }
+
+    query_kwargs["KeyConditionExpression"] = key_expr
+
+    response = table.query(**query_kwargs)
+
+    items = response.get("Items", [])
+    processed_items = [process_item_types(item) for item in items]
+
+    return {"statusCode": 200, "body": json.dumps(processed_items)}

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -34,13 +34,15 @@ def process_item_types(item: dict) -> dict:
         if isinstance(value, list):
             result[key] = [int(v) if v % 1 == 0 else round(float(v), 3) for v in value]
 
-        # Dictionary with number
-        elif isinstance(value, dict) and "N" in value:
-            num = Decimal(value["N"])
-            result[key] = int(num) if num % 1 == 0 else round(float(num), 3)
-
-        elif isinstance(value, dict) and "BOOL" in value:
-            result[key] = bool(value["BOOL"])
+        # Dictionary fields
+        elif isinstance(value, dict):
+            nested = {}
+            for k, v in value.items():
+                if isinstance(v, Decimal):
+                    nested[k] = int(v) if v % 1 == 0 else round(float(v), 3)
+                else:
+                    nested[k] = v
+            result[key] = nested
 
         # Scalar fields
         elif isinstance(value, Decimal):

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -24,6 +24,8 @@ def process_item_types(item: dict) -> dict:
     -------
     result : dict
         Properly formatted parameters.
+
+    Note: Truncates to 3 decimal places to reduce response size.
     """
     result = {}
 
@@ -31,6 +33,14 @@ def process_item_types(item: dict) -> dict:
         # Vectors fields
         if isinstance(value, list):
             result[key] = [int(v) if v % 1 == 0 else round(float(v), 3) for v in value]
+
+        # Dictionary with number
+        elif isinstance(value, dict) and "N" in value:
+            num = Decimal(value["N"])
+            result[key] = int(num) if num % 1 == 0 else round(float(num), 3)
+
+        elif isinstance(value, dict) and "BOOL" in value:
+            result[key] = bool(value["BOOL"])
 
         # Scalar fields
         elif isinstance(value, Decimal):
@@ -43,10 +53,7 @@ def process_item_types(item: dict) -> dict:
 
 
 def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
-    """Create metadata and add it to the database.
-
-    This function is an event handler for s3 ingest bucket.
-    It is also used to ingest data to the DynamoDB table.
+    """Read and format database query.
 
     Parameters
     ----------
@@ -58,6 +65,12 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
         information about the invocation, function,
         and runtime environment.
 
+    Example
+    -------
+    result = {'hit_he_omni_high_en': [0, None],
+    'mag_B_GSE': [[-6.382, -1.353, -5.045],
+    [-2.058, 3.792, -3.989]],
+    'time_tag': ['2025-10-02T07:07:13', '2025-10-02T07:07:17'], ...}
     """
     table_name = os.environ.get("ALGORITHM_TABLE")
     region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
@@ -77,10 +90,8 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     query_kwargs = {"KeyConditionExpression": key_expr}
 
     allowed_params = {
-        "met_start",
-        "met_end",
-        "met_in_utc_start",
-        "met_in_utc_end",
+        "start_time",
+        "end_time",
         "last_modified_start",
         "last_modified_end",
     }
@@ -184,12 +195,12 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     if processed_items:
         keys = processed_items[0].keys()
         result = {
-            key: [item[key] for item in processed_items]
+            key: [item.get(key) for item in processed_items]
             for key in keys
             if key not in ("met", "ttj2000ns", "apid", "last_modified")
         }
         if "met_in_utc" in result:
-            result["time"] = result.pop("met_in_utc")
+            result["time_tag"] = result.pop("met_in_utc")
     else:
         result = {}
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -65,8 +65,8 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
         information about the invocation, function,
         and runtime environment.
 
-    Example
-    -------
+    Example of result:
+    -----------------
     result = {'hit_he_omni_high_en': [0, None],
     'mag_B_GSE': [[-6.382, -1.353, -5.045],
     [-2.058, 3.792, -3.989]],
@@ -90,8 +90,10 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     query_kwargs = {"KeyConditionExpression": key_expr}
 
     allowed_params = {
-        "start_time",
-        "end_time",
+        "time_start",
+        "time_end",
+        "utc_start",
+        "utc_end",
         "last_modified_start",
         "last_modified_end",
     }
@@ -105,7 +107,7 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
             ),
         }
 
-    time_prefixes = {"met", "met_in_utc", "last_modified"}
+    time_prefixes = {"time", "utc", "last_modified"}
     used_time_prefixes = {
         param.split("_start")[0].split("_end")[0]
         for param in params
@@ -118,66 +120,66 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
             "body": json.dumps(
                 {
                     "message": "Cannot query multiple time keys "
-                    "(met, met_in_utc, last_modified)"
+                    "(time, utc, last_modified)"
                 }
             ),
         }
 
     if (
-        ("met_start" in params and "met_end" in params)
-        or ("met_in_utc_start" in params and "met_in_utc_end" in params)
+        ("time_start" in params and "time_end" in params)
+        or ("utc_start" in params and "utc_end" in params)
         or ("last_modified_start" in params and "last_modified_end" in params)
     ):
-        if "met_start" in params:
-            time_key = "met"
-        elif "met_in_utc_start" in params:
-            time_key = "met_in_utc"
+        if "time_start" in params:
+            time_key = "time"
+        elif "utc_start" in params:
+            time_key = "utc"
         else:
             time_key = "last_modified"
 
         start_value = (
             int(params[f"{time_key}_start"])
-            if time_key == "met"
+            if time_key == "time"
             else params[f"{time_key}_start"]
         )
         end_value = (
             int(params[f"{time_key}_end"])
-            if time_key == "met"
+            if time_key == "time"
             else params[f"{time_key}_end"]
         )
 
         key_expr &= Key(time_key).between(start_value, end_value)
 
-        if time_key in {"met_in_utc", "last_modified"}:
+        if time_key == "utc":
+            query_kwargs["IndexName"] = "met_in_utc"
+        if time_key == "last_modified":
             query_kwargs["IndexName"] = time_key
 
     elif (
-        "met_start" in params
-        or "met_in_utc_start" in params
+        "time_start" in params
+        or "utc_start" in params
         or "last_modified_start" in params
     ):
-        if "met_start" in params:
+        if "time_start" in params:
             time_key = "met"
-        elif "met_in_utc_start" in params:
+        elif "utc_start" in params:
             time_key = "met_in_utc"
         else:
             time_key = "last_modified"
 
         start_value = (
             int(params[f"{time_key}_start"])
-            if time_key == "met"
+            if time_key == "time"
             else params[f"{time_key}_start"]
         )
         key_expr &= Key(time_key).gte(start_value)
 
-        if time_key in {"met_in_utc", "last_modified"}:
+        if time_key == "utc":
+            query_kwargs["IndexName"] = "met_in_utc"
+        if time_key == "last_modified":
             query_kwargs["IndexName"] = time_key
 
-    elif (
-        "met_end" in params
-        or "met_in_utc_end" in params
-        or "last_modified_end" in params
-    ):
+    elif "time_end" in params or "utc_end" in params or "last_modified_end" in params:
         return {
             "statusCode": 400,
             "body": json.dumps(
@@ -200,8 +202,12 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
             if key not in ("met", "ttj2000ns", "apid", "last_modified")
         }
         if "met_in_utc" in result:
-            result["time_tag"] = result.pop("met_in_utc")
+            result["time_tag_utc"] = result.pop("met_in_utc")
     else:
         result = {}
+
+    # Append LastEvaluatedKey to the response if more data is available.
+    if "LastEvaluatedKey" in response:
+        result["last_evaluated_key"] = response.get("LastEvaluatedKey")
 
     return {"statusCode": 200, "body": json.dumps(result)}

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -131,28 +131,29 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
         or ("last_modified_start" in params and "last_modified_end" in params)
     ):
         if "time_start" in params:
-            time_key = "time"
+            params_key = "time"
+            time_key = "met"
         elif "utc_start" in params:
-            time_key = "utc"
+            params_key = "utc"
+            time_key = "met_in_utc"
         else:
+            params_key = "last_modified"
             time_key = "last_modified"
 
         start_value = (
-            int(params[f"{time_key}_start"])
-            if time_key == "time"
-            else params[f"{time_key}_start"]
+            int(params[f"{params_key}_start"])
+            if params_key == "time"
+            else params[f"{params_key}_start"]
         )
         end_value = (
-            int(params[f"{time_key}_end"])
-            if time_key == "time"
-            else params[f"{time_key}_end"]
+            int(params[f"{params_key}_end"])
+            if params_key == "time"
+            else params[f"{params_key}_end"]
         )
 
         key_expr &= Key(time_key).between(start_value, end_value)
 
-        if time_key == "utc":
-            query_kwargs["IndexName"] = "met_in_utc"
-        if time_key == "last_modified":
+        if time_key in {"met_in_utc", "last_modified"}:
             query_kwargs["IndexName"] = time_key
 
     elif (
@@ -161,22 +162,23 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
         or "last_modified_start" in params
     ):
         if "time_start" in params:
+            params_key = "time"
             time_key = "met"
         elif "utc_start" in params:
+            params_key = "utc"
             time_key = "met_in_utc"
         else:
+            params_key = "last_modified"
             time_key = "last_modified"
 
         start_value = (
-            int(params[f"{time_key}_start"])
-            if time_key == "time"
-            else params[f"{time_key}_start"]
+            int(params[f"{params_key}_start"])
+            if params_key == "time"
+            else params[f"{params_key}_start"]
         )
         key_expr &= Key(time_key).gte(start_value)
 
-        if time_key == "utc":
-            query_kwargs["IndexName"] = "met_in_utc"
-        if time_key == "last_modified":
+        if time_key in {"met_in_utc", "last_modified"}:
             query_kwargs["IndexName"] = time_key
 
     elif "time_end" in params or "utc_end" in params or "last_modified_end" in params:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -198,11 +198,26 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
 
     if processed_items:
         keys = processed_items[0].keys()
-        result = {
-            key: [item.get(key) for item in processed_items]
-            for key in keys
-            if key not in ("met", "ttj2000ns", "apid", "last_modified")
-        }
+        prefixes_to_remove = (
+            "codice_hi_",
+            "codice_lo_",
+            "hit_",
+            "mag_",
+            "swe_",
+            "swapi_",
+        )
+        result = {}
+        for key in keys:
+            if key in ("met", "ttj2000ns", "apid", "last_modified"):
+                continue
+
+            new_key = key
+            for prefix in prefixes_to_remove:
+                if new_key.startswith(prefix):
+                    new_key = new_key[len(prefix) :]
+                    break
+
+            result[new_key] = [item.get(key) for item in processed_items]
         if "met_in_utc" in result:
             result["time_tag_utc"] = result.pop("met_in_utc")
     else:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import boto3
@@ -150,6 +151,22 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
             else params[f"{params_key}_end"]
         )
 
+        # Raise an exception if the range is too large.
+        if params_key == "met":
+            time_range = end_value - start_value
+        else:
+            start_dt = datetime.fromisoformat(start_value)
+            end_dt = datetime.fromisoformat(end_value)
+            time_range = (end_dt - start_dt).total_seconds()
+
+        if time_range > 3600:
+            return {
+                "statusCode": 400,
+                "body": json.dumps(
+                    {"message": "Query range too large (maximum 1 hour)."}
+                ),
+            }
+
         key_expr &= Key(time_key).between(start_value, end_value)
 
         if time_key in {"met_in_utc", "last_modified"}:
@@ -175,7 +192,17 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
             if params_key == "met"
             else params[f"{params_key}_start"]
         )
-        key_expr &= Key(time_key).gte(start_value)
+
+        # Calculating end time.
+        if params_key == "met":
+            end_value = 3600 + start_value
+        else:
+            start_dt = datetime.fromisoformat(start_value)
+            end_dt = start_dt + timedelta(hours=1)
+            end_value = end_dt.isoformat()
+
+        logger.info(f"Calculated end_value for {params_key}: {end_value}")
+        key_expr &= Key(time_key).between(start_value, end_value)
 
         if time_key in {"met_in_utc", "last_modified"}:
             query_kwargs["IndexName"] = time_key

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -209,7 +209,8 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
         result = {}
 
     # Append LastEvaluatedKey to the response if more data is available.
-    if "LastEvaluatedKey" in response:
-        result["last_evaluated_key"] = response.get("LastEvaluatedKey")
+    last_evaluated_key = response.get("LastEvaluatedKey")
+    if last_evaluated_key:
+        result["last_evaluated_key"] = process_item_types(last_evaluated_key)
 
     return {"statusCode": 200, "body": json.dumps(result)}

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -197,7 +197,7 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     processed_items = [process_item_types(item) for item in items]
 
     if processed_items:
-        keys = processed_items[0].keys()
+        keys = {k for item in processed_items for k in item.keys()}
         prefixes_to_remove = (
             "codice_hi_",
             "codice_lo_",

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -70,7 +70,7 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     result = {'hit_he_omni_high_en': [0, None],
     'mag_B_GSE': [[-6.382, -1.353, -5.045],
     [-2.058, 3.792, -3.989]],
-    'time_tag': ['2025-10-02T07:07:13', '2025-10-02T07:07:17'], ...}
+    'time_tag_utc': ['2025-10-02T07:07:13', '2025-10-02T07:07:17'], ...}
     """
     table_name = os.environ.get("ALGORITHM_TABLE")
     region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -42,7 +42,7 @@ def process_item_types(item: dict) -> dict:
     return result
 
 
-def lambda_handler(event, context):  # noqa: PLR0912
+def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     """Create metadata and add it to the database.
 
     This function is an event handler for s3 ingest bucket.
@@ -186,8 +186,10 @@ def lambda_handler(event, context):  # noqa: PLR0912
         result = {
             key: [item[key] for item in processed_items]
             for key in keys
-            if key not in ("met", "ttj2000ns", "apid")
+            if key not in ("met", "ttj2000ns", "apid", "last_modified")
         }
+        if "met_in_utc" in result:
+            result["time"] = result.pop("met_in_utc")
     else:
         result = {}
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -30,11 +30,11 @@ def process_item_types(item: dict) -> dict:
     for key, value in item.items():
         # Vectors fields
         if isinstance(value, list):
-            result[key] = [int(v) if v % 1 == 0 else float(v) for v in value]
+            result[key] = [int(v) if v % 1 == 0 else round(float(v), 3) for v in value]
 
         # Scalar fields
         elif isinstance(value, Decimal):
-            result[key] = int(value) if value % 1 == 0 else float(value)
+            result[key] = int(value) if value % 1 == 0 else round(float(value), 3)
 
         else:
             result[key] = value
@@ -181,4 +181,14 @@ def lambda_handler(event, context):  # noqa: PLR0912
     items = response.get("Items", [])
     processed_items = [process_item_types(item) for item in items]
 
-    return {"statusCode": 200, "body": json.dumps(processed_items)}
+    if processed_items:
+        keys = processed_items[0].keys()
+        result = {
+            key: [item[key] for item in processed_items]
+            for key in keys
+            if key not in ("met", "ttj2000ns", "apid")
+        }
+    else:
+        result = {}
+
+    return {"statusCode": 200, "body": json.dumps(result)}

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api_formatted.py
@@ -67,8 +67,8 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
 
     Example of result:
     -----------------
-    result = {'hit_he_omni_high_en': [0, None],
-    'mag_B_GSE': [[-6.382, -1.353, -5.045],
+    result = {'he_omni_high_en': [0, None],
+    'B_GSE': [[-6.382, -1.353, -5.045],
     [-2.058, 3.792, -3.989]],
     'time_tag_utc': ['2025-10-02T07:07:13', '2025-10-02T07:07:17'], ...}
     """

--- a/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
+++ b/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
@@ -55,14 +55,14 @@ def test_query_with_met_range(algorithm_table):
     # GET <invoke url>/query?time_start=100&time_end=111
     event = {
         "queryStringParameters": {
-            "time_start": "100",
-            "time_end": "111",
+            "met_start": "100",
+            "met_end": "102",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
     items = json.loads(response["body"])
 
-    expected_data = ["2021-01-01T00:00:00", "2021-01-04T00:00:00"]
+    expected_data = ["2021-01-01T00:00:00"]
 
     assert items["time_tag_utc"] == expected_data
 
@@ -72,7 +72,7 @@ def test_query_with_met_start(algorithm_table):
     # GET <invoke url>/query?time_start=120
     event = {
         "queryStringParameters": {
-            "time_start": "120",
+            "met_start": "120",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -87,13 +87,30 @@ def test_query_with_met_end(algorithm_table):
     # GET <invoke url>/query?met_end=120
     event = {
         "queryStringParameters": {
-            "time_end": "120",
+            "met_end": "120",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
 
     assert response["statusCode"] == 400
     expected_message = {"message": "Cannot query by end time without start time"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_utc_error(algorithm_table):
+    """Test query_with_utc_range."""
+    # GET <invoke url>/query?utc_start=<utc_start>&
+    # utc_end=<utc_end>
+    event = {
+        "queryStringParameters": {
+            "utc_start": "2021-01-01T00:00:00",
+            "utc_end": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {"message": "Query range too large (maximum 1 hour)."}
     assert json.loads(response["body"]) == expected_message
 
 
@@ -104,7 +121,7 @@ def test_query_with_utc_range(algorithm_table):
     event = {
         "queryStringParameters": {
             "utc_start": "2021-01-01T00:00:00",
-            "utc_end": "2021-01-03T00:00:00",
+            "utc_end": "2021-01-01T00:59:00",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -112,8 +129,6 @@ def test_query_with_utc_range(algorithm_table):
 
     expected_utc = [
         "2021-01-01T00:00:00",
-        "2021-01-02T00:00:00",
-        "2021-01-03T00:00:00",
     ]
 
     assert items["time_tag_utc"] == expected_utc
@@ -132,8 +147,6 @@ def test_query_with_utc_start(algorithm_table):
 
     expected_data = [
         "2021-01-02T00:00:00",
-        "2021-01-03T00:00:00",
-        "2021-01-04T00:00:00",
     ]
 
     assert items["time_tag_utc"] == expected_data
@@ -158,8 +171,8 @@ def test_query_no_results(algorithm_table):
     # GET <invoke url>/query?time_start=<time_start>&met_end=<met_end>
     event = {
         "queryStringParameters": {
-            "time_start": "200",
-            "time_end": "300",
+            "met_start": "200",
+            "met_end": "300",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -172,8 +185,8 @@ def test_query_with_multiple_filters(algorithm_table):
     # GET <invoke url>/query?time_start=100&time_end=130&product_name=codicelo_product_1
     event = {
         "queryStringParameters": {
-            "time_start": "100",
-            "time_end": "130",
+            "met_start": "100",
+            "met_end": "130",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -188,15 +201,15 @@ def test_query_with_different_time_queries(algorithm_table):
     # utc_start=2021-01-02T00:00:00.
     event = {
         "queryStringParameters": {
-            "time_start": "100",
-            "time_end": "130",
+            "met_start": "100",
+            "met_end": "130",
             "utc_start": "2021-01-02T00:00:00",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
     assert response["statusCode"] == 400
     expected_message = {
-        "message": "Cannot query multiple time keys (time, utc, last_modified)"
+        "message": "Cannot query multiple time keys (met, utc, last_modified)"
     }
     assert json.loads(response["body"]) == expected_message
 
@@ -232,7 +245,7 @@ def test_query_with_mixed_parameters(algorithm_table):
     # GET <invoke url>/query?time_start=100&utc_end=2021-01-02T00:00:00.
     event = {
         "queryStringParameters": {
-            "time_start": "100",
+            "met_start": "100",
             "utc_end": "2021-01-02T00:00:00",
         }
     }
@@ -240,7 +253,7 @@ def test_query_with_mixed_parameters(algorithm_table):
 
     assert response["statusCode"] == 400
     expected_message = {
-        "message": "Cannot query multiple time keys (time, utc, last_modified)"
+        "message": "Cannot query multiple time keys (met, utc, last_modified)"
     }
     assert json.loads(response["body"]) == expected_message
 

--- a/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
+++ b/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
@@ -1,0 +1,274 @@
+"""Tests for the I-ALiRT DB Query API Lambda function."""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from sds_data_manager.lambda_code.IAlirtCode import ialirt_db_query_api_formatted
+
+
+@pytest.fixture
+def algorithm_table(setup_dynamodb):
+    """Return the mocked imap-algorithm-table and populate it with sample data."""
+    table = setup_dynamodb["algorithm_table"]
+
+    sample_data = [
+        {
+            "apid": 478,
+            "met": 101,
+            "last_modified": "2021-01-01T00:00:00",
+            "met_in_utc": "2021-01-01T00:00:00",
+            "data": "item1",
+        },
+        {
+            "apid": 478,
+            "met": 120,
+            "last_modified": "2021-01-02T00:00:00",
+            "met_in_utc": "2021-01-02T00:00:00",
+            "data": "item2",
+        },
+        {
+            "apid": 478,
+            "met": 130,
+            "last_modified": "2021-01-03T00:00:00",
+            "met_in_utc": "2021-01-03T00:00:00",
+            "data": "item3",
+        },
+        {
+            "apid": 478,
+            "met": 110,
+            "last_modified": "2021-01-04T00:00:00",
+            "met_in_utc": "2021-01-04T00:00:00",
+            "data": "item4",
+        },
+    ]
+
+    for item in sample_data:
+        table.put_item(Item=item)
+
+    return table
+
+
+def test_query_with_met_range(algorithm_table):
+    """Test query with met range."""
+    # GET <invoke url>/query?met_start=100&met_end=111
+    event = {
+        "queryStringParameters": {
+            "met_start": "100",
+            "met_end": "111",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+    items = json.loads(response["body"])
+
+    expected_data = ["2021-01-01T00:00:00", "2021-01-04T00:00:00"]
+
+    assert items["time"] == expected_data
+
+
+def test_query_with_met_start(algorithm_table):
+    """Test query with met start."""
+    # GET <invoke url>/query?met_start=120
+    event = {
+        "queryStringParameters": {
+            "met_start": "120",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+    items = json.loads(response["body"])
+
+    expected_data = ["2021-01-02T00:00:00", "2021-01-03T00:00:00"]
+    assert items["time"] == expected_data
+
+
+def test_query_with_met_end(algorithm_table):
+    """Test query with met end."""
+    # GET <invoke url>/query?met_end=120
+    event = {
+        "queryStringParameters": {
+            "met_end": "120",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {"message": "Cannot query by end time without start time"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_utc_range(algorithm_table):
+    """Test query_with_utc_range."""
+    # GET <invoke url>/query?met_in_utc_start=<met_in_utc_start>&
+    # met_in_utc_end=<met_in_utc_end>
+    event = {
+        "queryStringParameters": {
+            "met_in_utc_start": "2021-01-01T00:00:00",
+            "met_in_utc_end": "2021-01-03T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+    items = json.loads(response["body"])
+
+    expected_utc = [
+        "2021-01-01T00:00:00",
+        "2021-01-02T00:00:00",
+        "2021-01-03T00:00:00",
+    ]
+
+    assert items["time"] == expected_utc
+
+
+def test_query_with_utc_start(algorithm_table):
+    """Test with insert time start."""
+    # GET <invoke url>/query?utc_start=<utc_start>
+    event = {
+        "queryStringParameters": {
+            "met_in_utc_start": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+    items = json.loads(response["body"])
+
+    expected_data = [
+        "2021-01-02T00:00:00",
+        "2021-01-03T00:00:00",
+        "2021-01-04T00:00:00",
+    ]
+
+    assert items["time"] == expected_data
+
+
+def test_query_with_utc_end(algorithm_table):
+    """Test query with insert time end."""
+    # GET <invoke url>/query?met_in_utc_end=<met_in_utc_end>
+    event = {
+        "queryStringParameters": {
+            "met_in_utc_end": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+    assert response["statusCode"] == 400
+    expected_message = {"message": "Cannot query by end time without start time"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_no_results(algorithm_table):
+    """Test query if there are no results."""
+    # GET <invoke url>/query?met_start=<met_start>&met_end=<met_end>
+    event = {
+        "queryStringParameters": {
+            "met_start": "200",
+            "met_end": "300",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == {}
+
+
+def test_query_with_multiple_filters(algorithm_table):
+    """Test query with multiple filters."""
+    # GET <invoke url>/query?met_start=100&met_end=130&product_name=codicelo_product_1
+    event = {
+        "queryStringParameters": {
+            "met_start": "100",
+            "met_end": "130",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+
+    items = json.loads(response["body"])
+    assert len(items) == 2
+
+
+def test_query_with_different_time_queries(algorithm_table):
+    """Test query API with multiple filters."""
+    # GET <invoke url>/query?met_start=100&met_end=130&product_name=hit*&
+    # met_in_utc_start=2021-01-02T00:00:00.
+    event = {
+        "queryStringParameters": {
+            "met_start": "100",
+            "met_end": "130",
+            "met_in_utc_start": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+    assert response["statusCode"] == 400
+    expected_message = {
+        "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
+    }
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_invalid_parameters(algorithm_table):
+    """Test query with invalid parameters."""
+    # GET <invoke url>/query?met_bad=100.
+    event = {
+        "queryStringParameters": {
+            "met_bad": "100",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {"message": "Unexpected parameters: met_bad"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_no_parameters(algorithm_table):
+    """Test query with no parameters."""
+    # GET <invoke url>/query.
+    event = {"queryStringParameters": None}
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {"message": "No query parameters provided"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_mixed_parameters(algorithm_table):
+    """Test query with mixed parameters."""
+    # GET <invoke url>/query?met_start=100&met_in_utc_end=2021-01-02T00:00:00.
+    event = {
+        "queryStringParameters": {
+            "met_start": "100",
+            "met_in_utc_end": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {
+        "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
+    }
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_process_item_types():
+    """Test process_item_types function."""
+    items = [
+        {
+            "apid": Decimal("478"),
+            "met": Decimal("123456789"),
+            "ttj2000ns": Decimal("123456789000000"),
+            "mag_B_GSE": [Decimal("0.0"), Decimal("0.1"), Decimal("0.2")],
+            "mag_B_magnitude": Decimal("0.22"),
+            "met_in_utc": "2025-06-20T08:00:00",  # string should stay unchanged
+        }
+    ]
+
+    processed_items = [
+        ialirt_db_query_api_formatted.process_item_types(item) for item in items
+    ]
+
+    assert processed_items == [
+        {
+            "apid": 478,
+            "met": 123456789,
+            "ttj2000ns": 123456789000000,
+            "mag_B_GSE": [0.0, 0.1, 0.2],
+            "mag_B_magnitude": 0.22,
+            "met_in_utc": "2025-06-20T08:00:00",
+        }
+    ]

--- a/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
+++ b/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
@@ -52,11 +52,11 @@ def algorithm_table(setup_dynamodb):
 
 def test_query_with_met_range(algorithm_table):
     """Test query with met range."""
-    # GET <invoke url>/query?met_start=100&met_end=111
+    # GET <invoke url>/query?time_start=100&time_end=111
     event = {
         "queryStringParameters": {
-            "met_start": "100",
-            "met_end": "111",
+            "time_start": "100",
+            "time_end": "111",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -64,22 +64,22 @@ def test_query_with_met_range(algorithm_table):
 
     expected_data = ["2021-01-01T00:00:00", "2021-01-04T00:00:00"]
 
-    assert items["time"] == expected_data
+    assert items["time_tag_utc"] == expected_data
 
 
 def test_query_with_met_start(algorithm_table):
     """Test query with met start."""
-    # GET <invoke url>/query?met_start=120
+    # GET <invoke url>/query?time_start=120
     event = {
         "queryStringParameters": {
-            "met_start": "120",
+            "time_start": "120",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
     items = json.loads(response["body"])
 
     expected_data = ["2021-01-02T00:00:00", "2021-01-03T00:00:00"]
-    assert items["time"] == expected_data
+    assert items["time_tag_utc"] == expected_data
 
 
 def test_query_with_met_end(algorithm_table):
@@ -87,7 +87,7 @@ def test_query_with_met_end(algorithm_table):
     # GET <invoke url>/query?met_end=120
     event = {
         "queryStringParameters": {
-            "met_end": "120",
+            "time_end": "120",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -99,12 +99,12 @@ def test_query_with_met_end(algorithm_table):
 
 def test_query_with_utc_range(algorithm_table):
     """Test query_with_utc_range."""
-    # GET <invoke url>/query?met_in_utc_start=<met_in_utc_start>&
-    # met_in_utc_end=<met_in_utc_end>
+    # GET <invoke url>/query?utc_start=<utc_start>&
+    # utc_end=<utc_end>
     event = {
         "queryStringParameters": {
-            "met_in_utc_start": "2021-01-01T00:00:00",
-            "met_in_utc_end": "2021-01-03T00:00:00",
+            "utc_start": "2021-01-01T00:00:00",
+            "utc_end": "2021-01-03T00:00:00",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -116,7 +116,7 @@ def test_query_with_utc_range(algorithm_table):
         "2021-01-03T00:00:00",
     ]
 
-    assert items["time"] == expected_utc
+    assert items["time_tag_utc"] == expected_utc
 
 
 def test_query_with_utc_start(algorithm_table):
@@ -124,7 +124,7 @@ def test_query_with_utc_start(algorithm_table):
     # GET <invoke url>/query?utc_start=<utc_start>
     event = {
         "queryStringParameters": {
-            "met_in_utc_start": "2021-01-02T00:00:00",
+            "utc_start": "2021-01-02T00:00:00",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -136,15 +136,15 @@ def test_query_with_utc_start(algorithm_table):
         "2021-01-04T00:00:00",
     ]
 
-    assert items["time"] == expected_data
+    assert items["time_tag_utc"] == expected_data
 
 
 def test_query_with_utc_end(algorithm_table):
     """Test query with insert time end."""
-    # GET <invoke url>/query?met_in_utc_end=<met_in_utc_end>
+    # GET <invoke url>/query?utc_end=<utc_end>
     event = {
         "queryStringParameters": {
-            "met_in_utc_end": "2021-01-02T00:00:00",
+            "utc_end": "2021-01-02T00:00:00",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -155,11 +155,11 @@ def test_query_with_utc_end(algorithm_table):
 
 def test_query_no_results(algorithm_table):
     """Test query if there are no results."""
-    # GET <invoke url>/query?met_start=<met_start>&met_end=<met_end>
+    # GET <invoke url>/query?time_start=<time_start>&met_end=<met_end>
     event = {
         "queryStringParameters": {
-            "met_start": "200",
-            "met_end": "300",
+            "time_start": "200",
+            "time_end": "300",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -169,11 +169,11 @@ def test_query_no_results(algorithm_table):
 
 def test_query_with_multiple_filters(algorithm_table):
     """Test query with multiple filters."""
-    # GET <invoke url>/query?met_start=100&met_end=130&product_name=codicelo_product_1
+    # GET <invoke url>/query?time_start=100&time_end=130&product_name=codicelo_product_1
     event = {
         "queryStringParameters": {
-            "met_start": "100",
-            "met_end": "130",
+            "time_start": "100",
+            "time_end": "130",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
@@ -184,19 +184,19 @@ def test_query_with_multiple_filters(algorithm_table):
 
 def test_query_with_different_time_queries(algorithm_table):
     """Test query API with multiple filters."""
-    # GET <invoke url>/query?met_start=100&met_end=130&product_name=hit*&
-    # met_in_utc_start=2021-01-02T00:00:00.
+    # GET <invoke url>/query?time_start=100&time_end=130&product_name=hit*&
+    # utc_start=2021-01-02T00:00:00.
     event = {
         "queryStringParameters": {
-            "met_start": "100",
-            "met_end": "130",
-            "met_in_utc_start": "2021-01-02T00:00:00",
+            "time_start": "100",
+            "time_end": "130",
+            "utc_start": "2021-01-02T00:00:00",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
     assert response["statusCode"] == 400
     expected_message = {
-        "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
+        "message": "Cannot query multiple time keys (time, utc, last_modified)"
     }
     assert json.loads(response["body"]) == expected_message
 
@@ -229,18 +229,18 @@ def test_query_with_no_parameters(algorithm_table):
 
 def test_query_with_mixed_parameters(algorithm_table):
     """Test query with mixed parameters."""
-    # GET <invoke url>/query?met_start=100&met_in_utc_end=2021-01-02T00:00:00.
+    # GET <invoke url>/query?time_start=100&utc_end=2021-01-02T00:00:00.
     event = {
         "queryStringParameters": {
-            "met_start": "100",
-            "met_in_utc_end": "2021-01-02T00:00:00",
+            "time_start": "100",
+            "utc_end": "2021-01-02T00:00:00",
         }
     }
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
 
     assert response["statusCode"] == 400
     expected_message = {
-        "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
+        "message": "Cannot query multiple time keys (time, utc, last_modified)"
     }
     assert json.loads(response["body"]) == expected_message
 

--- a/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
+++ b/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
@@ -276,7 +276,7 @@ def test_process_item_types():
 
 def test_last_evaluated():
     """Test last evaluated response."""
-    last_evaluated_key = {"apid": {"N": "478"}, "met": {"N": "497034344"}}
+    last_evaluated_key = {"apid": Decimal("478"), "met": Decimal("497034344")}
 
     processed_item = ialirt_db_query_api_formatted.process_item_types(
         last_evaluated_key

--- a/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
+++ b/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
@@ -19,28 +19,28 @@ def algorithm_table(setup_dynamodb):
             "met": 101,
             "last_modified": "2021-01-01T00:00:00",
             "met_in_utc": "2021-01-01T00:00:00",
-            "data": "item1",
+            "codice_hi_data": "item1",
         },
         {
             "apid": 478,
             "met": 120,
             "last_modified": "2021-01-02T00:00:00",
             "met_in_utc": "2021-01-02T00:00:00",
-            "data": "item2",
+            "codice_hi_data": "item2",
         },
         {
             "apid": 478,
             "met": 130,
             "last_modified": "2021-01-03T00:00:00",
             "met_in_utc": "2021-01-03T00:00:00",
-            "data": "item3",
+            "mag_data_product": "item3",
         },
         {
             "apid": 478,
             "met": 110,
             "last_modified": "2021-01-04T00:00:00",
             "met_in_utc": "2021-01-04T00:00:00",
-            "data": "item4",
+            "mag_data_product": "item4",
         },
     ]
 

--- a/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
+++ b/tests/lambda_endpoints/test_ialirt_db_query_api_formatted.py
@@ -179,7 +179,7 @@ def test_query_with_multiple_filters(algorithm_table):
     response = ialirt_db_query_api_formatted.lambda_handler(event, context=None)
 
     items = json.loads(response["body"])
-    assert len(items) == 2
+    assert len(items["data"]) == 4
 
 
 def test_query_with_different_time_queries(algorithm_table):
@@ -272,3 +272,16 @@ def test_process_item_types():
             "met_in_utc": "2025-06-20T08:00:00",
         }
     ]
+
+
+def test_last_evaluated():
+    """Test last evaluated response."""
+    last_evaluated_key = {"apid": {"N": "478"}, "met": {"N": "497034344"}}
+
+    processed_item = ialirt_db_query_api_formatted.process_item_types(
+        last_evaluated_key
+    )
+    assert processed_item == {
+        "apid": 478,
+        "met": 497034344,
+    }


### PR DESCRIPTION
# Change Summary

## Overview
Improve the api used for DynamoDB responses.

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
- ialirt_db_query_api_formatted.py
   - The same as ialirt_db_query_api.py but with the following suggestions by Greg: 
   - Return arrays of values instead of individual items
   - A user doesn't need ttj2000ns, last_modified, met, etc. 
   - met_in_utc isn't super user friendly
   - Trim the floats to a few decimal places. 
   - make a new endpoint so you can keep the one that is currently there and deploy a new one alongside so there is no downtime for the LaTiS folks. 

## Updated Files
- ialirt_api_manager_construct.py
   - add new endpoint to construct

## Tests
test_ialirt_db_query_api_formatted.py