### PR TITLE
I-ALiRT - pointing schedule bug fix

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
@@ -9,7 +9,7 @@ import boto3
 import imap_processing.ialirt.constants
 from imap_processing.ialirt.process_ephemeris import generate_text_files
 
-from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import (
+from .ialirt_coverage import (
     get_latest_spice_kernels,
     setup_spice_file,
 )


### PR DESCRIPTION
# Change Summary

## Overview
An import from ialirt_pointing_schedule.py needed to be modified because when it is deployed the lambda is throwing errors.


## Updated Files
- ialirt_pointing_schedule.py
   - Updated import