### PR TITLE
Fix SPICE metakernel API query for ENA instrument

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -588,7 +588,6 @@ def calculate_pointing_date_range(session, pointing_id):
 
     start_date = pointing_record.pointing_start_utc.strftime("%Y%m%d")
     end_date = pointing_record.pointing_end_utc.strftime("%Y%m%d")
-
     logger.debug(f"pointing date range, start_date: {start_date}, end_date: {end_date}")
 
     return start_date, end_date

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -588,6 +588,7 @@ def calculate_pointing_date_range(session, pointing_id):
 
     start_date = pointing_record.pointing_start_utc.strftime("%Y%m%d")
     end_date = pointing_record.pointing_end_utc.strftime("%Y%m%d")
+
     logger.debug(f"pointing date range, start_date: {start_date}, end_date: {end_date}")
 
     return start_date, end_date

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -839,6 +839,7 @@ def get_upstream_dependency_inputs(
     dependencies: list,
     start_date: datetime,
     end_date: datetime,
+    data_source: str,
     repoint: Optional[int] = None,
     calculate_crids: bool = False,
     get_spice: bool = True,
@@ -857,6 +858,8 @@ def get_upstream_dependency_inputs(
         Start date to find dependent files with.
     end_date : datetime
         End date to find dependent files with.
+    data_source : str
+        Data source of the current processing job.
     repoint : int, optional
         If provided, will be used to filter files by repoint number.
     calculate_crids : bool
@@ -939,7 +942,12 @@ def get_upstream_dependency_inputs(
                     start_date.strftime("%Y%m%d")
                 )
                 # TODO revisit setting end_time after SIT-4. Should be handled upstream
-                add_24_hrs = True if end_date == start_date else False
+                if end_date == start_date or (
+                    data_source in REPOINT_DEPENDENT_INSTRUMENTS and repoint is not None
+                ):
+                    add_24_hrs = True
+                else:
+                    add_24_hrs = False
                 end_time = yyyymmdd_to_seconds_since_j2000(
                     end_date.strftime("%Y%m%d"), add_24_hrs
                 )
@@ -1260,6 +1268,7 @@ def get_jobs(
         start_date=start_date,
         end_date=end_date,
         repoint=repoint,
+        data_source=data_source,
         calculate_crids=calculate_crids,
         get_spice=get_spice,
     )

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -839,7 +839,6 @@ def get_upstream_dependency_inputs(
     dependencies: list,
     start_date: datetime,
     end_date: datetime,
-    data_source: str,
     repoint: Optional[int] = None,
     calculate_crids: bool = False,
     get_spice: bool = True,
@@ -858,8 +857,6 @@ def get_upstream_dependency_inputs(
         Start date to find dependent files with.
     end_date : datetime
         End date to find dependent files with.
-    data_source : str
-        Data source of the current processing job.
     repoint : int, optional
         If provided, will be used to filter files by repoint number.
     calculate_crids : bool
@@ -942,9 +939,7 @@ def get_upstream_dependency_inputs(
                     start_date.strftime("%Y%m%d")
                 )
                 # TODO revisit setting end_time after SIT-4. Should be handled upstream
-                if end_date == start_date or (
-                    data_source in REPOINT_DEPENDENT_INSTRUMENTS and repoint is not None
-                ):
+                if end_date == start_date or repoint is not None:
                     add_24_hrs = True
                 else:
                     add_24_hrs = False
@@ -1268,7 +1263,6 @@ def get_jobs(
         start_date=start_date,
         end_date=end_date,
         repoint=repoint,
-        data_source=data_source,
         calculate_crids=calculate_crids,
         get_spice=get_spice,
     )

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -1396,7 +1396,6 @@ def test_get_spice_for_ena(session):
         [dependencies],
         start_date=start_date,
         end_date=end_date,
-        data_source="ultra",
         repoint=1,
         calculate_crids=False,
         get_spice=True,

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -18,6 +18,7 @@ from sds_data_manager.lambda_code.SDSCode.database.models import (
     AncillaryFiles,
     RepointFiles,
     ScienceFiles,
+    SPICEFiles,
     SpinFiles,
 )
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import dependency
@@ -25,6 +26,7 @@ from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.dependency import (
     DependencyConfig,
     calculate_crid,
     get_files,
+    get_upstream_dependency_inputs,
     matching_crids_exist,
 )
 from tests.lambda_endpoints.conftest import (
@@ -1313,3 +1315,91 @@ def test_new_crid(session):
     )
     # Assert that the record now has a CRID associated with it.
     assert record.crid
+
+
+def test_get_spice_for_ena(session):
+    """Tests that the correct spice data is returned for an ena instrument."""
+    records = [
+        SPICEFiles(
+            file_path="path/to/imap_2025_289_2025_290_001.ah.bc",
+            file_name="imap_2025_289_2025_290_001.ah.bc",
+            ingestion_date=datetime.strptime(
+                "2025-10-17 21:05:14.000000 +00:00", "%Y-%m-%d %H:%M:%S.%f %z"
+            ),
+            file_root="imap_2025_289_2025_290_.ah.bc",
+            kernel_type="attitude_history",
+            min_date_j2000=813869293.1500088,
+            max_date_j2000=813959293.0681704,
+            file_intervals_j2000=[[813869293.1500088, 813959293.0681704]],
+            min_date_datetime=datetime.strptime(
+                "2025-10-16 06:47:03.967637 +00:00", "%Y-%m-%d %H:%M:%S.%f %z"
+            ),
+            max_date_datetime=datetime.strptime(
+                "2025-10-17 07:47:03.885793 +00:00", "%Y-%m-%d %H:%M:%S.%f %z"
+            ),
+            file_intervals_datetime=[
+                ["2025-10-16T06:47:03.967637+00:00", "2025-10-17T07:47:03.885793+00:00"]
+            ],
+            min_date_sclk="1/0498293225:00000",
+            max_date_sclk="1/0498383225:00000",
+            file_intervals_sclk=[["1/0498293225:00000", "1/0498383225:00000"]],
+            lsk_kernel="",
+            sclk_kernel="",
+            version=1,
+        ),
+        SPICEFiles(
+            file_path="path/to/imap_2025_290_2025_290_001.ah.bc",
+            file_name="imap_2025_290_2025_290_001.ah.bc",
+            ingestion_date=datetime.strptime(
+                "2025-10-17 21:05:14.000000 +00:00", "%Y-%m-%d %H:%M:%S.%f %z"
+            ),
+            file_root="imap_2025_290_2025_290_.ah.bc",
+            kernel_type="attitude_history",
+            min_date_j2000=813955694.071443,
+            max_date_j2000=813998895.0321598,
+            file_intervals_j2000=[[813955694.071443, 813998895.0321598]],
+            min_date_datetime=datetime.strptime(
+                "2025-10-17 06:47:04.889065 +00:00", "%Y-%m-%d %H:%M:%S.%f %z"
+            ),
+            max_date_datetime=datetime.strptime(
+                "2025-10-17 18:47:05.849779 +00:00", "%Y-%m-%d %H:%M:%S.%f %z"
+            ),
+            file_intervals_datetime=[
+                ["2025-10-17T06:47:04.889065+00:00", "2025-10-17T18:47:05.849779+00:00"]
+            ],
+            min_date_sclk="1/0498379626:00000",
+            max_date_sclk="1/0498422827:00000",
+            file_intervals_sclk=[["1/0498379626:00000", "1/0498422827:00000"]],
+            lsk_kernel="",
+            sclk_kernel="",
+            version=1,
+        ),
+    ]
+    session.add_all(records)
+
+    session.commit()
+    # For ENA instruments, the start and end dates are set from the pointing start
+    # and end times and are floored in batch_starter.py. This means the pointing end
+    # may get "cut off." Therefore, in get_upstream_dependency_inputs in dependency.py
+    # for ENA instruments that have a repointing number, we add one day to the end date
+    # to ensure all necessary SPICE files are retrieved.
+    dependencies = {
+        "data_source": "attitude_history",
+        "data_type": "spice",
+        "descriptor": "historical",
+    }
+    # For ENA instruments, the start date is not always equal to the end date because
+    # a pointing may happen over multiple days.
+    start_date = datetime(2025, 10, 16)
+    end_date = datetime(2025, 10, 17)
+    processing_inputs = get_upstream_dependency_inputs(
+        [dependencies],
+        start_date=start_date,
+        end_date=end_date,
+        data_source="ultra",
+        repoint=1,
+        calculate_crids=False,
+        get_spice=True,
+    )
+    # We should expect 2 SPICE files for the date range above.
+    assert len(processing_inputs.get_file_paths()) == 2


### PR DESCRIPTION
# Change Summary

## Overview
For ENA instruments, the start and end dates are set from the pointing start and end times and are floored in batch_starter.py. This means the pointing end was getting cut off. Therefore, in get_upstream_dependency_inputs in dependency.py for ENA instruments that have a repointing number, we add one day to the end date to ensure all necessary SPICE files are retrieved. 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
   - Add 24 hours to ENA pointing dependent instruments


## Testing
Add a test: This actually mocks the exact scenario that is causing issues with ULTRA l1b. The test proves that this solves the bug! 
