### PR TITLE
MNT: Bump imap-data-access version to 0.36.0

### DIFF
--- a/lambda_layer/database/requirements.txt
+++ b/lambda_layer/database/requirements.txt
@@ -153,9 +153,9 @@ greenlet==3.2.2 ; python_version < "3.14" and (platform_machine == "aarch64" or 
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.35.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:a483b127ba7650b43990c9bdaeebdc3e06e6f6dda0ebb8a6a91d0f015c02fe28 \
-    --hash=sha256:df4b7061a808f5859da0a49a39fc0ae5d40979e178bc06ec346e3c260015c0f0
+imap-data-access==0.36.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:e221c55395bc3a1163432110b67ec544566f87e1e332bd3da2c9f833c765136c \
+    --hash=sha256:edf8a57c89759bcf40979b290e5fa368f71b34094d757c203d1086ad57818a79
 psycopg2-binary==2.9.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:04392983d0bb89a8717772a193cfaac58871321e3ec69514e1c4e0d4957b5aff \
     --hash=sha256:056470c3dc57904bbf63d6f534988bafc4e970ffd50f6271fc4ee7daad9498a5 \
@@ -169,6 +169,7 @@ psycopg2-binary==2.9.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:245159e7ab20a71d989da00f280ca57da7641fa2cdcf71749c193cea540a74f7 \
     --hash=sha256:26540d4a9a4e2b096f1ff9cce51253d0504dca5a85872c7f7be23be5a53eb18d \
     --hash=sha256:270934a475a0e4b6925b5f804e3809dd5f90f8613621d062848dd82f9cd62007 \
+    --hash=sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142 \
     --hash=sha256:2ad26b467a405c798aaa1458ba09d7e2b6e5f96b1ce0ac15d82fd9f95dc38a92 \
     --hash=sha256:2b3d2491d4d78b6b14f76881905c7a8a8abcf974aad4a8a0b065273a0ed7a2cb \
     --hash=sha256:2ce3e21dc3437b1d960521eca599d57408a695a0d3c26797ea0f72e834c7ffe5 \

--- a/lambda_layer/spice/requirements.txt
+++ b/lambda_layer/spice/requirements.txt
@@ -97,9 +97,9 @@ charset-normalizer==3.4.2 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.35.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:a483b127ba7650b43990c9bdaeebdc3e06e6f6dda0ebb8a6a91d0f015c02fe28 \
-    --hash=sha256:df4b7061a808f5859da0a49a39fc0ae5d40979e178bc06ec346e3c260015c0f0
+imap-data-access==0.36.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:e221c55395bc3a1163432110b67ec544566f87e1e332bd3da2c9f833c765136c \
+    --hash=sha256:edf8a57c89759bcf40979b290e5fa368f71b34094d757c203d1086ad57818a79
 numpy==2.2.6 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff \
     --hash=sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47 \

--- a/poetry.lock
+++ b/poetry.lock
@@ -890,13 +890,13 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.35.0"
+version = "0.36.0"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap_data_access-0.35.0-py3-none-any.whl", hash = "sha256:df4b7061a808f5859da0a49a39fc0ae5d40979e178bc06ec346e3c260015c0f0"},
-    {file = "imap_data_access-0.35.0.tar.gz", hash = "sha256:a483b127ba7650b43990c9bdaeebdc3e06e6f6dda0ebb8a6a91d0f015c02fe28"},
+    {file = "imap_data_access-0.36.0-py3-none-any.whl", hash = "sha256:e221c55395bc3a1163432110b67ec544566f87e1e332bd3da2c9f833c765136c"},
+    {file = "imap_data_access-0.36.0.tar.gz", hash = "sha256:edf8a57c89759bcf40979b290e5fa368f71b34094d757c203d1086ad57818a79"},
 ]
 
 [package.dependencies]
@@ -1653,6 +1653,7 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
+    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -2547,4 +2548,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "c6845cf12e8e939bba2d973c29d95f4416510bc8e4b01262abb9c5f51b2b53a7"
+content-hash = "a790e25c5044ecf7b159b9ae8ab393bacedb9e1165cb7a2de70e6c08837e6a4a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ python = ">=3.10,<4"
 # WARNING - Please run this command when updateing `imap-data-access` to ensure that
 # the correct version and hash are used:
 #   poetry export -f requirements.txt -o lambda_layer/database/requirements.txt --with layer-database
-imap-data-access = ">=0.35.0"
+imap-data-access = ">=0.36.0"
 
 # Optional dependencies - install with `poetry install -E docs`
 sphinx = {version="^7.1.0", optional=true}

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -142,9 +142,9 @@ charset-normalizer==3.4.2 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.35.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:a483b127ba7650b43990c9bdaeebdc3e06e6f6dda0ebb8a6a91d0f015c02fe28 \
-    --hash=sha256:df4b7061a808f5859da0a49a39fc0ae5d40979e178bc06ec346e3c260015c0f0
+imap-data-access==0.36.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:e221c55395bc3a1163432110b67ec544566f87e1e332bd3da2c9f833c765136c \
+    --hash=sha256:edf8a57c89759bcf40979b290e5fa368f71b34094d757c203d1086ad57818a79
 imap-processing==1.0.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:808c614dbd4d1a198972bd224416bcb16a933b12bfe0a5391cac21ea198aca32 \
     --hash=sha256:f71001020a0047f9ceba9a2803384e34f669821779f88619e14c2cd598fa75fc


### PR DESCRIPTION
# Change Summary

## Overview

This bumps the imap-data-access for filename changes and repointing fixes.