### PR TITLE
BUG: FIx kernel ingest batch starter triggering

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -735,6 +735,12 @@ def s3_processing_event(session, events):
             else:
                 triggered_from_glows_l3e = True
 
+        # For spice files, the source is a list of possible kernel types.
+        # The event triggering batch starter for a spice file will always only have one
+        # type of kernel, so we take the first element of the list.
+        if input_obj.data_type == "spice":
+            input_obj.source = input_obj.source[0]
+
         potential_jobs = dependency.get_jobs(
             data_source=input_obj.source,
             descriptor=input_obj.descriptor,

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -735,8 +735,10 @@ def s3_processing_event(session, events):
             else:
                 triggered_from_glows_l3e = True
 
-        # For spice files, the source is a list of possible kernel types.
-        # The event triggering batch starter for a spice file will always only have one
+        # For spice files, the source is a list of kernel types because
+        # metakernel can contain multiple sources.
+        #     eg spacecraft_clock, spacecraft_clock and so on.
+        # But the file in the batch starter event will always only have one
         # type of kernel, so we take the first element of the list.
         if input_obj.data_type == "spice":
             input_obj.source = input_obj.source[0]

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -570,9 +570,10 @@ def send_spice_event(spice_obj: SPICEFilePath, s3_key: str):
     }
 
     eventbridge_client = boto3.client("events")
-    if spice_obj.spice_metadata["type"] == "repoint":
-        detail["object"]["instrument"] = "spacecraft"
-        detail["object"]["data_level"] = "l1a"
+    # In order to trigger batch starter, the event must have a key, instrument and
+    # data_level.
+    detail["object"]["instrument"] = "spacecraft"
+    detail["object"]["data_level"] = "l1a"
 
     event = IMAPLambdaPutEvent(
         detail_type="Processed File",

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -571,7 +571,8 @@ def send_spice_event(spice_obj: SPICEFilePath, s3_key: str):
 
     eventbridge_client = boto3.client("events")
     # In order to trigger batch starter, the event must have a key, instrument and
-    # data_level. Otherwise, it sends event but never makes it because of SQS filter policy
+    # data_level. Otherwise, it sends event but never makes it because of SQS filter
+    # policy
     detail["object"]["instrument"] = "spacecraft"
     detail["object"]["data_level"] = "l1a"
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -571,7 +571,7 @@ def send_spice_event(spice_obj: SPICEFilePath, s3_key: str):
 
     eventbridge_client = boto3.client("events")
     # In order to trigger batch starter, the event must have a key, instrument and
-    # data_level. Otherwise, it sends event but never makes it because of SQS filter policy 
+    # data_level. Otherwise, it sends event but never makes it because of SQS filter policy
     detail["object"]["instrument"] = "spacecraft"
     detail["object"]["data_level"] = "l1a"
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -571,7 +571,7 @@ def send_spice_event(spice_obj: SPICEFilePath, s3_key: str):
 
     eventbridge_client = boto3.client("events")
     # In order to trigger batch starter, the event must have a key, instrument and
-    # data_level.
+    # data_level. Otherwise, it sends event but never makes it because of SQS filter policy 
     detail["object"]["instrument"] = "spacecraft"
     detail["object"]["data_level"] = "l1a"
 


### PR DESCRIPTION
# Change Summary

## Overview
Batch starter could only be triggered by repoint files. This fix allows for all of the following kernels, when ingested to trigger. 

    spice_events = [
        "attitude_history",
        "attitude_predict",
        "ephemeris_reconstructed",
        "ephemeris_nominal",
        "ephemeris_predict",
        "spin",
        "repoint",
        "thruster",
    ]

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - For spice files, the source is a list
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
   - Add instrument and datalevel to all of the spice events
   - batch starter does not use this information from the event
