### PR TITLE
I-ALiRT - query modification based on MAG HK data

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api.py
@@ -30,11 +30,16 @@ def process_item_types(item: dict) -> dict:
     for key, value in item.items():
         # Vectors fields
         if isinstance(value, list):
-            result[key] = [int(v) if v % 1 == 0 else float(v) for v in value]
-
+            result[key] = [int(v) if v % 1 == 0 else round(float(v), 3) for v in value]
+        # Dictionary with number
+        elif isinstance(value, dict) and "N" in value:
+            num = Decimal(value["N"])
+            result[key] = int(num) if num % 1 == 0 else round(float(num), 3)
+        elif isinstance(value, dict) and "BOOL" in value:
+            result[key] = bool(value["BOOL"])
         # Scalar fields
         elif isinstance(value, Decimal):
-            result[key] = int(value) if value % 1 == 0 else float(value)
+            result[key] = int(value) if value % 1 == 0 else round(float(value), 3)
 
         else:
             result[key] = value

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api.py
@@ -35,6 +35,7 @@ def process_item_types(item: dict) -> dict:
         elif isinstance(value, dict) and "N" in value:
             num = Decimal(value["N"])
             result[key] = int(num) if num % 1 == 0 else round(float(num), 3)
+        # Dictionary with boolean
         elif isinstance(value, dict) and "BOOL" in value:
             result[key] = bool(value["BOOL"])
         # Scalar fields

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api.py
@@ -31,13 +31,15 @@ def process_item_types(item: dict) -> dict:
         # Vectors fields
         if isinstance(value, list):
             result[key] = [int(v) if v % 1 == 0 else round(float(v), 3) for v in value]
-        # Dictionary with number
-        elif isinstance(value, dict) and "N" in value:
-            num = Decimal(value["N"])
-            result[key] = int(num) if num % 1 == 0 else round(float(num), 3)
-        # Dictionary with boolean
-        elif isinstance(value, dict) and "BOOL" in value:
-            result[key] = bool(value["BOOL"])
+        # Dictionary fields
+        elif isinstance(value, dict):
+            nested = {}
+            for k, v in value.items():
+                if isinstance(v, Decimal):
+                    nested[k] = int(v) if v % 1 == 0 else round(float(v), 3)
+                else:
+                    nested[k] = v
+            result[key] = nested
         # Scalar fields
         elif isinstance(value, Decimal):
             result[key] = int(value) if value % 1 == 0 else round(float(value), 3)

--- a/tests/lambda_endpoints/test_ialirt_db_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_db_query_api.py
@@ -261,6 +261,7 @@ def test_process_item_types():
             "mag_B_GSE": [Decimal("0.0"), Decimal("0.1"), Decimal("0.2")],
             "mag_B_magnitude": Decimal("0.22"),
             "met_in_utc": "2025-06-20T08:00:00",  # string should stay unchanged
+            "mag_hk_status": {"pri_isvalid": True, "hkn8v5": Decimal("3680")},
         }
     ]
 
@@ -274,5 +275,6 @@ def test_process_item_types():
             "mag_B_GSE": [0.0, 0.1, 0.2],
             "mag_B_magnitude": 0.22,
             "met_in_utc": "2025-06-20T08:00:00",
+            "mag_hk_status": {"pri_isvalid": True, "hkn8v5": 3680},
         }
     ]


### PR DESCRIPTION
# Change Summary

## Overview
MAG added HK data to the database that needs to be formatted in order to return the json result.

## Updated Files
- ialirt_db_query_api.py
   - Update to format to account for MAG HK

## Example of MAG HK structure:

mag_hk_status

{ "pri_isvalid" : { "BOOL" : true }, "hkn8v5" : { "N" : "3680" }, "icu_temp" : { "N" : "2336" }, "hk3v3_current" : { "N" : "1784" }, "fib_temp" : { "N" : "2464" }, "hk1v8c_danger" : { "BOOL" : false }, "fob_saturated" : { "BOOL" : false }, "fib_saturated" : { "BOOL" : false }, "hk1v5_danger" : { "BOOL" : false }, "hk1v8_danger" : { "BOOL" : false }, "hk1v8c_warn" : { "BOOL" : false }, "mode" : { "N" : "6" }, "hk2v5c_danger" : { "BOOL" : false }, "hkp8v5_warn" : { "BOOL" : false }, "hk2v5_danger" : { "BOOL" : false }, "hkp8v5_danger" : { "BOOL" : false }, "hkp8v5c_danger" : { "BOOL" : false }, "hkp8v5c_warn" : { "BOOL" : false }, "hk1v5c_warn" : { "BOOL" : false }, "hk3v3" : { "N" : "2880" }, "fob_temp" : { "N" : "2512" }, "fob_range" : { "N" : "2" }, "fib_range" : { "N" : "2" }, "sec_isvalid" : { "BOOL" : true }, "hk1v5_warn" : { "BOOL" : false }, "hk1v5c_danger" : { "BOOL" : false }, "multbit_errs" : { "BOOL" : false }, "hk2v5_warn" : { "BOOL" : false }, "hkn8v5_current" : { "N" : "1368" }, "hk1v8_warn" : { "BOOL" : false }, "hk2v5c_warn" : { "BOOL" : false } }