### PR TITLE
I-ALiRT - update permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ For example from the command line with the proper AWS credentials:
 python sds_data_manager/lambda_code/authorization/manage_api_keys.py list
 python sds_data_manager/lambda_code/authorization/manage_api_keys.py add <owner> <email>
 python sds_data_manager/lambda_code/authorization/manage_api_keys.py remove <key>
+python sds_data_manager/lambda_code/authorization/manage_api_keys.py update_permission <owner> <email> <scope>
 AWS_PROFILE=imap-sdc-dev AWS_DEFAULT_REGION=us-west-2 \
   python sds_data_manager/lambda_code/authorization/manage_api_keys.py \
       add "First Last" "user@example.com"

--- a/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
+++ b/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
@@ -28,7 +28,18 @@ def lambda_handler(event, context):
     path = event.get("rawPath") or event.get("path", "")
 
     # Check scope-based authorization for specific endpoints
-    if path.startswith("/ialirt-db-query") and scope not in ("ialirt_db", "full"):
+    if path.startswith("/ialirt-db-query") and scope not in (
+        "ialirt_db",
+        "full",
+        "ialirt_external_partner",
+        "ialirt_scientist",
+    ):
+        return {"isAuthorized": False}
+    if path.startswith("/ialirt-download") and scope not in (
+        "full",
+        "ialirt_external_partner",
+        "ialirt_scientist",
+    ):
         return {"isAuthorized": False}
 
     return {"isAuthorized": True, "context": {"apiKey": api_key}}

--- a/sds_data_manager/lambda_code/authorization/manage_api_keys.py
+++ b/sds_data_manager/lambda_code/authorization/manage_api_keys.py
@@ -129,6 +129,35 @@ def remove_key(key):
     print(f"Removed key: {key}")
 
 
+def update_permission(owner: str, email: str, scope: str):
+    """Update permissions for API key."""
+    table = get_table()
+    keys = get_keys()
+
+    matches = [
+        key
+        for key, value in keys.items()
+        if value["owner"] == owner and value["email"] == email
+    ]
+    key = keys[matches[0]]
+
+    if matches:
+        table.put_item(
+            Item={
+                "api_key": matches[0],
+                "owner": key["owner"],
+                "email": key["email"],
+                "scope": scope,
+                "created": key["created"],
+            }
+        )
+        print(f"Updated key permission for: {owner}, {email}")
+    else:
+        print(
+            f"Update not performed since no api key match found for: {owner}, {email}."
+        )
+
+
 def main():
     """CLI entry point."""
     if len(sys.argv) < 2:
@@ -144,6 +173,8 @@ def main():
         add_key(sys.argv[2], sys.argv[3], sys.argv[4])
     elif cmd == "remove" and len(sys.argv) == 3:
         remove_key(sys.argv[2])
+    elif cmd == "update_permission":
+        update_permission(sys.argv[2], sys.argv[3], sys.argv[4])
     else:
         print(
             "Usage: python manage_api_keys.py [list|add|remove] "

--- a/tests/infrastructure/test_api_key_dynamodb.py
+++ b/tests/infrastructure/test_api_key_dynamodb.py
@@ -43,6 +43,7 @@ def test_api_key_management(dynamodb_table):
         add_key_to_db,
         get_keys,
         remove_key_from_db,
+        update_permission,
     )
 
     # Test adding a key
@@ -79,6 +80,11 @@ def test_api_key_management(dynamodb_table):
     event["rawPath"] = "/ialirt-db-query/test"
     result = lambda_handler(event, {})
     assert result["isAuthorized"] is True  # "full" scope should allow access
+
+    # Test that permissions were updated.
+    update_permission("Test User", "test@example.com", "ialirt_external_partner")
+    metadata = dynamodb_table.get_item(Key={"api_key": test_key}).get("Item")
+    assert metadata["scope"] == "ialirt_external_partner"
 
     # Test removing a key
     remove_key_from_db(test_key)


### PR DESCRIPTION
# Change Summary

## Overview
Created a way to update permissions and provided permissions to ialirt external partners. This is derived from them needing a way to access an automated DSN schedule. 

## Updated Files
- manage_api_keys.py
   - Created a way to update permissions
- lambda_api_key_authorizer.py
   - Add permissions for I-ALiRT
- README.md
   - Documentation

## Testing
test_api_key_dynamodb.py
