### PR TITLE
I-ALiRT - Dynamodb addition

### DIFF
--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -157,28 +157,14 @@ class IalirtIngestLambda(Construct):
                 name="instrument",
                 type=ddb.AttributeType.STRING,
             ),
-            # Sort key (SK) = met_in_utc.
+            # Sort key (SK) = time_utc.
             sort_key=ddb.Attribute(
-                name="met_in_utc",
+                name="time_utc",
                 type=ddb.AttributeType.STRING,
             ),
             billing_mode=ddb.BillingMode.PAY_PER_REQUEST,  # On-Demand capacity mode.
         )
 
-        # Add a GSI for last modified timestamp.
-        self.data_table.add_global_secondary_index(
-            index_name="last_modified",
-            # Partition key (PK) = instrument.
-            partition_key=ddb.Attribute(
-                name="instrument", type=ddb.AttributeType.STRING
-            ),
-            # Sort key (SK) = last modified.
-            sort_key=ddb.Attribute(
-                name="last_modified",
-                type=ddb.AttributeType.STRING,
-            ),
-            projection_type=ddb.ProjectionType.ALL,
-        )
         return self.data_table
 
     def create_lambda_function(

--- a/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
+++ b/sds_data_manager/constructs/ialirt_ingest_lambda_construct.py
@@ -62,11 +62,13 @@ class IalirtIngestLambda(Construct):
 
         # Create DynamoDB Table
         self.algorithm_data_table = self.create_algorithm_dynamodb_table()
+        self.data_table = self.create_table()
 
         # Create Lambda Function
         self.ialirt_ingest_lambda = self.create_lambda_function(
             ialirt_bucket,
             self.algorithm_data_table,
+            self.data_table,
             docker_path,
             data_access_url,
         )
@@ -133,10 +135,57 @@ class IalirtIngestLambda(Construct):
         )
         return self.algorithm_data_table
 
+    def create_table(self) -> aws_dynamodb.Table:
+        """Create and return the algorithm data product table."""
+        removal_policy = (
+            RemovalPolicy.RETAIN
+            if self.account_name == "prod"
+            else RemovalPolicy.DESTROY
+        )
+        point_in_time_recovery = True if self.account_name == "prod" else False
+
+        self.data_table = ddb.Table(
+            self,
+            "IalirtDataTable",
+            table_name="ialirt-data-table",
+            # RemovalPolicy.RETAIN to keep the table after stack deletion.
+            removal_policy=removal_policy,
+            # Restore data to any point in time within the last 35 days.
+            point_in_time_recovery=point_in_time_recovery,
+            # Partition key (PK) = instrument.
+            partition_key=ddb.Attribute(
+                name="instrument",
+                type=ddb.AttributeType.STRING,
+            ),
+            # Sort key (SK) = met_in_utc.
+            sort_key=ddb.Attribute(
+                name="met_in_utc",
+                type=ddb.AttributeType.STRING,
+            ),
+            billing_mode=ddb.BillingMode.PAY_PER_REQUEST,  # On-Demand capacity mode.
+        )
+
+        # Add a GSI for last modified timestamp.
+        self.data_table.add_global_secondary_index(
+            index_name="last_modified",
+            # Partition key (PK) = instrument.
+            partition_key=ddb.Attribute(
+                name="instrument", type=ddb.AttributeType.STRING
+            ),
+            # Sort key (SK) = last modified.
+            sort_key=ddb.Attribute(
+                name="last_modified",
+                type=ddb.AttributeType.STRING,
+            ),
+            projection_type=ddb.ProjectionType.ALL,
+        )
+        return self.data_table
+
     def create_lambda_function(
         self,
         ialirt_bucket: aws_s3.Bucket,
         algorithm_data_table: aws_dynamodb.Table,
+        data_table: aws_dynamodb.Table,
         docker_path: str,
         data_access_url: str,
     ) -> lambda_.DockerImageFunction:
@@ -187,6 +236,7 @@ class IalirtIngestLambda(Construct):
             ),
             environment={
                 "ALGORITHM_TABLE": algorithm_data_table.table_name,
+                "DATA_TABLE": data_table.table_name,
                 "S3_BUCKET": ialirt_bucket.bucket_name,
                 "EFS_SPICE_MOUNT_PATH": "/mnt/data",
                 "IMAP_DATA_ACCESS_URL": data_access_url,
@@ -194,6 +244,7 @@ class IalirtIngestLambda(Construct):
         )
         ialirt_ingest_lambda.add_to_role_policy(s3_read_policy)
         algorithm_data_table.grant_read_write_data(ialirt_ingest_lambda)
+        data_table.grant_read_write_data(ialirt_ingest_lambda)
 
         # The resource is deleted when the stack is deleted.
         ialirt_ingest_lambda.apply_removal_policy(cdk.RemovalPolicy.DESTROY)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -329,7 +329,13 @@ def process_algorithms(combined: xr.Dataset, algorithm_table):
             insert_data(result, algorithm_table, instrument)
 
 
-def insert_data(data: list[dict], algorithm_table, instrument: str):
+def insert_data(
+    data: list[dict],
+    algorithm_table,
+    instrument: str,
+    partition_key: str = "apid",
+    sort_key: str = "met",
+):
     """Insert or update database row, depending on content of item.
 
     Parameters
@@ -340,31 +346,37 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
         The DynamoDB table to insert or update the data.
     instrument : str
         The prefix for the product name.
+    partition_key : str
+        The partition key for the DynamoDB table.
+    sort_key : str
+        The sort key for the DynamoDB table.
     """
-    apid = data[0]["apid"]
-    mets = [item["met"] for item in data]
-    min_met = min(mets)
-    max_met = max(mets)
-    logger.info(f"Processing mets {min_met} to {max_met}.")
-    logger.info(f"Processing utc {met_to_utc(min_met)} to {met_to_utc(max_met)}.")
+    instrument_key = data[0][partition_key]
+    times = [item[sort_key] for item in data]
+    min_time = min(times)
+    max_time = max(times)
+    logger.info(f"Processing {min_time} to {max_time}.")
 
     # Query existing items.
     response = algorithm_table.query(
-        KeyConditionExpression=Key("apid").eq(apid)
-        & Key("met").between(min_met, max_met)
+        KeyConditionExpression=Key(partition_key).eq(instrument_key)
+        & Key(sort_key).between(min_time, max_time)
     )
 
-    existing_items = {item["met"]: item for item in response.get("Items", [])}
+    existing_items = {item[sort_key]: item for item in response.get("Items", [])}
 
     # Insert or update as needed
     for raw in data:
-        met = raw["met"]
-        key = {"apid": apid, "met": met}
-        existing = existing_items.get(met)
+        time = raw[sort_key]
+        key = {partition_key: instrument_key, sort_key: time}
+        existing = existing_items.get(time)
         raw["last_modified"] = datetime.now(timezone.utc).isoformat()
 
         # Calculate the spacecraft position and velocity in GSM coordinates.
-        et = sct_to_et(met_to_sclkticks(met))
+        if isinstance(time, str):
+            et = str_to_et(time)
+        else:
+            et = sct_to_et(met_to_sclkticks(time))
         gsm_state = imap_state(
             [et], ref_frame=SpiceFrame.IMAP_GSM, observer=SpiceBody.EARTH
         )
@@ -381,6 +393,9 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
             if any(key.startswith(instrument) for key in existing.keys()):
                 continue
 
+            # TODO: remove once we transition databases.
+            # This is if an item contains multiple instruments
+            # and that will never happen in the new database.
             update_expr = "SET " + ", ".join(
                 f"{field} = :{field}"
                 for field in raw
@@ -445,6 +460,7 @@ def insert_kernels(dependency_inputs, algorithm_table):
         "met": int(met),
         "met_in_utc": met_to_utc(met).split(".")[0],
         "ttj2000ns": int(met_to_ttj2000ns(met)),
+        "instrument": "spice",
         "last_modified": last_modified_utc,
         "spice_kernels": spice_kernels,
     }
@@ -477,8 +493,10 @@ def lambda_handler(event, context):
     logger.info("Received event: %s", json.dumps(event))
 
     algorithm_table_name = os.environ.get("ALGORITHM_TABLE")
+    data_table_name = os.environ.get("DATA_TABLE")
     dynamodb = boto3.resource("dynamodb")
     algorithm_table = dynamodb.Table(algorithm_table_name)
+    data_table = dynamodb.Table(data_table_name)
     url = os.environ.get("IMAP_DATA_ACCESS_URL")
 
     bucket = event["detail"]["bucket"]["name"]
@@ -511,6 +529,9 @@ def lambda_handler(event, context):
         process_algorithms(combined, algorithm_table)
         # Insert kernel metadata every minute.
         insert_kernels(dependency_inputs, algorithm_table)
+
+        process_algorithms(combined, data_table)
+        insert_kernels(dependency_inputs, data_table)
 
         logger.info("Successfully wrote all new items to DynamoDB")
     else:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -491,39 +491,16 @@ def insert_formatted_data(
 
     science_data, hk_data = reformat_data(data)
 
-    # Query existing items.
-    response = data_table.query(
-        KeyConditionExpression=Key("instrument").eq(instrument)
-        & Key("time_utc").between(min_time, max_time)
-    )
-    hk_response = data_table.query(
-        KeyConditionExpression=Key("instrument").eq(f"{instrument}_hk")
-        & Key("time_utc").between(min_time, max_time)
-    )
-
-    existing_items = {item["time_utc"]: item for item in response.get("Items", [])}
-    existing_hk_items = {
-        item["time_utc"]: item for item in hk_response.get("Items", [])
-    }
-
     # Insert science data
-    for raw in science_data:
-        time = raw["time_utc"]
-        existing = existing_items.get(time)
-
-        if not existing:
-            data_table.put_item(Item=raw)
-        logger.info(f"Inserted {instrument.upper()}.")
+    for record in science_data:
+        data_table.put_item(Item=record)
+    logger.info(f"Inserted {instrument.upper()}.")
 
     # Insert hk data
     if hk_data:
-        for raw in hk_data:
-            time = raw["time_utc"]
-            existing = existing_hk_items.get(time)
-
-            if not existing:
-                data_table.put_item(Item=raw)
-            logger.info(f"Inserted Housekeeping for {instrument.upper()}.")
+        for record in hk_data:
+            data_table.put_item(Item=record)
+    logger.info(f"Inserted Housekeeping for {instrument.upper()}.")
 
     # Calculate the spacecraft position and velocity in GSE/GSM coordinates.
     et = str_to_et(min_time)
@@ -533,8 +510,8 @@ def insert_formatted_data(
     gse_state = imap_state(
         [et], ref_frame=SpiceFrame.IMAP_GSE, observer=SpiceBody.EARTH
     )
-    geolocation = {
-        "instrument": "geolocation",
+    spacecraft = {
+        "instrument": "spacecraft",
         "time_utc": min_time,
         "sc_position_GSM": [Decimal(str(val)) for val in gsm_state[0, :3]],
         "sc_velocity_GSM": [Decimal(str(val)) for val in gsm_state[0, 3:]],
@@ -543,7 +520,7 @@ def insert_formatted_data(
     }
 
     # Insert geolocation data
-    data_table.put_item(Item=geolocation)
+    data_table.put_item(Item=spacecraft)
 
 
 def insert_kernels(dependency_inputs, algorithm_table):

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -455,7 +455,11 @@ def reformat_data(data):
     ]
     keep_keys = {"met_in_utc", "instrument", "mag_hk_status"}
     hk_data = [
-        {rename_map.get(k, k): v for k, v in item.items() if k in keep_keys}
+        {
+            rename_map.get(k, k): ("mag_hk" if k == "instrument" and v == "mag" else v)
+            for k, v in item.items()
+            if k in keep_keys
+        }
         for item in data
     ]
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -399,6 +399,7 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
                     "sc_velocity_GSM",
                     "sc_position_GSE",
                     "sc_velocity_GSE",
+                    "instrument",
                 }
             )
 
@@ -415,6 +416,7 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
                     "sc_velocity_GSM",
                     "sc_position_GSE",
                     "sc_velocity_GSE",
+                    "instrument",
                 }
             }
 
@@ -428,32 +430,21 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
         logger.info(f"Inserted {instrument.upper()}.")
 
 
-def insert_formatted_data(
-    data: list[dict],
-    data_table,
-    instrument: str,
-):
-    """Insert or update database row, depending on content of item.
+def reformat_data(data):
+    """Reformat science and housekeeping data.
 
     Parameters
     ----------
     data : list[dict]
-        Data product produced from processing respectively instrument.
-    data_table : dynamodb.Table
-        The DynamoDB table to insert or update the data.
-    instrument : str
-        The prefix for the product name.
-    partition_key : str
-        The partition key for the DynamoDB table.
-    sort_key : str
-        The sort key for the DynamoDB table.
-    """
-    # Get time range.
-    times = [item["time_utc"] for item in data]
-    min_time = min(times)
-    max_time = max(times)
-    logger.info(f"Processing {min_time} to {max_time}.")
+        Data product.
 
+    Returns
+    -------
+    science_data : list[dict]
+        Reformatted science data.
+    hk_data : list[dict]
+        Reformatted housekeeping data.
+    """
     # Reformat data (remove all keep/exclude keys except hk
     # once imap_processing is updated)
     exclude_keys = {"apid", "met", "mag_hk_status"}
@@ -467,6 +458,33 @@ def insert_formatted_data(
         {rename_map.get(k, k): v for k, v in item.items() if k in keep_keys}
         for item in data
     ]
+
+    return science_data, hk_data
+
+
+def insert_formatted_data(
+    data: list[dict],
+    data_table,
+    instrument: str,
+):
+    """Insert database rows.
+
+    Parameters
+    ----------
+    data : list[dict]
+        Data product produced from processing respectively instrument.
+    data_table : dynamodb.Table
+        The DynamoDB table to insert or update the data.
+    instrument : str
+        The prefix for the product name.
+    """
+    # Get time range.
+    times = [item["time_utc"] for item in data]
+    min_time = min(times)
+    max_time = max(times)
+    logger.info(f"Processing {min_time} to {max_time}.")
+
+    science_data, hk_data = reformat_data(data)
 
     # Query existing items.
     response = data_table.query(
@@ -483,30 +501,16 @@ def insert_formatted_data(
         item["time_utc"]: item for item in hk_response.get("Items", [])
     }
 
-    # Insert data
+    # Insert science data
     for raw in science_data:
         time = raw["time_utc"]
         existing = existing_items.get(time)
-
-        # Calculate the spacecraft position and velocity in GSM coordinates.
-        et = str_to_et(time)
-
-        gsm_state = imap_state(
-            [et], ref_frame=SpiceFrame.IMAP_GSM, observer=SpiceBody.EARTH
-        )
-        gse_state = imap_state(
-            [et], ref_frame=SpiceFrame.IMAP_GSE, observer=SpiceBody.EARTH
-        )
-
-        raw["sc_position_GSM"] = [Decimal(str(val)) for val in gsm_state[0, :3]]
-        raw["sc_velocity_GSM"] = [Decimal(str(val)) for val in gsm_state[0, 3:]]
-        raw["sc_position_GSE"] = [Decimal(str(val)) for val in gse_state[0, :3]]
-        raw["sc_velocity_GSE"] = [Decimal(str(val)) for val in gse_state[0, 3:]]
 
         if not existing:
             data_table.put_item(Item=raw)
         logger.info(f"Inserted {instrument.upper()}.")
 
+    # Insert hk data
     for raw in hk_data:
         time = raw["time_utc"]
         existing = existing_hk_items.get(time)
@@ -514,6 +518,26 @@ def insert_formatted_data(
         if not existing:
             data_table.put_item(Item=raw)
         logger.info(f"Inserted Housekeeping for {instrument.upper()}.")
+
+    # Calculate the spacecraft position and velocity in GSE/GSM coordinates.
+    et = str_to_et(min_time)
+    gsm_state = imap_state(
+        [et], ref_frame=SpiceFrame.IMAP_GSM, observer=SpiceBody.EARTH
+    )
+    gse_state = imap_state(
+        [et], ref_frame=SpiceFrame.IMAP_GSE, observer=SpiceBody.EARTH
+    )
+    geolocation = {
+        "instrument": "geolocation",
+        "time_utc": min_time,
+        "sc_position_GSM": [Decimal(str(val)) for val in gsm_state[0, :3]],
+        "sc_velocity_GSM": [Decimal(str(val)) for val in gsm_state[0, 3:]],
+        "sc_position_GSE": [Decimal(str(val)) for val in gse_state[0, :3]],
+        "sc_velocity_GSE": [Decimal(str(val)) for val in gse_state[0, 3:]],
+    }
+
+    # Insert geolocation data
+    data_table.put_item(Item=geolocation)
 
 
 def insert_kernels(dependency_inputs, algorithm_table):

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -430,10 +430,8 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
 
 def insert_formatted_data(
     data: list[dict],
-    algorithm_table,
+    data_table,
     instrument: str,
-    partition_key: str = "apid",
-    sort_key: str = "met",
 ):
     """Insert or update database row, depending on content of item.
 
@@ -441,7 +439,7 @@ def insert_formatted_data(
     ----------
     data : list[dict]
         Data product produced from processing respectively instrument.
-    algorithm_table : dynamodb.Table
+    data_table : dynamodb.Table
         The DynamoDB table to insert or update the data.
     instrument : str
         The prefix for the product name.
@@ -450,32 +448,49 @@ def insert_formatted_data(
     sort_key : str
         The sort key for the DynamoDB table.
     """
-    instrument_key = data[0][partition_key]
-    times = [item[sort_key] for item in data]
+    # Get time range.
+    times = [item["time_utc"] for item in data]
     min_time = min(times)
     max_time = max(times)
     logger.info(f"Processing {min_time} to {max_time}.")
 
+    # Reformat data (remove all keep/exclude keys except hk
+    # once imap_processing is updated)
+    exclude_keys = {"apid", "met", "mag_hk_status"}
+    rename_map = {"met_in_utc": "time_utc"}
+    science_data = [
+        {rename_map.get(k, k): v for k, v in item.items() if k not in exclude_keys}
+        for item in data
+    ]
+    keep_keys = {"met_in_utc", "instrument", "mag_hk_status"}
+    hk_data = [
+        {rename_map.get(k, k): v for k, v in item.items() if k in keep_keys}
+        for item in data
+    ]
+
     # Query existing items.
-    response = algorithm_table.query(
-        KeyConditionExpression=Key(partition_key).eq(instrument_key)
-        & Key(sort_key).between(min_time, max_time)
+    response = data_table.query(
+        KeyConditionExpression=Key("instrument").eq(instrument)
+        & Key("time_utc").between(min_time, max_time)
+    )
+    hk_response = data_table.query(
+        KeyConditionExpression=Key("instrument").eq(f"{instrument}_hk")
+        & Key("time_utc").between(min_time, max_time)
     )
 
-    existing_items = {item[sort_key]: item for item in response.get("Items", [])}
+    existing_items = {item["time_utc"]: item for item in response.get("Items", [])}
+    existing_hk_items = {
+        item["time_utc"]: item for item in hk_response.get("Items", [])
+    }
 
-    # Insert or update as needed
-    for raw in data:
-        time = raw[sort_key]
-        key = {partition_key: instrument_key, sort_key: time}
+    # Insert data
+    for raw in science_data:
+        time = raw["time_utc"]
         existing = existing_items.get(time)
-        raw["last_modified"] = datetime.now(timezone.utc).isoformat()
 
         # Calculate the spacecraft position and velocity in GSM coordinates.
-        if isinstance(time, str):
-            et = str_to_et(time)
-        else:
-            et = sct_to_et(met_to_sclkticks(time))
+        et = str_to_et(time)
+
         gsm_state = imap_state(
             [et], ref_frame=SpiceFrame.IMAP_GSM, observer=SpiceBody.EARTH
         )
@@ -488,53 +503,17 @@ def insert_formatted_data(
         raw["sc_position_GSE"] = [Decimal(str(val)) for val in gse_state[0, :3]]
         raw["sc_velocity_GSE"] = [Decimal(str(val)) for val in gse_state[0, 3:]]
 
-        if existing:
-            if any(key.startswith(instrument) for key in existing.keys()):
-                continue
-
-            # TODO: remove once we transition databases.
-            # This is if an item contains multiple instruments
-            # and that will never happen in the new database.
-            update_expr = "SET " + ", ".join(
-                f"{field} = :{field}"
-                for field in raw
-                if field
-                not in {
-                    "apid",
-                    "met",
-                    "met_in_utc",
-                    "ttj2000ns",
-                    "sc_position_GSM",
-                    "sc_velocity_GSM",
-                    "sc_position_GSE",
-                    "sc_velocity_GSE",
-                }
-            )
-
-            expression_values = {
-                f":{field}": value
-                for field, value in raw.items()
-                if field
-                not in {
-                    "apid",
-                    "met",
-                    "met_in_utc",
-                    "ttj2000ns",
-                    "sc_position_GSM",
-                    "sc_velocity_GSM",
-                    "sc_position_GSE",
-                    "sc_velocity_GSE",
-                }
-            }
-
-            algorithm_table.update_item(
-                Key=key,
-                UpdateExpression=update_expr,
-                ExpressionAttributeValues=expression_values,
-            )
-        else:
-            algorithm_table.put_item(Item=raw)
+        if not existing:
+            data_table.put_item(Item=raw)
         logger.info(f"Inserted {instrument.upper()}.")
+
+    for raw in hk_data:
+        time = raw["time_utc"]
+        existing = existing_hk_items.get(time)
+
+        if not existing:
+            data_table.put_item(Item=raw)
+        logger.info(f"Inserted Housekeeping for {instrument.upper()}.")
 
 
 def insert_kernels(dependency_inputs, algorithm_table):

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -267,7 +267,7 @@ def parse_packets(filenames: list, bucket: str, download_dir: Path, apid=478):
     return combined
 
 
-def process_algorithms(combined: xr.Dataset, algorithm_table):
+def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):
     """Process the algorithms and insert data, as needed.
 
     Parameters
@@ -276,6 +276,8 @@ def process_algorithms(combined: xr.Dataset, algorithm_table):
         L0 parsed data.
     algorithm_table : dynamodb.Table
         The DynamoDB table to insert or update the data.
+    table_name : str
+        Name of the DynamoDB table
     """
     processors = [
         ("mag", process_packet),
@@ -326,10 +328,107 @@ def process_algorithms(combined: xr.Dataset, algorithm_table):
         logger.info("%s result: %s", instrument, result)
 
         if any(result) and all(result):
-            insert_data(result, algorithm_table, instrument)
+            if table_name == "ialirt-algorithm-table":
+                insert_data(result, algorithm_table, instrument)
+            else:
+                insert_formatted_data(result, algorithm_table, instrument)
 
 
-def insert_data(
+def insert_data(data: list[dict], algorithm_table, instrument: str):
+    """Insert or update database row, depending on content of item.
+
+    Parameters
+    ----------
+    data : list[dict]
+        Data product produced from processing respectively instrument.
+    algorithm_table : dynamodb.Table
+        The DynamoDB table to insert or update the data.
+    instrument : str
+        The prefix for the product name.
+    """
+    apid = data[0]["apid"]
+    mets = [item["met"] for item in data]
+    min_met = min(mets)
+    max_met = max(mets)
+    logger.info(f"Processing mets {min_met} to {max_met}.")
+    logger.info(f"Processing utc {met_to_utc(min_met)} to {met_to_utc(max_met)}.")
+
+    # Query existing items.
+    response = algorithm_table.query(
+        KeyConditionExpression=Key("apid").eq(apid)
+        & Key("met").between(min_met, max_met)
+    )
+
+    existing_items = {item["met"]: item for item in response.get("Items", [])}
+
+    # Insert or update as needed
+    for raw in data:
+        met = raw["met"]
+        key = {"apid": apid, "met": met}
+        existing = existing_items.get(met)
+        raw["last_modified"] = datetime.now(timezone.utc).isoformat()
+
+        # Calculate the spacecraft position and velocity in GSM coordinates.
+        et = sct_to_et(met_to_sclkticks(met))
+        gsm_state = imap_state(
+            [et], ref_frame=SpiceFrame.IMAP_GSM, observer=SpiceBody.EARTH
+        )
+        gse_state = imap_state(
+            [et], ref_frame=SpiceFrame.IMAP_GSE, observer=SpiceBody.EARTH
+        )
+
+        raw["sc_position_GSM"] = [Decimal(str(val)) for val in gsm_state[0, :3]]
+        raw["sc_velocity_GSM"] = [Decimal(str(val)) for val in gsm_state[0, 3:]]
+        raw["sc_position_GSE"] = [Decimal(str(val)) for val in gse_state[0, :3]]
+        raw["sc_velocity_GSE"] = [Decimal(str(val)) for val in gse_state[0, 3:]]
+
+        if existing:
+            if any(key.startswith(instrument) for key in existing.keys()):
+                continue
+
+            update_expr = "SET " + ", ".join(
+                f"{field} = :{field}"
+                for field in raw
+                if field
+                not in {
+                    "apid",
+                    "met",
+                    "met_in_utc",
+                    "ttj2000ns",
+                    "sc_position_GSM",
+                    "sc_velocity_GSM",
+                    "sc_position_GSE",
+                    "sc_velocity_GSE",
+                }
+            )
+
+            expression_values = {
+                f":{field}": value
+                for field, value in raw.items()
+                if field
+                not in {
+                    "apid",
+                    "met",
+                    "met_in_utc",
+                    "ttj2000ns",
+                    "sc_position_GSM",
+                    "sc_velocity_GSM",
+                    "sc_position_GSE",
+                    "sc_velocity_GSE",
+                }
+            }
+
+            algorithm_table.update_item(
+                Key=key,
+                UpdateExpression=update_expr,
+                ExpressionAttributeValues=expression_values,
+            )
+        else:
+            algorithm_table.put_item(Item=raw)
+        logger.info(f"Inserted {instrument.upper()}.")
+
+
+def insert_formatted_data(
     data: list[dict],
     algorithm_table,
     instrument: str,
@@ -506,7 +605,6 @@ def lambda_handler(event, context):
     filename = os.path.basename(s3_filepath)
     logger.info("Retrieved filename: %s", filename)
     dependency_inputs = get_latest_spice_kernels(url)
-
     logger.info("dependency_inputs: %s", dependency_inputs)
     download_spice_file(dependency_inputs)
 
@@ -526,11 +624,11 @@ def lambda_handler(event, context):
         combined = parse_packets(filenames, bucket, Path("/tmp"))  # noqa: S108
         logger.info("Packets parsed. Processing algorithms.")
         # Process algorithms and insert new data.
-        process_algorithms(combined, algorithm_table)
+        process_algorithms(combined, algorithm_table, algorithm_table_name)
         # Insert kernel metadata every minute.
         insert_kernels(dependency_inputs, algorithm_table)
 
-        process_algorithms(combined, data_table)
+        process_algorithms(combined, data_table, data_table_name)
         insert_kernels(dependency_inputs, data_table)
 
         logger.info("Successfully wrote all new items to DynamoDB")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -461,6 +461,7 @@ def reformat_data(data):
             if k in keep_keys
         }
         for item in data
+        if item.get("instrument") == "mag"
     ]
 
     return science_data, hk_data
@@ -483,7 +484,7 @@ def insert_formatted_data(
         The prefix for the product name.
     """
     # Get time range.
-    times = [item["time_utc"] for item in data]
+    times = [item["met_in_utc"] for item in data]
     min_time = min(times)
     max_time = max(times)
     logger.info(f"Processing {min_time} to {max_time}.")
@@ -515,13 +516,14 @@ def insert_formatted_data(
         logger.info(f"Inserted {instrument.upper()}.")
 
     # Insert hk data
-    for raw in hk_data:
-        time = raw["time_utc"]
-        existing = existing_hk_items.get(time)
+    if hk_data:
+        for raw in hk_data:
+            time = raw["time_utc"]
+            existing = existing_hk_items.get(time)
 
-        if not existing:
-            data_table.put_item(Item=raw)
-        logger.info(f"Inserted Housekeeping for {instrument.upper()}.")
+            if not existing:
+                data_table.put_item(Item=raw)
+            logger.info(f"Inserted Housekeeping for {instrument.upper()}.")
 
     # Calculate the spacecraft position and velocity in GSE/GSM coordinates.
     et = str_to_et(min_time)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,3 +56,45 @@ def setup_dynamodb():
         yield {
             "algorithm_table": algorithm_table,
         }
+
+
+@pytest.fixture
+def setup_data_table():
+    """Initialize DynamoDB resource and create table."""
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
+    os.environ["INGEST_TABLE"] = "imap-ingest-table"
+    os.environ["DATA_TABLE"] = "imap-data-table"
+
+    with mock_dynamodb():
+        # Initialize DynamoDB resource
+        dynamodb = boto3.resource("dynamodb", region_name="us-west-2")
+
+        data_table = dynamodb.create_table(
+            TableName=os.environ["DATA_TABLE"],
+            KeySchema=[
+                # Partition key
+                {"AttributeName": "instrument", "KeyType": "HASH"},
+                # Sort key
+                {"AttributeName": "met_in_utc", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "instrument", "AttributeType": "S"},
+                {"AttributeName": "met_in_utc", "AttributeType": "S"},
+                {"AttributeName": "last_modified", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "last_modified",  # Unique index name
+                    "KeySchema": [
+                        {"AttributeName": "instrument", "KeyType": "HASH"},
+                        {"AttributeName": "last_modified", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        yield {
+            "data_table": data_table,
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,22 +75,11 @@ def setup_data_table():
                 # Partition key
                 {"AttributeName": "instrument", "KeyType": "HASH"},
                 # Sort key
-                {"AttributeName": "met_in_utc", "KeyType": "RANGE"},
+                {"AttributeName": "time_utc", "KeyType": "RANGE"},
             ],
             AttributeDefinitions=[
                 {"AttributeName": "instrument", "AttributeType": "S"},
-                {"AttributeName": "met_in_utc", "AttributeType": "S"},
-                {"AttributeName": "last_modified", "AttributeType": "S"},
-            ],
-            GlobalSecondaryIndexes=[
-                {
-                    "IndexName": "last_modified",  # Unique index name
-                    "KeySchema": [
-                        {"AttributeName": "instrument", "KeyType": "HASH"},
-                        {"AttributeName": "last_modified", "KeyType": "RANGE"},
-                    ],
-                    "Projection": {"ProjectionType": "ALL"},
-                },
+                {"AttributeName": "time_utc", "AttributeType": "S"},
             ],
             BillingMode="PAY_PER_REQUEST",
         )

--- a/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
+++ b/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
@@ -37,13 +37,13 @@ def populate_data_table(setup_data_table):
     items = [
         {
             "instrument": "mag",
-            "met_in_utc": "2021-01-01T00:00:00",
+            "met_in_utc": "2021-01-01T00:00:00.000000001",
             "last_modified": "2021-01-01T00:00:00",
             "data_product_1": str(1234.56),
         },
         {
             "instrument": "mag",
-            "met_in_utc": "2021-02-01T00:00:00",
+            "met_in_utc": "2021-02-01T00:00:00.000000005",
             "last_modified": "2021-02-01T00:00:00",
             "data_product_2": str(101.3),
         },

--- a/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
+++ b/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
@@ -37,14 +37,12 @@ def populate_data_table(setup_data_table):
     items = [
         {
             "instrument": "mag",
-            "met_in_utc": "2021-01-01T00:00:00.000000001",
-            "last_modified": "2021-01-01T00:00:00",
+            "time_utc": "2021-01-01T00:00:00",
             "data_product_1": str(1234.56),
         },
         {
             "instrument": "mag",
-            "met_in_utc": "2021-02-01T00:00:00.000000005",
-            "last_modified": "2021-02-01T00:00:00",
+            "time_utc": "2021-02-01T00:00:00",
             "data_product_2": str(101.3),
         },
     ]
@@ -68,26 +66,11 @@ def test_data_query_by_utc(setup_data_table, populate_data_table):
 
     response = data_table.query(
         KeyConditionExpression=Key("instrument").eq("mag")
-        & Key("met_in_utc").between("2021-00-00T00:00:00", "2021-01-02T00:00:00")
+        & Key("time_utc").between("2021-00-00T00:00:00", "2021-01-02T00:00:00")
     )
     items = response["Items"]
     assert len(items) == 1
-    assert items[0]["met_in_utc"] == expected_items[0]["met_in_utc"]
-
-
-def test_data_query_by_last_modified(setup_data_table, populate_data_table):
-    """Test to query by last_modified."""
-    data_table = setup_data_table["data_table"]
-    expected_items = populate_data_table
-
-    response = data_table.query(
-        IndexName="last_modified",
-        KeyConditionExpression=Key("instrument").eq("mag")
-        & Key("last_modified").begins_with("2021-01"),
-    )
-    items = response["Items"]
-    assert len(items) == 1
-    assert items[0] == expected_items[0]
+    assert items[0]["time_utc"] == expected_items[0]["time_utc"]
 
 
 def test_algorithm_query_by_met(setup_dynamodb, populate_algorithm_table):

--- a/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
+++ b/tests/infrastructure/test_ialirt_ingest_lambda_construct.py
@@ -30,6 +30,66 @@ def populate_algorithm_table(setup_dynamodb):
     return items
 
 
+@pytest.fixture
+def populate_data_table(setup_data_table):
+    """Populate DynamoDB table."""
+    data_table = setup_data_table["data_table"]
+    items = [
+        {
+            "instrument": "mag",
+            "met_in_utc": "2021-01-01T00:00:00",
+            "last_modified": "2021-01-01T00:00:00",
+            "data_product_1": str(1234.56),
+        },
+        {
+            "instrument": "mag",
+            "met_in_utc": "2021-02-01T00:00:00",
+            "last_modified": "2021-02-01T00:00:00",
+            "data_product_2": str(101.3),
+        },
+    ]
+    for item in items:
+        data_table.put_item(Item=item)
+
+    return items
+
+
+def test_data_query_by_utc(setup_data_table, populate_data_table):
+    """Test to query by met_in_utc."""
+    data_table = setup_data_table["data_table"]
+    expected_items = populate_data_table
+
+    response = data_table.query(KeyConditionExpression=Key("instrument").eq("mag"))
+
+    items = response["Items"]
+
+    for item in range(len(items)):
+        assert items[item] == expected_items[item]
+
+    response = data_table.query(
+        KeyConditionExpression=Key("instrument").eq("mag")
+        & Key("met_in_utc").between("2021-00-00T00:00:00", "2021-01-02T00:00:00")
+    )
+    items = response["Items"]
+    assert len(items) == 1
+    assert items[0]["met_in_utc"] == expected_items[0]["met_in_utc"]
+
+
+def test_data_query_by_last_modified(setup_data_table, populate_data_table):
+    """Test to query by last_modified."""
+    data_table = setup_data_table["data_table"]
+    expected_items = populate_data_table
+
+    response = data_table.query(
+        IndexName="last_modified",
+        KeyConditionExpression=Key("instrument").eq("mag")
+        & Key("last_modified").begins_with("2021-01"),
+    )
+    items = response["Items"]
+    assert len(items) == 1
+    assert items[0] == expected_items[0]
+
+
 def test_algorithm_query_by_met(setup_dynamodb, populate_algorithm_table):
     """Test to query by met."""
     algorithm_table = setup_dynamodb["algorithm_table"]

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -26,6 +26,7 @@ from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
     parse_packets,
     process_algorithms,
     query_filenames,
+    reformat_data,
 )
 
 
@@ -242,6 +243,74 @@ def test_insert_data(
     assert item3["hit_e_a_side_low_en"] == Decimal("5.0")
 
 
+def test_reformat_data():
+    """Test reformat_data function."""
+    test_data = [
+        {
+            "apid": 478,
+            "met": 374,
+            "instrument": "mag",
+            "met_in_utc": "2021-01-01T00:00:00",
+            "ttj2000ns": 759175836184000000,
+            "mag_data": Decimal("1.0"),
+            "mag_hk_status": {"hk1v5_warn": False, "hk1v5_danger": True},
+        },
+        {
+            "apid": 478,
+            "met": 375,
+            "instrument": "mag",
+            "met_in_utc": "2021-01-01T00:00:01",
+            "ttj2000ns": 759175836184000001,
+            "mag_data": Decimal("2.0"),
+            "mag_hk_status": {"hk1v5_warn": True, "hk1v5_danger": False},
+        },
+    ]
+
+    science_data, hk_data = reformat_data(test_data)
+
+    assert all("apid" not in d for d in science_data)
+    assert all("met" not in d for d in science_data)
+    assert all("mag_hk_status" not in d for d in science_data)
+    assert science_data[0]["time_utc"] == "2021-01-01T00:00:00"
+
+    assert hk_data[0]["instrument"] == "mag_hk"
+    assert hk_data[0]["time_utc"] == "2021-01-01T00:00:00"
+    assert hk_data[0]["mag_hk_status"]["hk1v5_danger"] is True
+
+
+def test_reformat_data_no_hk():
+    """Test reformat_data function with no HK data."""
+    test_data = [
+        {
+            "apid": 478,
+            "met": 374,
+            "instrument": "hit",
+            "met_in_utc": "2021-01-01T00:00:00",
+            "ttj2000ns": 759175836184000000,
+            "hit_data": Decimal("1.0"),
+        },
+        {
+            "apid": 478,
+            "met": 375,
+            "instrument": "hit",
+            "met_in_utc": "2021-01-01T00:00:01",
+            "ttj2000ns": 759175836184000001,
+            "hit_data": Decimal("2.0"),
+        },
+    ]
+
+    science_data, hk_data = reformat_data(test_data)
+
+    assert all("apid" not in d for d in science_data)
+    assert all("met" not in d for d in science_data)
+    assert all("mag_hk_status" not in d for d in science_data)
+    assert science_data[0]["time_utc"] == "2021-01-01T00:00:00"
+
+    assert hk_data[0]["instrument"] == "mag_hk"
+    assert hk_data[0]["time_utc"] == "2021-01-01T00:00:00"
+    assert hk_data[0]["mag_hk_status"]["hk1v5_danger"] is True
+
+
 @patch(
     "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_state",
     return_value=np.array([[1, 2, 3, 4, 5, 6]]),
@@ -250,19 +319,19 @@ def test_insert_data(
     "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.str_to_et",
     return_value=12345.0,
 )
-def test_insert_restructured_data(
+def test_insert_formatted_data(
     mock_str_to_et,
     mock_imap_state,
     setup_data_table,
 ):
-    """Test insert_data function."""
+    """Test insert_formatted_data function."""
     data_table = setup_data_table["data_table"]
 
     # Existing item.
     data_table.put_item(
         Item={
             "instrument": "mag",
-            "met_in_utc": "2021-01-01T00:00:00.000000001",
+            "met_in_utc": "2021-01-01T00:00:00",
             "mag_data": Decimal("0.0"),
         }
     )
@@ -271,7 +340,7 @@ def test_insert_restructured_data(
     data_table.put_item(
         Item={
             "instrument": "mag",
-            "met_in_utc": "2021-02-01T00:00:00.000000001",
+            "met_in_utc": "2021-02-01T00:00:00",
             "mag_data": Decimal("0.0"),
         }
     )
@@ -281,21 +350,21 @@ def test_insert_restructured_data(
         # Will skip.
         {
             "instrument": "mag",
-            "met_in_utc": "2021-01-01T00:00:00.000000001",
+            "met_in_utc": "2021-01-01T00:00:00",
             "ttj2000ns": 759175836184000000,
             "mag_data": Decimal("2.0"),
         },
         # Will skip.
         {
             "instrument": "mag",
-            "met_in_utc": "2021-02-01T00:00:00.000000001",
+            "met_in_utc": "2021-02-01T00:00:00",
             "ttj2000ns": 759175836184000001,
             "mag_data": Decimal("3.0"),
         },
         # Will insert.
         {
             "instrument": "mag",
-            "met_in_utc": "2021-03-01T00:00:00.000000001",
+            "met_in_utc": "2021-03-01T00:00:00",
             "ttj2000ns": 759175836184000002,
             "mag_data": Decimal("5.0"),
         },

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -203,7 +203,7 @@ def test_insert_data(
         {
             "apid": 478,
             "met": 123456,
-            "utc": "2025-05-21T14:00:00",
+            "met_in_utc": "2025-05-21T14:00:00",
             "ttj2000ns": 759175836184000000,
             "hit_e_a_side_med_en": Decimal("2.0"),
         },
@@ -211,7 +211,7 @@ def test_insert_data(
         {
             "apid": 478,
             "met": 123457,
-            "utc": "2025-05-21T14:00:01",
+            "met_in_utc": "2025-05-21T14:00:01",
             "ttj2000ns": 759175836184000001,
             "hit_e_a_side_low_en": Decimal("3.0"),
         },
@@ -219,7 +219,7 @@ def test_insert_data(
         {
             "apid": 478,
             "met": 123458,
-            "utc": "2025-05-21T14:00:02",
+            "met_in_utc": "2025-05-21T14:00:02",
             "ttj2000ns": 759175836184000002,
             "hit_e_a_side_low_en": Decimal("5.0"),
         },
@@ -240,6 +240,87 @@ def test_insert_data(
 
     # New item should be inserted
     assert item3["hit_e_a_side_low_en"] == Decimal("5.0")
+
+
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_state",
+    return_value=np.array([[1, 2, 3, 4, 5, 6]]),
+)
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.str_to_et",
+    return_value=12345.0,
+)
+def test_insert_restructured_data(
+    mock_str_to_et,
+    mock_imap_state,
+    setup_data_table,
+):
+    """Test insert_data function."""
+    data_table = setup_data_table["data_table"]
+
+    # Existing item.
+    data_table.put_item(
+        Item={
+            "instrument": "mag",
+            "met_in_utc": "2021-01-01T00:00:00.000000001",
+            "mag_data": Decimal("0.0"),
+        }
+    )
+
+    # Existing item.
+    data_table.put_item(
+        Item={
+            "instrument": "mag",
+            "met_in_utc": "2021-02-01T00:00:00.000000001",
+            "mag_data": Decimal("0.0"),
+        }
+    )
+
+    # Create data for all three cases
+    test_data = [
+        # Will skip.
+        {
+            "instrument": "mag",
+            "met_in_utc": "2021-01-01T00:00:00.000000001",
+            "ttj2000ns": 759175836184000000,
+            "mag_data": Decimal("2.0"),
+        },
+        # Will skip.
+        {
+            "instrument": "mag",
+            "met_in_utc": "2021-02-01T00:00:00.000000001",
+            "ttj2000ns": 759175836184000001,
+            "mag_data": Decimal("3.0"),
+        },
+        # Will insert.
+        {
+            "instrument": "mag",
+            "met_in_utc": "2021-03-01T00:00:00.000000001",
+            "ttj2000ns": 759175836184000002,
+            "mag_data": Decimal("5.0"),
+        },
+    ]
+
+    insert_data(
+        test_data, data_table, "mag", partition_key="instrument", sort_key="met_in_utc"
+    )
+
+    item1 = data_table.get_item(
+        Key={"instrument": "mag", "met_in_utc": "2021-01-01T00:00:00.000000001"}
+    )["Item"]
+    item2 = data_table.get_item(
+        Key={"instrument": "mag", "met_in_utc": "2021-02-01T00:00:00.000000001"}
+    )["Item"]
+    item3 = data_table.get_item(
+        Key={"instrument": "mag", "met_in_utc": "2021-03-01T00:00:00.000000001"}
+    )["Item"]
+
+    # Not updated
+    assert item1["mag_data"] == Decimal("0.0")
+    assert item2["mag_data"] == Decimal("0.0")
+
+    # New item should be inserted
+    assert item3["mag_data"] == Decimal("5.0")
 
 
 @patch(

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -1,5 +1,6 @@
 """Test the I-Alirt ingest lambda function."""
 
+import os
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -52,6 +53,7 @@ def test_lambda_handler(mock_get, mock_download, mock_furnsh, setup_dynamodb):
     """Test the lambda_handler function."""
     # Mock event data
     algorithm_table = setup_dynamodb["algorithm_table"]
+    os.environ["DATA_TABLE"] = algorithm_table.name
 
     mock_response = MagicMock()
     mock_response.json.return_value = [

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -513,7 +513,11 @@ def test_process_algorithms(
         "/mock/imap_mag_l1b-calibration_20250101_v002.cdf"
     )
 
-    process_algorithms(combined=None, algorithm_table=algorithm_table)
+    process_algorithms(
+        combined=None,
+        algorithm_table=algorithm_table,
+        table_name="ialirt-algorithm-table",
+    )
 
     response = algorithm_table.query(KeyConditionExpression=Key("apid").eq(478))[
         "Items"

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -304,10 +304,22 @@ def test_reformat_data_no_hk():
 
     science_data, hk_data = reformat_data(test_data)
 
-    assert all("apid" not in d for d in science_data)
-    assert all("met" not in d for d in science_data)
-    assert science_data[0]["time_utc"] == "2021-01-01T00:00:00"
+    expected_science_data = [
+        {
+            "instrument": "hit",
+            "time_utc": "2021-01-01T00:00:00",
+            "ttj2000ns": 759175836184000000,
+            "hit_data": Decimal("1.0"),
+        },
+        {
+            "instrument": "hit",
+            "time_utc": "2021-01-01T00:00:01",
+            "ttj2000ns": 759175836184000001,
+            "hit_data": Decimal("2.0"),
+        },
+    ]
 
+    assert science_data == expected_science_data
     assert hk_data == []
 
 
@@ -356,7 +368,7 @@ def test_insert_formatted_data(
 
     # Create data for all three cases
     test_data = [
-        # Will skip.
+        # Will insert.
         {
             "instrument": "mag",
             "met_in_utc": "2021-01-01T00:00:00",
@@ -364,7 +376,7 @@ def test_insert_formatted_data(
             "mag_data": Decimal("2.0"),
             "mag_hk_status": {"hk1v5_warn": False, "hk1v5_danger": True},
         },
-        # Will skip.
+        # Will insert.
         {
             "instrument": "mag",
             "met_in_utc": "2021-02-01T00:00:00",
@@ -397,12 +409,12 @@ def test_insert_formatted_data(
         Key={"instrument": "mag_hk", "time_utc": "2021-02-01T00:00:00"}
     )["Item"]
     item5 = data_table.get_item(
-        Key={"instrument": "geolocation", "time_utc": "2021-01-01T00:00:00"}
+        Key={"instrument": "spacecraft", "time_utc": "2021-01-01T00:00:00"}
     )["Item"]
 
-    # Not updated
-    assert item1["mag_data"] == Decimal("0.0")
-    assert item2["mag_data"] == Decimal("0.0")
+    # Existing
+    assert item1["mag_data"] == Decimal("2.0")
+    assert item2["mag_data"] == Decimal("3.0")
 
     # New item should be inserted
     assert item3["mag_data"] == Decimal("5.0")

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -21,6 +21,7 @@ from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
     get_ancillary,
     get_latest_spice_kernels,
     insert_data,
+    insert_formatted_data,
     insert_kernels,
     lambda_handler,
     parse_packets,
@@ -303,12 +304,9 @@ def test_reformat_data_no_hk():
 
     assert all("apid" not in d for d in science_data)
     assert all("met" not in d for d in science_data)
-    assert all("mag_hk_status" not in d for d in science_data)
     assert science_data[0]["time_utc"] == "2021-01-01T00:00:00"
 
-    assert hk_data[0]["instrument"] == "mag_hk"
-    assert hk_data[0]["time_utc"] == "2021-01-01T00:00:00"
-    assert hk_data[0]["mag_hk_status"]["hk1v5_danger"] is True
+    assert hk_data == []
 
 
 @patch(
@@ -331,7 +329,7 @@ def test_insert_formatted_data(
     data_table.put_item(
         Item={
             "instrument": "mag",
-            "met_in_utc": "2021-01-01T00:00:00",
+            "time_utc": "2021-01-01T00:00:00",
             "mag_data": Decimal("0.0"),
         }
     )
@@ -340,8 +338,17 @@ def test_insert_formatted_data(
     data_table.put_item(
         Item={
             "instrument": "mag",
-            "met_in_utc": "2021-02-01T00:00:00",
+            "time_utc": "2021-02-01T00:00:00",
             "mag_data": Decimal("0.0"),
+        }
+    )
+
+    # Existing item.
+    data_table.put_item(
+        Item={
+            "instrument": "mag_hk",
+            "time_utc": "2021-02-01T00:00:00",
+            "mag_hk_status": {"hk1v5_warn": False, "hk1v5_danger": True},
         }
     )
 
@@ -353,6 +360,7 @@ def test_insert_formatted_data(
             "met_in_utc": "2021-01-01T00:00:00",
             "ttj2000ns": 759175836184000000,
             "mag_data": Decimal("2.0"),
+            "mag_hk_status": {"hk1v5_warn": False, "hk1v5_danger": True},
         },
         # Will skip.
         {
@@ -360,6 +368,7 @@ def test_insert_formatted_data(
             "met_in_utc": "2021-02-01T00:00:00",
             "ttj2000ns": 759175836184000001,
             "mag_data": Decimal("3.0"),
+            "mag_hk_status": {"hk1v5_warn": False, "hk1v5_danger": True},
         },
         # Will insert.
         {
@@ -367,21 +376,26 @@ def test_insert_formatted_data(
             "met_in_utc": "2021-03-01T00:00:00",
             "ttj2000ns": 759175836184000002,
             "mag_data": Decimal("5.0"),
+            "mag_hk_status": {"hk1v5_warn": False, "hk1v5_danger": True},
         },
     ]
 
-    insert_data(
-        test_data, data_table, "mag", partition_key="instrument", sort_key="met_in_utc"
-    )
+    insert_formatted_data(test_data, data_table, "mag")
 
     item1 = data_table.get_item(
-        Key={"instrument": "mag", "met_in_utc": "2021-01-01T00:00:00.000000001"}
+        Key={"instrument": "mag", "time_utc": "2021-01-01T00:00:00"}
     )["Item"]
     item2 = data_table.get_item(
-        Key={"instrument": "mag", "met_in_utc": "2021-02-01T00:00:00.000000001"}
+        Key={"instrument": "mag", "time_utc": "2021-02-01T00:00:00"}
     )["Item"]
     item3 = data_table.get_item(
-        Key={"instrument": "mag", "met_in_utc": "2021-03-01T00:00:00.000000001"}
+        Key={"instrument": "mag", "time_utc": "2021-03-01T00:00:00"}
+    )["Item"]
+    item4 = data_table.get_item(
+        Key={"instrument": "mag_hk", "time_utc": "2021-02-01T00:00:00"}
+    )["Item"]
+    item5 = data_table.get_item(
+        Key={"instrument": "geolocation", "time_utc": "2021-01-01T00:00:00"}
     )["Item"]
 
     # Not updated
@@ -390,6 +404,8 @@ def test_insert_formatted_data(
 
     # New item should be inserted
     assert item3["mag_data"] == Decimal("5.0")
+    assert item4["mag_hk_status"]["hk1v5_danger"] is True
+    assert item5["sc_position_GSM"] == [Decimal("1"), Decimal("2"), Decimal("3")]
 
 
 @patch(


### PR DESCRIPTION
# Change Summary

## Overview
Add a parallel db table w/ new partition key and sort key.

## Updated Files
- ialirt_ingest_lambda_construct.py
   - Add new db table w/ partition key = instrument and sort key = met_in_utc
- ialirt_ingest.py
   - Add new partition key “instrument” to kernel ingest
   - Update the insert function
   - Add capability to insert into new table (after the old table just in case there are any errors)

## Testing
- conftest.py
   - Add new database setup
- test_ialirt_ingest_lambda_construct.py
   - test_ialirt_ingest.py

## Notes
We will need to update our query apis and also archive api once this is approved and we begin to transition to the new database.