### PR TITLE
I-ALiRT - Spice metadata

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -487,9 +487,6 @@ def lambda_handler(event, context):
     logger.info("Retrieved filename: %s", filename)
     dependency_inputs = get_latest_spice_kernels(url)
 
-    # Insert kernel metadata every minute.
-    insert_kernels(dependency_inputs, algorithm_table)
-
     logger.info("dependency_inputs: %s", dependency_inputs)
     download_spice_file(dependency_inputs)
 
@@ -510,6 +507,8 @@ def lambda_handler(event, context):
         logger.info("Packets parsed. Processing algorithms.")
         # Process algorithms and insert new data.
         process_algorithms(combined, algorithm_table)
+        # Insert kernel metadata every minute.
+        insert_kernels(dependency_inputs, algorithm_table)
 
         logger.info("Successfully wrote all new items to DynamoDB")
     else:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -35,7 +35,14 @@ from imap_processing.spice.geometry import (
     SpiceFrame,
     imap_state,
 )
-from imap_processing.spice.time import met_to_sclkticks, met_to_utc, sct_to_et
+from imap_processing.spice.time import (
+    et_to_met,
+    met_to_sclkticks,
+    met_to_ttj2000ns,
+    met_to_utc,
+    sct_to_et,
+    str_to_et,
+)
 from imap_processing.utils import packet_file_to_datasets
 
 logger = logging.getLogger(__name__)
@@ -414,6 +421,40 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
         logger.info(f"Inserted {instrument.upper()}.")
 
 
+def insert_kernels(dependency_inputs, algorithm_table):
+    """Insert SPICE kernel metadata into the database.
+
+    Parameters
+    ----------
+    dependency_inputs : ProcessingInputCollection
+        SPICE kernel dependencies.
+    algorithm_table : dynamodb.Table
+        The DynamoDB table to insert or update the data.
+    """
+    last_modified = datetime.now(timezone.utc)
+    last_modified_for_spice = last_modified.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    met = et_to_met(str_to_et(last_modified_for_spice))
+    last_modified_utc = last_modified.isoformat()
+    spice_input = dependency_inputs.processing_input[0]
+    spice_kernels = dict(zip(spice_input.source, spice_input.filename_list))
+
+    kernel_item = {
+        "apid": 478,
+        "met": int(met),
+        "met_in_utc": met_to_utc(met).split(".")[0],
+        "ttj2000ns": int(met_to_ttj2000ns(met)),
+        "last_modified": last_modified_utc,
+        "spice_kernels": spice_kernels,
+    }
+
+    algorithm_table.put_item(Item=kernel_item)
+
+    logger.info(
+        f"Stored SPICE kernel mapping in "
+        f"DynamoDB: {json.dumps(spice_kernels, indent=2)}"
+    )
+
+
 def lambda_handler(event, context):
     """Create metadata and add it to the database.
 
@@ -445,6 +486,10 @@ def lambda_handler(event, context):
     filename = os.path.basename(s3_filepath)
     logger.info("Retrieved filename: %s", filename)
     dependency_inputs = get_latest_spice_kernels(url)
+
+    # Insert kernel metadata every minute.
+    insert_kernels(dependency_inputs, algorithm_table)
+
     logger.info("dependency_inputs: %s", dependency_inputs)
     download_spice_file(dependency_inputs)
 

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -21,6 +21,7 @@ from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
     get_ancillary,
     get_latest_spice_kernels,
     insert_data,
+    insert_kernels,
     lambda_handler,
     parse_packets,
     process_algorithms,
@@ -434,3 +435,54 @@ def test_get_ancillary(mock_query, mock_ancillaryfilepath, mock_download):
         path = get_ancillary("swe", "l1b-in-flight-cal")
 
     assert path == mock_path
+
+
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.met_to_ttj2000ns",
+    return_value=813665124895612928,
+)
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.met_to_utc",
+    return_value="2025-10-13T22:04:15.000",
+)
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.et_to_met",
+    return_value=498089058,
+)
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.str_to_et",
+    return_value=123456.0,
+)
+def test_insert_kernels(
+    mock_str_to_et,
+    mock_et_to_met,
+    mock_met_to_utc,
+    mock_met_to_ttj2000ns,
+    setup_dynamodb,
+):
+    "Test insert_kernels function."
+    algorithm_table = setup_dynamodb["algorithm_table"]
+
+    spice_input = MagicMock()
+    spice_input.source = ["leapseconds", "planetary_constants", "imap_frames"]
+    spice_input.filename_list = ["naif0012.tls", "pck00011.tpc", "imap_100.tf"]
+
+    dependency_inputs = MagicMock()
+    dependency_inputs.processing_input = [spice_input]
+
+    insert_kernels(dependency_inputs, algorithm_table)
+
+    response = algorithm_table.query(
+        KeyConditionExpression="apid = :a", ExpressionAttributeValues={":a": 478}
+    )
+    items = response["Items"]
+
+    assert items[0]["apid"] == 478
+    assert items[0]["met"] == 498089058
+    assert items[0]["met_in_utc"] == "2025-10-13T22:04:15"
+    assert int(items[0]["ttj2000ns"]) == 813665124895612928
+    assert items[0]["spice_kernels"] == {
+        "leapseconds": "naif0012.tls",
+        "planetary_constants": "pck00011.tpc",
+        "imap_frames": "imap_100.tf",
+    }


### PR DESCRIPTION
# Change Summary

## Overview
We need a way to track when SPICE kernels are used. This PR creates an entry in the database for each processing job as a way to track which SPICE kernels are used.

## Updated Files
- ialirt_ingest.py
   - Add SPICE kernels to the DynamoDB

## Testing
- test_ialirt_ingest.py
