### PR TITLE
CI/REL: Fix adding git information for tagging in production release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,11 @@ jobs:
       - name: Create tag
         if: env.should_tag == 'true'
         run: |
+          # Configure Git identity for tagging
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+          # Create and push tag
           TAG_NAME="prod-$(date -u +'%Y-%m-%d-%H%M%S')"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           git tag -a "$TAG_NAME" -m "Production deployment on $(date -u)"


### PR DESCRIPTION
# Change Summary

## Overview

The production deploy succeeded, but the tagging back to the repository step failed. We need to configure the git identity before tagging and pushing. 🤞 this fixes the issue.

xref failing job logs: https://github.com/IMAP-Science-Operations-Center/sds-data-manager/actions/runs/18541840821/job/52851009455