### PR TITLE
Revert s3-db query response out of sync updates

### DIFF
--- a/sds_data_manager/constructs/sds_api_manager_construct.py
+++ b/sds_data_manager/constructs/sds_api_manager_construct.py
@@ -187,7 +187,6 @@ class SdsApiManager(Construct):
             environment={
                 "REGION": env.region,
                 "SECRET_NAME": db_secret_name,
-                "S3_BUCKET": data_bucket.bucket_name,
             },
             layers=layers,
         )

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/query_api.py
@@ -3,11 +3,8 @@
 import datetime
 import json
 import logging
-import os
 from collections import namedtuple
 
-import boto3
-import botocore
 from sqlalchemy import func, select
 
 from ..api_lambdas.utils import is_authenticated_user
@@ -19,7 +16,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def lambda_handler(event, context):  # noqa: PLR0912 PLR0915
+def lambda_handler(event, context):  # noqa: PLR0912
     """Entry point to the query API lambda.
 
     Parameters
@@ -134,28 +131,6 @@ def lambda_handler(event, context):  # noqa: PLR0912 PLR0915
     # Convert the search results (list of tuples) to a list of dicts
     search_results = [result._asdict() for result in search_results]
 
-    # Check if those files exists in S3 before returning them
-    bucket = os.environ["S3_BUCKET"]
-    region = os.environ["REGION"]
-    s3_client = boto3.client(
-        "s3",
-        region_name=region,
-        config=botocore.client.Config(signature_version="s3v4"),
-        endpoint_url=f"https://s3.{region}.amazonaws.com",
-    )
-    existing_files = []
-    for result in search_results:
-        s3_key = result["file_path"]
-        # check if object exists
-        try:
-            s3_client.head_object(Bucket=bucket, Key=s3_key)
-            existing_files.append(result)
-        except Exception as e:
-            logger.error(
-                f"File not found in S3: {s3_key} but exists in DB - error: {e}"
-            )
-
-    search_results = existing_files
     # Convert datetimes to string values of format 'YYYYMMDD'
     # Also remove values that are not needed by users
     for result in search_results:

--- a/tests/lambda_endpoints/test_query_api.py
+++ b/tests/lambda_endpoints/test_query_api.py
@@ -2,9 +2,7 @@
 
 import datetime
 import json
-from unittest.mock import MagicMock
 
-import boto3
 import pytest
 
 from sds_data_manager.lambda_code.SDSCode.api_lambdas import query_api
@@ -38,31 +36,6 @@ def _populate_test_data(session):
     # Add data to the ScienceFiles table and return the session
     session.add(models.ScienceFiles(**metadata_params))
     session.commit()
-
-
-@pytest.fixture(autouse=True)
-def mock_head_object(monkeypatch):
-    """Patch boto3's S3 client head_object to always return success."""
-    # Create a mock that always returns a success response
-    mock_head = MagicMock(return_value={"ResponseMetadata": {"HTTPStatusCode": 200}})
-
-    # Also patch the boto3.resource to handle the bucket name issue
-    mock_bucket = MagicMock()
-    mock_bucket.name = "mock-bucket-name"  # Add a name attribute that can be used
-
-    # Patch both s3_client.head_object and the bucket name access
-    def mock_client(*args, **kwargs):
-        mock = MagicMock()
-        mock.head_object = mock_head
-        return mock
-
-    def mock_resource(*args, **kwargs):
-        mock = MagicMock()
-        mock.Bucket.return_value = mock_bucket
-        return mock
-
-    monkeypatch.setattr(boto3, "client", mock_client)
-    monkeypatch.setattr(boto3, "resource", mock_resource)
 
 
 @pytest.fixture


### PR DESCRIPTION
We don't want to do a HEAD request on every file we are querying. If the database and s3 are out of sync, we have bigger issues and we should be running the synchronizer lambda instead.