### PR TITLE
Packet download cron based

### DIFF
--- a/sds_data_manager/constructs/packet_downloader_lambda_construct.py
+++ b/sds_data_manager/constructs/packet_downloader_lambda_construct.py
@@ -2,13 +2,12 @@
 
 import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_events
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_s3 as s3
-from aws_cdk import aws_s3_notifications as s3n
 from aws_cdk import aws_secretsmanager as secretsmanager
 from aws_cdk import aws_ssm as ssm
 from constructs import Construct
-from imap_data_access import SPICEFilePath
 
 
 class PacketDownloaderLambda(Construct):
@@ -71,6 +70,7 @@ class PacketDownloaderLambda(Construct):
             environment={
                 "IMAP_DATA_ACCESS_URL": data_access_url,
                 "SSM_API_KEY_PARAMETER": "/imap-sdc/batch-jobs/api-key",
+                "S3_BUCKET": data_bucket.bucket_name,
             },
         )
 
@@ -96,11 +96,12 @@ class PacketDownloaderLambda(Construct):
         )
         api_key_parameter.grant_read(packet_lambda)
 
-        # Notify the lambda whenever a new file matching our repoint filename is added
-        data_bucket.add_event_notification(
-            s3.EventType.OBJECT_CREATED,
-            s3n.LambdaDestination(packet_lambda),  # Lambda notification
-            s3.NotificationKeyFilter(
-                prefix=f"{SPICEFilePath._dir_prefix}/repoint/imap_",
-            ),
+        # Trigger the lambda on a schedule (every 6 hours)
+        rule = aws_events.Rule(
+            self,
+            "PacketDownloaderScheduleRule",
+            # Every 6 hours at 5 minutes past the hour
+            # 00:00 -> 06:00, 06:00 -> 12:00, 12:00 -> 18:00, 18:00 -> 00:00
+            schedule=cdk.aws_events.Schedule.cron(minute="5", hour="*/6"),
         )
+        rule.add_target(cdk.aws_events_targets.LambdaFunction(packet_lambda))

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
@@ -2,12 +2,14 @@
 
 import logging
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import boto3
 import imap_data_access
 from imap_data_access import SPICEFilePath, webpoda
 
+S3_BUCKET = os.environ["S3_BUCKET"]
 S3_CLIENT = boto3.client("s3")
 # We need to access the webpoda-api-key
 SECRETS_MANAGER = boto3.client("secretsmanager")
@@ -22,87 +24,8 @@ else:
 logger = logging.getLogger(__name__)
 
 
-def get_two_most_recent_contact_times(bucket):
-    """Retrieve the two most recent file upload times.
-
-    This is an approximation of Earth Received Times (ERT) to indicate when we should
-    be querying for data. The repointing files will be delivered to us after a contact.
-    So we will be querying for data between when a previous repointing file was uploaded
-    and the most recent one. It is a broader window than we need, but is a rough guess
-    with the information we have in an attempt to bracket the packet lookups.
-
-    Parameters
-    ----------
-    bucket : str
-        The name of the S3 bucket to search for repointing files.
-
-    Returns
-    -------
-    list or None
-        A list of the two most recent file upload times.
-        None if there are less than 2 repointing files available.
-    """
-    paginator = S3_CLIENT.get_paginator("list_objects_v2")
-    # In case we have more than 1000 of these files (~3 years)
-    pages = paginator.paginate(
-        Bucket=bucket, Prefix=f"{SPICEFilePath._dir_prefix}/repoint/imap_"
-    )
-
-    repointing_file_times = []
-    for page in pages:
-        if "Contents" not in page:
-            continue
-
-        # Process objects in the page and keep only the latest two
-        for obj in page["Contents"]:
-            # We want last-modified time to know when these files were uploaded
-            repointing_file_times.append(obj["LastModified"])
-
-    if len(repointing_file_times) == 0:
-        # Nothing in the bucket yet, query from the start of the mission to right now.
-        logger.warning("No repointing files found")
-        return None
-    elif len(repointing_file_times) == 1:
-        # Only one repointing file, so we can't bracket a contact yet.
-        # Use the first launch opportunity as an initial start time,
-        # and the time this repointing file landed as the end time to
-        # brack the queries with.
-        logger.warning("Only one repointing file found, using the start of the mission")
-        return ["2025-09-23T00:00:00.000Z", repointing_file_times[0]]
-
-    # We only want the latest two times
-    return sorted(repointing_file_times)[-2:]
-
-
-def lambda_handler(event, context):
-    """Lambda handler to download raw packet data and create L0 files.
-
-    The lambda function will be triggered by an S3 event when a new
-    repointing file is uploaded to the S3 bucket. This means a contact
-    has finished and the other SPICE / packet files are available now.
-
-    Parameters
-    ----------
-    event : dict
-        The JSON formatted document with the source s3 event (repointing file).
-    context : obj
-        The context object for the lambda function
-    """
-    logger.info("Received event: %s", event)
-    # Extract bucket name and key from event
-    record = event["Records"][0]
-    bucket_name = record["s3"]["bucket"]["name"]
-    repointing_key = record["s3"]["object"]["key"]
-    repointing_file = "/tmp/" + repointing_key.split("/")[-1]  # noqa: S108
-
-    times = get_two_most_recent_contact_times(bucket_name)
-    if times is None:
-        return {
-            "statusCode": 500,
-            "body": "There were fewer than 2 repointing files available.",
-        }
-    start_time, end_time = times
-
+def setup_environment():
+    """Get secrets and set necessary config values."""
     response = SECRETS_MANAGER.get_secret_value(SecretId="webpoda-token")
     if "SecretString" not in response:
         return {
@@ -127,15 +50,82 @@ def lambda_handler(event, context):
 
     imap_data_access.config["DATA_DIR"] = Path("/tmp")  # noqa: S108
 
+
+def get_latest_repoint_file():
+    """Retrieve the latest repointing file from S3.
+
+    If we want to connect to the database later, we could use the RepointingFile
+    database table to get this value instead.
+
+    Returns
+    -------
+    str or None
+        The string of the s3 key of the latest repointing file.
+        None if there are no repointing files.
+    """
+    paginator = S3_CLIENT.get_paginator("list_objects_v2")
+    # In case we have more than 1000 of these files (~3 years)
+    # Paginate through all objects in the repoint directory
+    pages = paginator.paginate(
+        Bucket=S3_BUCKET, Prefix=f"{SPICEFilePath._dir_prefix}/repoint/imap_"
+    )
+
+    # Collect all file keys
+    all_files = []
+    for page in pages:
+        if "Contents" in page:
+            all_files.extend([obj["Key"] for obj in page["Contents"]])
+
+    if not all_files:
+        logger.warning("No files found in the repoint directory.")
+        return None
+
+    # Sort files by key (filename); adjust if you want to sort by LastModified instead
+    last_file = sorted(all_files)[-1]
+    logger.info(f"Last file in directory: {last_file}")
+    return last_file
+
+
+def lambda_handler(event, context):
+    """Lambda handler to download raw packet data and create L0 files.
+
+    The lambda function is triggered based upon a cron job indicating new
+    data is available and should be fetched. Currently, this is downloading
+    6-hours of data on a cron-based schedule. In the future, this should be
+    updated to be triggered based upon the arrival of files or notifications
+    about the end of contacts and a database tracking what data has been
+    downloaded.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the source s3 event.
+    context : obj
+        The context object for the lambda function
+    """
+    setup_environment()
+
+    repointing_key = get_latest_repoint_file()
+    imap_data_access.config["DATA_DIR"]
+    repointing_file = imap_data_access.config["DATA_DIR"] / Path(repointing_key).name
     # Download the repointing file from S3 for use in the repointing downloads
     S3_CLIENT.download_file(
-        Bucket=bucket_name,
+        Bucket=S3_BUCKET,
         Key=repointing_key,
         Filename=repointing_file,
     )
 
     # ENA imagers group by repointing
     repointing_instruments = {"glows", "hi", "lo", "ultra"}
+
+    # TODO: Update start_time and end_time based upon the actual downlink times
+    #       once those come in. Currently it is every 6-hours on a cron schedule.
+    now = datetime.now(timezone.utc)
+    # Floor to the previous 6-hour mark
+    end_time = now.replace(minute=0, second=0, microsecond=0)
+    end_time = end_time - timedelta(hours=end_time.hour % 6)
+    start_time = end_time - timedelta(hours=6)
+    logger.info(f"Downloading data from {start_time} to {end_time}")
 
     for instrument in webpoda.INSTRUMENT_APIDS:
         logger.info("Downloading data for instrument: %s", instrument)

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
@@ -15,8 +15,10 @@ SECRETS_MANAGER = boto3.client("secretsmanager")
 SSM_CLIENT = boto3.client("ssm")
 
 # Logger setup
-# Set default logging level to INFO, to also capture INFO for the underlying downloaders
-logging.basicConfig(level=logging.INFO)
+if len(logging.getLogger().handlers) > 0:
+    logging.getLogger().setLevel(logging.INFO)
+else:
+    logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
The event based approach was too simplistic and didn't account for
multiple files arriving. For now, people want their data sooner, so
run the data retrieval every 6-hours and create packet files as
needed during those periods only if there was data received on the
ground. This could lead to more version bumps than necessary, but
tries to strike a reasonable position of not having to wait too
long to get packets either.