### PR TITLE
BUG: Filter science dependencies by repoint number if ENA/glows

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/__init__.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/__init__.py
@@ -1,1 +1,3 @@
 VALID_CADENCE_STRS = ["1mo", "3mo", "6mo", "1yr"]
+
+REPOINT_DEPENDENT_INSTRUMENTS = ["glows", "hi", "lo", "ultra"]

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -26,7 +26,7 @@ from sqlalchemy.exc import IntegrityError
 from ..api_lambdas import upload_api
 from ..database import database as db
 from ..database import models
-from . import VALID_CADENCE_STRS, dependency
+from . import REPOINT_DEPENDENT_INSTRUMENTS, VALID_CADENCE_STRS, dependency
 from .dependency import DependencyConfig
 
 # Logger setup
@@ -49,8 +49,6 @@ BATCH_JOB_RETRY_STRATEGY = {
 }
 # Create an sqs client
 SQS_CLIENT = boto3.client("sqs", region_name="us-west-2")
-
-REPOINT_DEPENDENT_INSTRUMENTS = ["glows", "hi", "lo", "ultra"]
 
 
 def cadence_to_datetime_range(
@@ -486,11 +484,7 @@ def submit_all_jobs(
         start_date, end_date = determine_date_range(session, science_file)
 
         # Get the repointing number from the science file object
-        job_repointing = (
-            science_file.repointing
-            if job_node["data_source"] in REPOINT_DEPENDENT_INSTRUMENTS
-            else None
-        )
+        job_repointing = science_file.repointing
 
         # If there is only one file to process, then we can use upstream dependencies
         # that have already been queried.

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -50,6 +50,8 @@ BATCH_JOB_RETRY_STRATEGY = {
 # Create an sqs client
 SQS_CLIENT = boto3.client("sqs", region_name="us-west-2")
 
+REPOINT_DEPENDENT_INSTRUMENTS = ["glows", "hi", "lo", "ultra"]
+
 
 def cadence_to_datetime_range(
     cadence: str,
@@ -484,7 +486,11 @@ def submit_all_jobs(
         start_date, end_date = determine_date_range(session, science_file)
 
         # Get the repointing number from the science file object
-        job_repointing = science_file.repointing
+        job_repointing = (
+            science_file.repointing
+            if job_node["data_source"] in REPOINT_DEPENDENT_INSTRUMENTS
+            else None
+        )
 
         # If there is only one file to process, then we can use upstream dependencies
         # that have already been queried.
@@ -499,6 +505,7 @@ def submit_all_jobs(
                 relationship="ALL",
                 start_date=start_date,
                 end_date=end_date,
+                repoint=job_repointing,
                 calculate_crids=False,
                 get_spice=True,
             )
@@ -666,12 +673,10 @@ def determine_date_range(session, file_obj):
             end_date = file_obj.spice_metadata["end_date"].strftime("%Y%m%d")
     elif isinstance(file_obj, ScienceFilePath):
         # TODO: GLOWS may need other handling using carrington rotation.
-        if file_obj.repointing is not None and file_obj.instrument in [
-            "glows",
-            "hi",
-            "lo",
-            "ultra",
-        ]:
+        if (
+            file_obj.repointing is not None
+            and file_obj.instrument in REPOINT_DEPENDENT_INSTRUMENTS
+        ):
             logger.debug(
                 "Using repointing file to calculate date range for"
                 f" {file_obj.instrument}."

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -20,7 +20,7 @@ from ..api_lambdas import spice_metakernel_api
 from ..database import database as db
 from ..database import models
 from ..database.models import AncillaryFiles
-from . import VALID_CADENCE_STRS
+from . import REPOINT_DEPENDENT_INSTRUMENTS, VALID_CADENCE_STRS
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -1085,7 +1085,10 @@ def get_files(
             )
         )
         # If repoint is provided, filter by repointing number
-        if repoint is not None:
+        if (
+            repoint is not None
+            and dependency["data_source"] in REPOINT_DEPENDENT_INSTRUMENTS
+        ):
             type_specific_conditions.append(table.repointing == repoint)
 
     filter_conditions = [

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -839,7 +839,8 @@ def get_upstream_dependency_inputs(
     dependencies: list,
     start_date: datetime,
     end_date: datetime,
-    calculate_crids: bool,
+    repoint: Optional[int] = None,
+    calculate_crids: bool = False,
     get_spice: bool = True,
 ):
     """Construct a ProcessingInputCollection of dependency files.
@@ -856,6 +857,8 @@ def get_upstream_dependency_inputs(
         Start date to find dependent files with.
     end_date : datetime
         End date to find dependent files with.
+    repoint : int, optional
+        If provided, will be used to filter files by repoint number.
     calculate_crids : bool
         If True, we will check if the expected CRIDs exist for the upstream
         dependencies. If so, processing will continue. If not, it will return None.
@@ -989,7 +992,7 @@ def get_upstream_dependency_inputs(
                 f"Searching for upstream dependencies with dependency string: {dep}"
             )
 
-            records = get_files(session, dep, start_date, end_date)
+            records = get_files(session, dep, start_date, end_date, repoint)
             if not records and relationship in [
                 Relationship.HARD,
                 Relationship.HARD_NO_TRIGGER,
@@ -1029,6 +1032,7 @@ def get_files(
     dependency: dict,
     start_date: datetime,
     end_date: datetime,
+    repoint: Optional[int] = None,
 ):
     """Query to database to get ScienceFile or AncillaryFile records.
 
@@ -1048,6 +1052,8 @@ def get_files(
         Start date of the event data.
     end_date: datetime
         End date of the event data.
+    repoint : int, optional
+        Repoint number of the event data.
 
     Returns
     -------
@@ -1078,6 +1084,10 @@ def get_files(
                 models.ScienceFiles.start_date <= end_date,
             )
         )
+        # If repoint is provided, filter by repointing number
+        if repoint is not None:
+            type_specific_conditions.append(table.repointing == repoint)
+
     filter_conditions = [
         table.instrument == dependency["data_source"],
         table.descriptor == dependency["descriptor"],
@@ -1127,6 +1137,7 @@ def get_jobs(
     descriptor: str,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
+    repoint: Optional[int] = None,
     calculate_crids: bool = False,
     get_spice: bool = True,
 ) -> list | ProcessingInputCollection | None:
@@ -1151,6 +1162,8 @@ def get_jobs(
     end_date : str, optional
         End date to find dependent files with, in YYYYMMDD format. Required if
         start_date is provided.
+    repoint : int, optional
+        Repoint number associated with the job.
     calculate_crids : bool, optional
         If True, we will check if the expected CRIDs exist for the upstream
         dependencies. If so, processing will continue. If not, it will return None.
@@ -1243,6 +1256,7 @@ def get_jobs(
         dependencies=dependencies,
         start_date=start_date,
         end_date=end_date,
+        repoint=repoint,
         calculate_crids=calculate_crids,
         get_spice=get_spice,
     )

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -189,7 +189,7 @@ def test_missing_required_params():
 
 def test_get_jobs_repoint(session):
     """Test that jobs with the correct repoint are returned as dependencies."""
-    # Add two idenical glows l0 raw files except for repointing number
+    # Add two identical glows l0 raw files except for repointing number
     session.add_all(
         [
             ScienceFiles(

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -2,6 +2,7 @@
 
 import base64
 from datetime import datetime
+from os.path import basename
 from unittest.mock import patch
 
 import imap_data_access
@@ -184,6 +185,74 @@ def test_missing_required_params():
             descriptor="sci",
             start_date="20240104",
         )
+
+
+def test_get_jobs_repoint(session):
+    """Test that jobs with the correct repoint are returned as dependencies."""
+    # Add two idenical glows l0 raw files except for repointing number
+    session.add_all(
+        [
+            ScienceFiles(
+                file_path="/path/to/imap_glows_l0_raw_20240101-repoint00047_v001.pkts",
+                instrument="glows",
+                data_level="l0",
+                descriptor="raw",
+                start_date=datetime(2024, 1, 1),
+                version="v001",
+                extension="pkts",
+                repointing=47,
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),
+            ScienceFiles(
+                file_path="/path/to/imap_glows_l0_raw_20240101-repoint00048_v001.pkts",
+                instrument="glows",
+                data_level="l0",
+                descriptor="raw",
+                start_date=datetime(2024, 1, 1),
+                version="v001",
+                extension="pkts",
+                repointing=48,
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),
+        ]
+    )
+    session.commit()
+    # Get upstream files for glows l1a all. This should return None because although
+    # the glows l0 raw file exists, the spice files do not exist in the database.
+    dependency_response = dependency.get_jobs(
+        data_source="glows",
+        data_type="l1a",
+        descriptor="all",
+        start_date="20240101",
+        end_date="20240101",
+        relationship="ALL",
+        dependency_type="UPSTREAM",
+        get_spice=False,
+    )
+    # Without specifying repointing, both files are returned
+    assert len(dependency_response.get_file_paths("glows", descriptor="raw")) == 2
+    dependency_response = dependency.get_jobs(
+        data_source="glows",
+        data_type="l1a",
+        descriptor="all",
+        start_date="20240101",
+        end_date="20240101",
+        repoint=48,
+        relationship="ALL",
+        dependency_type="UPSTREAM",
+        get_spice=False,
+    )
+    # With specifying repointing, only one file is returned
+    glows_l0_files = dependency_response.get_file_paths("glows", descriptor="raw")
+    assert len(glows_l0_files) == 1
+    assert (
+        basename(glows_l0_files[0])
+        == "imap_glows_l0_raw_20240101-repoint00048_v001.pkts"
+    )
 
 
 def test_get_jobs_spice(session):

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -221,8 +221,7 @@ def test_get_jobs_repoint(session):
         ]
     )
     session.commit()
-    # Get upstream files for glows l1a all. This should return None because although
-    # the glows l0 raw file exists, the spice files do not exist in the database.
+    # Get upstream files for glows l1a all. This should return both glows l0 raw files
     dependency_response = dependency.get_jobs(
         data_source="glows",
         data_type="l1a",


### PR DESCRIPTION
# Change Summary

## Overview
Jobs were getting kicked off with dependencies that contained multiple files of different repoint ids. This caused processing job failures for at least HI and ULTRA.

Fix: Search for science files that have the same repointing number for glows, hi, ultra, and lo


## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - Add repointing number for the upstream file query.
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
   - Pass through the repoint number and add functionality to filter science files by it. 

## Testing
test to make sure the new parameter in the function works as expected
