### PR TITLE
Change how start date is calculated for repoint table triggers

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -681,6 +681,56 @@ def calculate_pointing_date_range(session, pointing_id):
     return start_date, end_date
 
 
+def calculate_repoint_table_date_range(session, file_obj):
+    """Calculate the date range for a repoint-table.
+
+    The end date can easily be gotten from the filename. In order to determine
+    the start date, we query the database and use the end date from the previous
+    repoint table.
+
+    NOTE:
+    Repoint file is used to kick off the pointing_attitude job only.
+    This date range is used to query attitude kernel file(s). If
+    other jobs become dependent on triggering off of the repoint file,
+    please revisit this logic.
+
+
+    Parameters
+    ----------
+    session : sqlalchemy.orm.Session
+        Database session.
+    file_obj : SPICEFilePath
+        Repoint table file object.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the start date and end date in the format YYYYMMDD.
+    """
+    # Query the pointing table to find the pointing information.
+    end_date = file_obj.spice_metadata["end_date"]
+    previous_entries = (
+        session.query(models.RepointFiles)
+        .filter(models.RepointFiles.end_date <= end_date)
+        .order_by(models.RepointFiles.end_date, models.RepointFiles.version)
+        .all()
+    )
+    # Check if a previous entry exists
+    if len(previous_entries) < 2:
+        # No previous entry exists. Use end_date minus one day as start date
+        start_date = end_date - datetime.timedelta(days=1)
+    else:
+        start_date = previous_entries[-2].end_date
+
+    start_date = start_date.strftime("%Y%m%d")
+    end_date = end_date.strftime("%Y%m%d")
+    logger.debug(
+        f"repoint table date range, start_date: {start_date}, end_date: {end_date}"
+    )
+
+    return start_date, end_date
+
+
 def determine_date_range(session, file_obj):
     """Determine the start and end dates based on the file type.
 
@@ -701,14 +751,7 @@ def determine_date_range(session, file_obj):
     if isinstance(file_obj, SPICEFilePath):
         file_type = file_obj.spice_metadata["type"]
         if file_type == "repoint":
-            # NOTE:
-            # Repoint file is used to kicks off pointing_attitude job only.
-            # This date range is used to query attitude kernel file(s). If
-            # Other is dependent on the repoint file, please revisit this logic.
-            start_date = (
-                file_obj.spice_metadata["end_date"] - datetime.timedelta(days=1)
-            ).strftime("%Y%m%d")
-            end_date = file_obj.spice_metadata["end_date"].strftime("%Y%m%d")
+            start_date, end_date = calculate_repoint_table_date_range(session, file_obj)
         else:
             # Convert datetime object to string of format YYYYMMDD
             start_date = file_obj.spice_metadata["start_date"].strftime("%Y%m%d")

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -688,7 +688,8 @@ def calculate_repoint_table_date_range(session, file_obj):
     the start date, we query the database and use the end date from the previous
     repoint table.
 
-    NOTE:
+    Notes
+    -----
     Repoint file is used to kick off the pointing_attitude job only.
     This date range is used to query attitude kernel file(s). If
     other jobs become dependent on triggering off of the repoint file,

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1955,6 +1955,12 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
                 version="03",
                 ingestion_date=datetime.now(),
             ),
+            RepointFiles(
+                file_path="/path/to/imap_2000_060_01.repoint.csv",
+                end_date=datetime(2000, 2, 25),
+                version="03",
+                ingestion_date=datetime.now(),
+            ),
             PointingTable(
                 pointing_id=47,
                 pointing_start_utc=datetime(2000, 2, 24, 0, 0, 0),
@@ -1996,6 +2002,26 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
     file_obj = imap_data_access.ScienceFilePath(filename)
     non_repoint_date_range = determine_date_range(session, file_obj)
     assert non_repoint_date_range == ("20260926", "20260926")
+
+    # Check that with no previous repoint file, start date is
+    # end_date - 1 day
+    filename = "imap_2000_055_01.repoint.csv"
+    file_obj = imap_data_access.SPICEFilePath(filename)
+    repoint_date_range = determine_date_range(session, file_obj)
+    assert repoint_date_range == ("20000223", "20000224")
+
+    # Check that correct start date is returned when there is a previous
+    # repoint file.
+    # Last repoint file the same day as end date
+    filename = "imap_2000_056_03.repoint.csv"
+    file_obj = imap_data_access.SPICEFilePath(filename)
+    repoint_date_range = determine_date_range(session, file_obj)
+    assert repoint_date_range == ("20000225", "20000225")
+    # Last repoint several days before end date
+    filename = "imap_2000_060_01.repoint.csv"
+    file_obj = imap_data_access.SPICEFilePath(filename)
+    repoint_date_range = determine_date_range(session, file_obj)
+    assert repoint_date_range == ("20000225", "20000229")
 
     # Add files other needed for the pointing attitude job
     session.add_all(
@@ -2093,11 +2119,11 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
                     "--descriptor",
                     "pointing-attitude",
                     "--start-date",
-                    "20000224",
+                    "20000225",
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_spacecraft_l1a_pointing-attitude-60996159_20000224_v001.json",
+                    "imap_spacecraft_l1a_pointing-attitude-12ca6ae0_20000225_v001.json",
                     "--upload-to-sdc",
                 ]
             },


### PR DESCRIPTION
# Change Summary

## Overview
This updates how the start_date is calculated for repoint table files in batch starter.
I identified an issue with the current implementation where we would miss a day when generating the pointing attitude kernel. This implementation is intended to make sure that the current and previous attitude history kernels are included in the dependencies for the job that gets triggered.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - New function `calculate_repoint_table_date_range` that queries the DB and gets the end date from the previous repoint file as the start date for the new file.
- tests/lambda_endpoints/test_batch_starter.py
   - Directly test that the correct start/end date are returned from `determine_date_range` for repoint files
   - Update expected job parameters to agree with latest change.

Closes: #903 
