### PR TITLE
MNT: Bump imap-data-access version for new file type support

### DIFF
--- a/lambda_layer/database/requirements.txt
+++ b/lambda_layer/database/requirements.txt
@@ -153,9 +153,9 @@ greenlet==3.2.2 ; python_version < "3.14" and (platform_machine == "aarch64" or 
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.36.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:e221c55395bc3a1163432110b67ec544566f87e1e332bd3da2c9f833c765136c \
-    --hash=sha256:edf8a57c89759bcf40979b290e5fa368f71b34094d757c203d1086ad57818a79
+imap-data-access==0.37.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:7887ad43c4404c6465035af73621237aef7a8d88d506439dd4618aef1db8cf87 \
+    --hash=sha256:9801aba311311815866336636fdad9e37b530498f4c3f21abce283d860a7c643
 psycopg2-binary==2.9.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:04392983d0bb89a8717772a193cfaac58871321e3ec69514e1c4e0d4957b5aff \
     --hash=sha256:056470c3dc57904bbf63d6f534988bafc4e970ffd50f6271fc4ee7daad9498a5 \

--- a/lambda_layer/spice/requirements.txt
+++ b/lambda_layer/spice/requirements.txt
@@ -97,9 +97,9 @@ charset-normalizer==3.4.2 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.36.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:e221c55395bc3a1163432110b67ec544566f87e1e332bd3da2c9f833c765136c \
-    --hash=sha256:edf8a57c89759bcf40979b290e5fa368f71b34094d757c203d1086ad57818a79
+imap-data-access==0.37.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:7887ad43c4404c6465035af73621237aef7a8d88d506439dd4618aef1db8cf87 \
+    --hash=sha256:9801aba311311815866336636fdad9e37b530498f4c3f21abce283d860a7c643
 numpy==2.2.6 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff \
     --hash=sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47 \

--- a/poetry.lock
+++ b/poetry.lock
@@ -890,13 +890,13 @@ files = [
 
 [[package]]
 name = "imap-data-access"
-version = "0.36.0"
+version = "0.37.0"
 description = "IMAP SDC Data Access"
 optional = false
 python-versions = "*"
 files = [
-    {file = "imap_data_access-0.36.0-py3-none-any.whl", hash = "sha256:e221c55395bc3a1163432110b67ec544566f87e1e332bd3da2c9f833c765136c"},
-    {file = "imap_data_access-0.36.0.tar.gz", hash = "sha256:edf8a57c89759bcf40979b290e5fa368f71b34094d757c203d1086ad57818a79"},
+    {file = "imap_data_access-0.37.0-py3-none-any.whl", hash = "sha256:9801aba311311815866336636fdad9e37b530498f4c3f21abce283d860a7c643"},
+    {file = "imap_data_access-0.37.0.tar.gz", hash = "sha256:7887ad43c4404c6465035af73621237aef7a8d88d506439dd4618aef1db8cf87"},
 ]
 
 [package.dependencies]
@@ -2548,4 +2548,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "a790e25c5044ecf7b159b9ae8ab393bacedb9e1165cb7a2de70e6c08837e6a4a"
+content-hash = "589f6bf52dbd1f4348c071a32f6866aee551ce2adb130f8f71e1d07808b96f3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ python = ">=3.10,<4"
 # WARNING - Please run this command when updateing `imap-data-access` to ensure that
 # the correct version and hash are used:
 #   poetry export -f requirements.txt -o lambda_layer/database/requirements.txt --with layer-database
-imap-data-access = ">=0.36.0"
+imap-data-access = ">=0.37.0"
 
 # Optional dependencies - install with `poetry install -E docs`
 sphinx = {version="^7.1.0", optional=true}

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -142,9 +142,9 @@ charset-normalizer==3.4.2 ; python_version >= "3.10" and python_version < "4" \
 idna==3.10 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imap-data-access==0.36.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:e221c55395bc3a1163432110b67ec544566f87e1e332bd3da2c9f833c765136c \
-    --hash=sha256:edf8a57c89759bcf40979b290e5fa368f71b34094d757c203d1086ad57818a79
+imap-data-access==0.37.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:7887ad43c4404c6465035af73621237aef7a8d88d506439dd4618aef1db8cf87 \
+    --hash=sha256:9801aba311311815866336636fdad9e37b530498f4c3f21abce283d860a7c643
 imap-processing==1.0.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:808c614dbd4d1a198972bd224416bcb16a933b12bfe0a5391cac21ea198aca32 \
     --hash=sha256:f71001020a0047f9ceba9a2803384e34f669821779f88619e14c2cd598fa75fc


### PR DESCRIPTION
# Change Summary

## Overview

In the title, a version bump of imap-data-access