### PR TITLE
Get end time of repoint table from Pointing table

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -615,7 +615,7 @@ def calculate_repoint_table_date_range(session, file_obj):
     tuple
         A tuple containing the start date and end date in the format YYYYMMDD.
     """
-    # Query the pointing table to find the pointing information.
+    # Query the repoint table to get the exact date/time.
     end_date = file_obj.spice_metadata["end_date"]
     previous_entries = (
         session.query(models.RepointFiles)

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
@@ -408,16 +408,33 @@ def index_repoint_file(s3_key):
     """
     logger.info(f"Indexing {s3_key} to RepointFiles table")
     with db.Session() as session:
-        spin_obj = SPICEFilePath(os.path.basename(s3_key))
-        spin_metadata = spin_obj.spice_metadata
+        repoint_obj = SPICEFilePath(os.path.basename(s3_key))
+        metadata = repoint_obj.spice_metadata
+
+        # Query Pointing Table to get the exact date/time of the latest data
+        # in the repoint file. This requires that `index_pointing_data` is run
+        # before indexing the repoint file.
+        final_pointings = (
+            session.query(models.PointingTable)
+            .order_by(models.PointingTable.pointing_id.desc())
+            .limit(2)
+            .all()
+        )
+        # The repoint end time should be the last Pointing start time if it is not
+        # null. Otherwise, it should be the second-to-last repoint start time.
+        end_date = (
+            final_pointings[0].pointing_start_utc
+            or final_pointings[1].repoint_start_utc
+        )
+
         params = {
             "file_path": s3_key,
-            "end_date": spin_metadata["end_date"],
-            "version": spin_metadata["version"],
+            "end_date": end_date,
+            "version": metadata["version"],
             "ingestion_date": get_file_ingestion_date(s3_key),
         }
-        spin_table = models.RepointFiles(**params)
-        session.add(spin_table)
+        repoint_table = models.RepointFiles(**params)
+        session.add(repoint_table)
         session.commit()
 
     logger.info(f"Indexed {s3_key} to SPICEFiles table")

--- a/tests/lambda_endpoints/test_spice_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_spice_indexer_lambda.py
@@ -23,6 +23,7 @@ from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer import 
     MAXIMUM_SCLK_INTERVAL,
     get_coverage_dictionary,
     index_pointing_data,
+    parse_datetime,
 )
 
 
@@ -336,6 +337,30 @@ def test_s3_repoint_files(mock_download, session, s3_client, events_client):
     pointing_ids = session.query(models.PointingTable.pointing_id).all()
     assert len(pointing_ids) == 49
 
+    # Query RepointFiles table to verify it was populated
+    repoint_file_entry = (
+        session.query(models.RepointFiles)
+        .filter_by(file_path="imap/spice/repoint/imap_2000_056_03.repoint.csv")
+        .first()
+    )
+    assert repoint_file_entry is not None
+    assert repoint_file_entry.version == "03"
+    assert (
+        repoint_file_entry.file_path
+        == "imap/spice/repoint/imap_2000_056_03.repoint.csv"
+    )
+    # The end_date should be from the last pointing entry
+    last_pointing = (
+        session.query(models.PointingTable)
+        .order_by(models.PointingTable.pointing_id.desc())
+        .first()
+    )
+    expected_end_date = (
+        last_pointing.pointing_end_utc or last_pointing.pointing_start_utc
+    )
+    assert repoint_file_entry.end_date == expected_end_date
+    assert repoint_file_entry.ingestion_date is not None
+
 
 def test_send_spice_event(session, events_client, s3_client):
     """Test the ``send_spice_event`` function."""
@@ -440,3 +465,125 @@ def test_index_pointing_data_updates_null_values(mock_download, session, tmpdir)
     assert first_pointing_entry.repoint_start_utc == datetime(2025, 7, 2, 10, 0, 0)
     # # i_pointing + 1 repoint_end_utc
     assert first_pointing_entry.repoint_end_utc == datetime(2025, 7, 2, 10, 10, 0)
+
+
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.get_file_ingestion_date",
+    return_value=datetime(2025, 1, 1, 10, 0, 0),
+)
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.download_from_s3"
+)
+def test_index_repoint_file_with_null_pointing_end_utc(
+    mock_download, mock_get_ingestion_date, session, tmp_path
+):
+    """Test index_repoint_file when repoint_end_utc is a NaN."""
+    new_repoint_file = tmp_path / "imap_2025_100_01.repoint.csv"
+    mock_download.return_value = new_repoint_file
+
+    # Create a test CSV file with repoint data
+    test_csv_content = """repoint_id,repoint_start_utc,repoint_end_utc
+1,2025-04-10T10:00:00.000000,2025-04-10T10:10:00.000000
+2,2025-04-11T10:00:00.000000,NaN
+"""
+    with open(new_repoint_file, "w") as f:
+        f.write(test_csv_content)
+
+    # First index the pointing data
+    index_pointing_data("imap/spice/repoint/imap_2025_100_01.repoint.csv")
+
+    # Get the last pointing entry and verify it has None for pointing_end_utc
+    last_pointing = (
+        session.query(models.PointingTable)
+        .order_by(models.PointingTable.pointing_id.desc())
+        .first()
+    )
+    assert last_pointing.pointing_start_utc is None
+
+    # Now call index_repoint_file directly
+    from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer import (
+        index_repoint_file,
+    )
+
+    index_repoint_file("imap/spice/repoint/imap_2025_100_01.repoint.csv")
+
+    # Verify the repoint file was indexed with the pointing_start_utc as end_date
+    repoint_entry = (
+        session.query(models.RepointFiles)
+        .filter_by(file_path="imap/spice/repoint/imap_2025_100_01.repoint.csv")
+        .first()
+    )
+    assert repoint_entry is not None
+    assert repoint_entry.version == "01"
+    # Since pointing_end_utc is None, it should use pointing_start_utc
+    assert repoint_entry.end_date == parse_datetime("2025-04-11T10:00:00.000000")
+    assert repoint_entry.ingestion_date is not None
+
+
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.get_file_ingestion_date",
+    return_value=datetime(2025, 1, 1, 10, 0, 0),
+)
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer.download_from_s3"
+)
+def test_index_repoint_file_multiple_versions(
+    mock_download, mock_get_ingestion_date, session, tmpdir
+):
+    """Test indexing multiple repoint files with different versions."""
+    # Create first repoint file (version 01)
+    repoint_file_v01 = os.path.join(tmpdir, "imap_2025_200_01.repoint.csv")
+    test_csv_v01 = """repoint_id,repoint_start_utc,repoint_end_utc
+1,2025-07-19T10:00:00.000000,2025-07-19T10:10:00.000000
+2,2025-07-20T10:00:00.000000,2025-07-20T10:10:00.000000
+"""
+    with open(repoint_file_v01, "w") as f:
+        f.write(test_csv_v01)
+
+    mock_download.return_value = repoint_file_v01
+
+    # Index first version
+    index_pointing_data("imap/spice/repoint/imap_2025_200_01.repoint.csv")
+    from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.spice_indexer import (
+        index_repoint_file,
+    )
+
+    index_repoint_file("imap/spice/repoint/imap_2025_200_01.repoint.csv")
+
+    # Verify first version was indexed
+    repoint_v01 = (
+        session.query(models.RepointFiles)
+        .filter_by(file_path="imap/spice/repoint/imap_2025_200_01.repoint.csv")
+        .first()
+    )
+    assert repoint_v01 is not None
+    assert repoint_v01.version == "01"
+
+    # Create second repoint file (version 02) with more data
+    repoint_file_v02 = os.path.join(tmpdir, "imap_2025_200_02.repoint.csv")
+    test_csv_v02 = """repoint_id,repoint_start_utc,repoint_end_utc
+1,2025-07-19T10:00:00.000000,2025-07-19T10:10:00.000000
+2,2025-07-20T10:00:00.000000,2025-07-20T10:10:00.000000
+3,2025-07-21T10:00:00.000000,2025-07-21T10:10:00.000000
+"""
+    with open(repoint_file_v02, "w") as f:
+        f.write(test_csv_v02)
+
+    mock_download.return_value = repoint_file_v02
+
+    # Index second version
+    index_pointing_data("imap/spice/repoint/imap_2025_200_02.repoint.csv")
+    index_repoint_file("imap/spice/repoint/imap_2025_200_02.repoint.csv")
+
+    # Verify second version was indexed
+    repoint_v02 = (
+        session.query(models.RepointFiles)
+        .filter_by(file_path="imap/spice/repoint/imap_2025_200_02.repoint.csv")
+        .first()
+    )
+    assert repoint_v02 is not None
+    assert repoint_v02.version == "02"
+
+    # Verify both versions exist in the database
+    all_repoint_files = session.query(models.RepointFiles).all()
+    assert len(all_repoint_files) == 2


### PR DESCRIPTION
Add test coverage to make sure end_time of repoint table gets set correctly on ingest

# Change Summary

## Overview
From the ticket: 
### Background:

The current implementation just uses the year_doy from the filename as the repoint table end date when indexing the file This date gets truncated to the start of that DOY. This potentially causes data to get missed that we could process because the repoint table likely includes data after the start of that DOY.
### Suggested Fix

Query the Pointing table to get the end time. The end time should be the greater of either the last Pointing end time or the last pointing start time. Tenzin says that the Pointing table is updated before the repoint table gets indexed.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Fix comment
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/spice_indexer.py
   - Get repoint file end_date from Pointing table which will have already been updated before repoint ingest.
- tests/lambda_endpoints/test_spice_indexer_lambda.py
   - Add some explicit test coverage for the logic used to get the repoint file end_date

Closes: #954 
