### PR TITLE
updates to pointing schedule api naming and catalog api structure

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -56,7 +56,7 @@ def lambda_handler(event, context) -> dict:
             },
             'body': '{
                     "file_names":
-                        ["20250206_station1_01.txt", "20250206_station1_02.txt"],
+                        ["2025-02-06_station1_01.txt", "2025-02-06_station1_02.txt"],
                      "dates_modified":
                         ["2025-02-12 18:37", "2025-02-12 18:37"]}
             }'

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_catalog_api.py
@@ -55,8 +55,7 @@ def lambda_handler(event, context) -> dict:
                 'Content-Type': 'application/json'
             },
             'body': '{
-                "2025-02-06":
-                    {"file_names":
+                    "file_names":
                         ["20250206_station1_01.txt", "20250206_station1_02.txt"],
                      "dates_modified":
                         ["2025-02-12 18:37", "2025-02-12 18:37"]}
@@ -96,28 +95,28 @@ def lambda_handler(event, context) -> dict:
         config=botocore.client.Config(signature_version="s3v4"),
     )
 
-    response_body = {}
+    response_body = {"file_names": [], "dates_modified": []}
     while day < end_date:
-        day_path = f"pointing_schedules/{station}/{day.strftime('%Y%m%d')}/"
+        day_path = f"pointing_schedules/{station}/{day.strftime('%Y-%m-%d')}"
         files = s3_client.list_objects_v2(Bucket=bucket, Prefix=day_path)
+        # Return all existing files.
         if "Contents" not in files.keys():
-            return {
-                "statusCode": 404,
-                "headers": {"Content-Type": "application/json"},
-                "body": "There are not files associated with the provided date {day}. "
-                "Please supply a valid time range that is covered by existing "
-                "files.",
-            }
-        file_names = []
-        dates_modified = []
+            logger.info(f"No files found for {day.strftime('%Y-%m-%d')}")
+            day += timedelta(days=1)
+            continue
         for file in files["Contents"]:
-            file_names.append(file["Key"].rsplit("/", 1)[1])
-            dates_modified.append(file["LastModified"].strftime("%Y-%m-%d %H:%M"))
-        response_body[f"{day}"] = {
-            "file_names": file_names,
-            "dates_modified": dates_modified,
-        }
+            response_body["file_names"].append(file["Key"].rsplit("/", 1)[1])
+            response_body["dates_modified"].append(
+                file["LastModified"].strftime("%Y-%m-%d %H:%M")
+            )
         day += timedelta(days=1)
+
+    if not response_body["file_names"]:
+        return {
+            "statusCode": 404,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"message": "No files found for the requested range."}),
+        }
 
     return {
         "statusCode": 200,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_pointing_schedule.py
@@ -35,7 +35,7 @@ def generate_and_upload_schedule(bucket: str, region: str, station: str, day: st
         Ex: "2025-08-11".
     """
     file_name = f"{day}_{station}.txt"
-    s3_path = f"pointing_schedules/{station}/{day}/{file_name}"
+    s3_path = f"pointing_schedules/{station}/{file_name}"
 
     output = generate_text_files(station, day)
 
@@ -48,10 +48,7 @@ def generate_and_upload_schedule(bucket: str, region: str, station: str, day: st
             Key=s3_path,
             Body="".join(output),
         )
-        logger.info(
-            f"Pointing schedule '{day}_{station}.txt' uploaded to "
-            f"s3://{bucket}/{s3_path}"
-        )
+        logger.info(f"Pointing schedule uploaded to s3://{bucket}/{s3_path}")
     except Exception as e:
         logger.error(f"Error uploading file: {e}")
 

--- a/tests/lambda_endpoints/test_ialirt_catalog_api.py
+++ b/tests/lambda_endpoints/test_ialirt_catalog_api.py
@@ -56,8 +56,8 @@ def test_no_files_ialirt_catalog_api(s3_client):
 
 def test_success_ialirt_catalog_api(s3_client):
     """Test a successful call to the catalog endpoint."""
-    test_file1 = "pointing_schedules/station1/20250206/20250206_station1_01.txt"
-    test_file2 = "pointing_schedules/station1/20250206/20250206_station1_02.txt"
+    test_file1 = "pointing_schedules/station1/2025-02-06_station1_01.txt"
+    test_file2 = "pointing_schedules/station1/2025-02-06_station1_02.txt"
     s3_client.put_object(
         Bucket="test-data-bucket",
         Key=test_file1,
@@ -77,7 +77,7 @@ def test_success_ialirt_catalog_api(s3_client):
     }
     response = ialirt_catalog_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 200
-    assert json.loads(response["body"])["2025-02-06 00:00:00"]["file_names"] == [
-        "20250206_station1_01.txt",
-        "20250206_station1_02.txt",
+    assert json.loads(response["body"])["file_names"] == [
+        "2025-02-06_station1_01.txt",
+        "2025-02-06_station1_02.txt",
     ]


### PR DESCRIPTION
# Change Summary

## Overview
Update catalog api for filenaming consistency and also some minor changes regarding directory structure.

## Updated Files
- ialirt_pointing_schedule.py
   - Instead of using a directory for each day, just use filename
-  ialirt_catalog_api.py
   - Correct prefix for s3 query. Make it to where the returned structure is flatter.

## Testing
test_ialirt_catalog_endpoint.py
