### PR TITLE
ENH: Add repoint table query endpoint

### DIFF
--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -280,12 +280,12 @@ class SdsApiManager(Construct):
             api, "/download", "HEAD", download_api_lambda, auth_route_prefixes
         )
 
-        universal_spin_table_handler = lambda_.Function(
+        spin_repoint_query_api_lambda = lambda_.Function(
             self,
-            id="universal-spin-table-api-handler",
-            function_name="universal-spin-table-api-handler",
+            id="spin-repoint-query-api",
+            function_name="spin-repoint-query-api",
             code=code,
-            handler="SDSCode.api_lambdas.spin_table_api.lambda_handler",
+            handler="SDSCode.api_lambdas.spin_repoint_table_api.lambda_handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
             timeout=cdk.Duration.minutes(1),
             memory_size=1000,
@@ -358,7 +358,7 @@ class SdsApiManager(Construct):
         rds_secret = secrets.Secret.from_secret_name_v2(
             self, "rds_secret", db_secret_name
         )
-        rds_secret.grant_read(grantee=universal_spin_table_handler)
+        rds_secret.grant_read(grantee=spin_repoint_query_api_lambda)
         rds_secret.grant_read(grantee=query_api_lambda)
         rds_secret.grant_read(grantee=download_api_lambda)
         rds_secret.grant_read(grantee=spice_query_api_lambda)
@@ -367,8 +367,15 @@ class SdsApiManager(Construct):
         rds_secret.grant_read(grantee=batch_job_query_api_lambda)
 
         for prefix in auth_route_prefixes:
+            # Add spin table route
             api.add_route(
                 route=f"{prefix}/spin-table",
                 http_method="GET",
-                lambda_function=universal_spin_table_handler,
+                lambda_function=spin_repoint_query_api_lambda,
+            )
+            # Same handler, but add a route to the repointing table
+            api.add_route(
+                route=f"{prefix}/repoint-table",
+                http_method="GET",
+                lambda_function=spin_repoint_query_api_lambda,
             )

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spin_repoint_table_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spin_repoint_table_api.py
@@ -7,21 +7,35 @@ import logging
 from sqlalchemy import desc, func, select
 
 from ..database import database as db
-from ..database.models import SpinFiles
+from ..database.models import RepointFiles, SpinFiles
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def lambda_handler(event, context):
+def lambda_handler(event, context):  # noqa: PLR0912
     """Handle API requests for the spin-data endpoint."""
-    logger.debug("Spin Query Event: " + json.dumps(event, indent=2))
+    logger.debug("Spin/Repoint Query Event: " + json.dumps(event, indent=2))
+
+    if "spin" in event.get("path", "").lower():
+        table = SpinFiles
+    elif "repoint" in event.get("path", "").lower():
+        table = RepointFiles
+    else:
+        response = {
+            "statusCode": 400,
+            "body": json.dumps(
+                "Invalid path. Path must contain either 'spin' or 'repoint'."
+            ),
+        }
+        logger.debug("Invalid path, must contain either 'spin' or 'repoint'.")
+        return response
 
     # add session, pick model like in indexer and add query to filter_as
     query_params = event["queryStringParameters"]
     with db.Session() as session:
         # select the SPICE files table for the query
-        query = select(SpinFiles)
+        query = select(table)
 
         # get a list of all valid search parameters
         valid_parameters = [
@@ -50,22 +64,25 @@ def lambda_handler(event, context):
                 )
                 return response
             try:
-                if param == "start_date":
+                if param == "start_date" and table == SpinFiles:
+                    # Only the SpinFiles table has a start_date field
+                    # This parameter can be ignore for the repointing table
+                    # because those files have all start dates in every file.
                     parsed_date = datetime.datetime.strptime(value, "%Y%m%d")
-                    query = query.where(SpinFiles.start_date >= parsed_date)
+                    query = query.where(table.start_date >= parsed_date)
                 elif param == "end_date":
                     parsed_date = datetime.datetime.strptime(value, "%Y%m%d")
-                    query = query.where(SpinFiles.end_date <= parsed_date)
+                    query = query.where(table.end_date <= parsed_date)
                 elif param == "file_path":
-                    query = query.where(SpinFiles.file_path == value)
+                    query = query.where(table.file_path == value)
                 elif param == "latest" and value.lower() == "true":
                     # TODO: fix this logic
                     # Make a subquery that gives latest spin file
                     row_number = (
                         func.row_number()
                         .over(
-                            partition_by=(SpinFiles.start_date, SpinFiles.end_date),
-                            order_by=desc(SpinFiles.version),
+                            partition_by=(table.start_date, table.end_date),
+                            order_by=desc(table.version),
                         )
                         .label("row_num")
                     )
@@ -73,20 +90,20 @@ def lambda_handler(event, context):
                     # Use a subquery to select only rows where row_num == 1
                     # (latest version)
                     subquery = select(
-                        SpinFiles.file_path,
-                        SpinFiles.start_date,
-                        SpinFiles.end_date,
-                        SpinFiles.version,
-                        SpinFiles.ingestion_date,
+                        table.file_path,
+                        table.start_date,
+                        table.end_date,
+                        table.version,
+                        table.ingestion_date,
                         row_number,
                     ).alias("latest_spin_files")
                     query = select(subquery).where(subquery.c.row_num == 1)
                 elif param == "start_ingest_date":
                     parsed_date = datetime.datetime.strptime(value, "%Y%m%d")
-                    query = query.where(SpinFiles.ingestion_date >= parsed_date)
+                    query = query.where(table.ingestion_date >= parsed_date)
                 elif param == "end_ingest_date":
                     parsed_date = datetime.datetime.strptime(value, "%Y%m%d")
-                    query = query.where(SpinFiles.ingestion_date <= parsed_date)
+                    query = query.where(table.ingestion_date <= parsed_date)
             except ValueError:
                 response = {
                     "statusCode": 400,
@@ -97,6 +114,20 @@ def lambda_handler(event, context):
 
         search_results = session.execute(query).scalars().all()
     # format the search results into a list of dictionaries
+    if table == RepointFiles:
+        # Repointing files do not have a start_date field
+        search_results = [
+            {
+                "file_path": result.file_path,
+                "end_date": result.end_date.strftime("%Y-%m-%d, %H:%M:%S"),
+                "version": result.version,
+                "ingestion_date": result.ingestion_date.strftime("%Y-%m-%d, %H:%M:%S"),
+            }
+            for result in search_results
+        ]
+        return {"statusCode": 200, "body": json.dumps(search_results)}
+
+    # Spin files have a start_date field
     search_results = [
         {
             "file_path": result.file_path,

--- a/tests/lambda_endpoints/test_spin_api.py
+++ b/tests/lambda_endpoints/test_spin_api.py
@@ -9,8 +9,8 @@ import pytest
 
 # Add the project root to the path to allow imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
-from sds_data_manager.lambda_code.SDSCode.api_lambdas import spin_table_api
-from sds_data_manager.lambda_code.SDSCode.database.models import SpinFiles
+from sds_data_manager.lambda_code.SDSCode.api_lambdas import spin_repoint_table_api
+from sds_data_manager.lambda_code.SDSCode.database.models import RepointFiles, SpinFiles
 
 
 @pytest.fixture
@@ -45,17 +45,41 @@ def spin_db(session):
     session.commit()
 
 
+@pytest.fixture
+def repoint_db(session):
+    """Create a session with test data for spin files."""
+    # Create sample repoint file records
+    repoint_files = [
+        RepointFiles(
+            file_path="imap/spice/repoint/imap_2026_267_2026_268_02.repoint",
+            end_date=datetime.datetime(2026, 9, 25, 0, 0, 0),
+            version="02",
+            ingestion_date=datetime.datetime(2025, 7, 8, 20, 10, 57, 614857),
+        ),
+        RepointFiles(
+            file_path="imap/spice/repoint/imap_2026_268_2026_268_01.repoint",
+            end_date=datetime.datetime(2026, 9, 30, 0, 0, 0),
+            version="01",
+            ingestion_date=datetime.datetime(2025, 7, 9, 20, 10, 55, 256060),
+        ),
+    ]
+
+    session.add_all(repoint_files)
+    session.commit()
+
+
 def test_spin_table_api_date_filters(spin_db):
     """Test query with date filters similar to the API example."""
     event = {
         "queryStringParameters": {
             "start_date": "20260925",
             "end_date": "20260925",
-        }
+        },
+        "path": "/spin-table",
     }
     context = {}
 
-    response = spin_table_api.lambda_handler(event, context)
+    response = spin_repoint_table_api.lambda_handler(event, context)
 
     assert response["statusCode"] == 200
     results = json.loads(response["body"])
@@ -103,9 +127,12 @@ def test_spin_table_api_date_filters(spin_db):
 
 def test_spin_table_api_invalid_parameter(spin_db):
     """Test error handling for invalid query parameters."""
-    event = {"queryStringParameters": {"invalid_param": "value"}}
+    event = {
+        "queryStringParameters": {"invalid_param": "value"},
+        "path": "/spin-table",
+    }
 
-    response = spin_table_api.lambda_handler(event, {})
+    response = spin_repoint_table_api.lambda_handler(event, {})
 
     # Check that we get the proper error response
     assert response["statusCode"] == 400
@@ -114,9 +141,12 @@ def test_spin_table_api_invalid_parameter(spin_db):
 
 def test_spin_table_api_invalid_date_format(spin_db):
     """Test error handling for invalid date formats."""
-    event = {"queryStringParameters": {"start_date": "2025-09-25"}}
+    event = {
+        "queryStringParameters": {"start_date": "2025-09-25"},
+        "path": "/spin-table",
+    }
 
-    response = spin_table_api.lambda_handler(event, {})
+    response = spin_repoint_table_api.lambda_handler(event, {})
 
     # Check that we get the proper error response
     assert response["statusCode"] == 400
@@ -125,9 +155,12 @@ def test_spin_table_api_invalid_date_format(spin_db):
 
 def test_ingestion_date(spin_db):
     """Test that ingestion date query works."""
-    event = {"queryStringParameters": {"start_ingest_date": "20250710"}}
+    event = {
+        "queryStringParameters": {"start_ingest_date": "20250710"},
+        "path": "/spin-table",
+    }
 
-    response = spin_table_api.lambda_handler(event, {})
+    response = spin_repoint_table_api.lambda_handler(event, {})
 
     # Check successful response
     assert response["statusCode"] == 200
@@ -144,9 +177,12 @@ def test_ingestion_date(spin_db):
         assert result["ingestion_date"] >= "2025-07-10"
 
     # Try with end date now
-    event = {"queryStringParameters": {"end_ingest_date": "20250709"}}
+    event = {
+        "queryStringParameters": {"end_ingest_date": "20250709"},
+        "path": "/spin-table",
+    }
 
-    response = spin_table_api.lambda_handler(event, {})
+    response = spin_repoint_table_api.lambda_handler(event, {})
     assert response["statusCode"] == 200
     results = json.loads(response["body"])
 
@@ -156,3 +192,36 @@ def test_ingestion_date(spin_db):
     for result in results:
         # Ingestion date should be on or after 2025-07-10
         assert result["ingestion_date"] >= "2025-07-08"
+
+
+def test_repoint_table(repoint_db):
+    """Test querying the repointing table."""
+    event = {
+        "queryStringParameters": {
+            "start_date": "20260925",
+            "end_date": "20260925",
+        },
+        "path": "/repoint-table",
+    }
+    context = {}
+
+    response = spin_repoint_table_api.lambda_handler(event, context)
+
+    assert response["statusCode"] == 200
+    results = json.loads(response["body"])
+    assert isinstance(results, list)
+
+    # Validate the result format
+    for result in results:
+        assert "file_path" in result
+        assert "end_date" in result
+        assert "version" in result
+        assert "ingestion_date" in result
+    assert len(results) == 1
+
+    # Check the first result has expected values
+    assert (
+        results[0]["file_path"]
+        == "imap/spice/repoint/imap_2026_267_2026_268_02.repoint"
+    )
+    assert results[0]["end_date"].startswith("2026-09-25")


### PR DESCRIPTION
# Change Summary

## Overview

This adds an API endpoint to query for repointing files. It is really similar to the spin table, so I tried to keep the logic the same and re-use the lambda. Unfortunately there is a slight difference in the spin-table having a `start_date`, but the repoint-table not having that key so some slight avoidance of that was necessary.