### PR TITLE
Supply repointing number to the first upstream dependency query

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -381,6 +381,7 @@ def submit_all_jobs(
     job_node,
     trigger_start_date,
     trigger_end_date,
+    repoint: Optional[int] = None,
     calculate_crids=False,
     filter_dependencies=True,
 ):
@@ -398,6 +399,8 @@ def submit_all_jobs(
         determines the range of potential jobs.
     trigger_end_date : str
         The end date of the file that triggered the job in the format 'YYYYMMDD'.
+    repoint : int, optional
+        The repointing number for the job. Default is None.
     calculate_crids : bool
         True if the file that triggered the job is a science file, False if it is SPICE
         or ancillary.
@@ -429,6 +432,7 @@ def submit_all_jobs(
         relationship="ALL",
         start_date=trigger_start_date,
         end_date=trigger_end_date,
+        repoint=repoint,
         calculate_crids=calculate_crids,
         get_spice=get_spice,
     )
@@ -792,11 +796,16 @@ def s3_processing_event(session, events):
             if isinstance(file_obj, AncillaryFilePath):
                 filter_dependencies = True
 
+            # Pass along the repointing number if the file is a science file.
+            repoint = (
+                file_obj.repointing if isinstance(file_obj, ScienceFilePath) else None
+            )
             submit_all_jobs(
                 session,
                 job,
                 trigger_start_time,
                 trigger_end_time,
+                repoint,
                 calculate_crids,
                 filter_dependencies,
             )

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1642,6 +1642,7 @@ def test_repoint_date_range(sqs_mock, mock_download, session, s3_client, tmp_pat
                 start_date=datetime(2000, 2, 24),
                 version="v001",
                 extension="pkts",
+                repointing=47,
                 ingestion_date=datetime.strptime(
                     "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
                 ),


### PR DESCRIPTION
# Change Summary

## Overview
My original fix for the repoint query did not work for many processing jobs because if the trigger file is a science file, and has not been reprocessed, then it should not filter the dependencies from the original dependency query. The problem was that I did not pass the repointing number to that first query. This PR handles that. 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - pass the repoint number through in the first query to the upstream dependencies

## Testing
Fix test. 
