### PR TITLE
Increase batch job retries

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -38,7 +38,7 @@ DEPENDENCY_CONFIG = DependencyConfig()
 BATCH_CLIENT = boto3.client("batch", region_name="us-west-2")
 # Define the retry strategy for batch jobs
 BATCH_JOB_RETRY_STRATEGY = {
-    "attempts": 2,
+    "attempts": 10,
     "evaluateOnExit": [
         {
             "onStatusReason": "Your Spot Task was interrupted.",


### PR DESCRIPTION
# Change Summary

## Overview
Increase the number of tries for the batch jobs. If a job gets terminated due to a spot task interruption. Max retries is 10. 

I looked into "hibernating" the instance but unfortunately that only is available for ec2 spot compute environments and not fargate spot. 

A lot of people in aws discussion boards have been asking for a fargate spot to fargate on-demand fallback policy but seems like that wont happen ( too easy maybe :)). 

It seems like the general recommendation is just to switch to on-demand or increase retries and make sure you are using many availability zones which our vpc already has. 

*** another thing to note fargate spot interruptions can send termination notices so eventually we should configure out jobs to stop processing when we get that 2 min warning. Hopefully this will stop jobs getting terminated right in the middle of uploading files. https://repost.aws/knowledge-center/fargate-spot-termination-notice

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - increase retries to the max value.
