### PR TITLE
FIX: Update spin/repoint api for proper event path

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/spin_repoint_table_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/spin_repoint_table_api.py
@@ -17,9 +17,10 @@ def lambda_handler(event, context):  # noqa: PLR0912
     """Handle API requests for the spin-data endpoint."""
     logger.debug("Spin/Repoint Query Event: " + json.dumps(event, indent=2))
 
-    if "spin" in event.get("path", "").lower():
+    raw_path = event.get("rawPath", "")
+    if "spin" in raw_path:
         table = SpinFiles
-    elif "repoint" in event.get("path", "").lower():
+    elif "repoint" in raw_path:
         table = RepointFiles
     else:
         response = {
@@ -32,7 +33,7 @@ def lambda_handler(event, context):  # noqa: PLR0912
         return response
 
     # add session, pick model like in indexer and add query to filter_as
-    query_params = event["queryStringParameters"]
+    query_params = event.get("queryStringParameters", {})
     with db.Session() as session:
         # select the SPICE files table for the query
         query = select(table)

--- a/tests/lambda_endpoints/test_spin_api.py
+++ b/tests/lambda_endpoints/test_spin_api.py
@@ -75,7 +75,7 @@ def test_spin_table_api_date_filters(spin_db):
             "start_date": "20260925",
             "end_date": "20260925",
         },
-        "path": "/spin-table",
+        "rawPath": "/spin-table",
     }
     context = {}
 
@@ -129,7 +129,7 @@ def test_spin_table_api_invalid_parameter(spin_db):
     """Test error handling for invalid query parameters."""
     event = {
         "queryStringParameters": {"invalid_param": "value"},
-        "path": "/spin-table",
+        "rawPath": "/spin-table",
     }
 
     response = spin_repoint_table_api.lambda_handler(event, {})
@@ -143,7 +143,7 @@ def test_spin_table_api_invalid_date_format(spin_db):
     """Test error handling for invalid date formats."""
     event = {
         "queryStringParameters": {"start_date": "2025-09-25"},
-        "path": "/spin-table",
+        "rawPath": "/spin-table",
     }
 
     response = spin_repoint_table_api.lambda_handler(event, {})
@@ -157,7 +157,7 @@ def test_ingestion_date(spin_db):
     """Test that ingestion date query works."""
     event = {
         "queryStringParameters": {"start_ingest_date": "20250710"},
-        "path": "/spin-table",
+        "rawPath": "/spin-table",
     }
 
     response = spin_repoint_table_api.lambda_handler(event, {})
@@ -179,7 +179,7 @@ def test_ingestion_date(spin_db):
     # Try with end date now
     event = {
         "queryStringParameters": {"end_ingest_date": "20250709"},
-        "path": "/spin-table",
+        "rawPath": "/spin-table",
     }
 
     response = spin_repoint_table_api.lambda_handler(event, {})
@@ -201,7 +201,7 @@ def test_repoint_table(repoint_db):
             "start_date": "20260925",
             "end_date": "20260925",
         },
-        "path": "/repoint-table",
+        "rawPath": "/repoint-table",
     }
     context = {}
 


### PR DESCRIPTION
Our API uses "rawPath". Also allow no queryParams to be input and just return a scan of the file database.

Found testing this in dev routes and verified both spin and repoint work with this update.