### PR TITLE
FIX: APIGateway results_cache_ttl can be a maximum of 1 hour is all

### DIFF
--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -127,7 +127,7 @@ class ApiGateway(Construct):
             identity_source=["$request.header.x-api-key"],
             # Cache multiple requests with the same API key so we don't
             # invoke the lambda repeatedly for the same key
-            results_cache_ttl=Duration.hours(12),
+            results_cache_ttl=Duration.hours(1),
         )
 
         # Add a custom domain to the API if we have one


### PR DESCRIPTION
# Change Summary

## Overview

Did not realize this because it synthesized just fine and only failed on deploy, but did fail with a useful error message saying a maximum of 3600 seconds.

https://github.com/IMAP-Science-Operations-Center/sds-data-manager/actions/runs/18608988297/job/53063654478#step:10:668