### PR TITLE
MNT/ENH: Add repoint file kickoff for ENA imagers

### DIFF
--- a/sds_data_manager/constructs/packet_downloader_lambda_construct.py
+++ b/sds_data_manager/constructs/packet_downloader_lambda_construct.py
@@ -5,9 +5,11 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_events
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_s3_notifications as s3n
 from aws_cdk import aws_secretsmanager as secretsmanager
 from aws_cdk import aws_ssm as ssm
 from constructs import Construct
+from imap_data_access import SPICEFilePath
 
 
 class PacketDownloaderLambda(Construct):
@@ -96,7 +98,7 @@ class PacketDownloaderLambda(Construct):
         )
         api_key_parameter.grant_read(packet_lambda)
 
-        # Trigger the lambda on a schedule (every 6 hours)
+        # Trigger the lambda on a schedule (every 6 hours) for in-situ instruments
         rule = aws_events.Rule(
             self,
             "PacketDownloaderScheduleRule",
@@ -105,3 +107,13 @@ class PacketDownloaderLambda(Construct):
             schedule=cdk.aws_events.Schedule.cron(minute="20", hour="*/6"),
         )
         rule.add_target(cdk.aws_events_targets.LambdaFunction(packet_lambda))
+
+        # Trigger the lambda on new repoint files for ENA instruments
+        # Notify the lambda whenever a new file matching our repoint filename is added
+        data_bucket.add_event_notification(
+            s3.EventType.OBJECT_CREATED,
+            s3n.LambdaDestination(packet_lambda),  # Lambda notification
+            s3.NotificationKeyFilter(
+                prefix=f"{SPICEFilePath._dir_prefix}/repoint/imap_",
+            ),
+        )

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
@@ -23,6 +23,9 @@ else:
     logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# ENA imagers group by repointing
+REPOINTING_INSTRUMENTS = {"glows", "hi", "lo", "ultra"}
+
 
 def setup_environment():
     """Get secrets and set necessary config values."""
@@ -51,9 +54,15 @@ def setup_environment():
     imap_data_access.config["DATA_DIR"] = Path("/tmp")  # noqa: S108
 
 
-def get_latest_repoint_file():
+def get_latest_repoint_file_and_query_times():
     """Retrieve the latest repointing file from S3.
 
+    Additionally, determine the time range to query for packets based upon
+    the latest repointing file and the previous repointing file that is
+    outside of 1-hour before the latest repointing file.
+
+    Notes
+    -----
     If we want to connect to the database later, we could use the RepointingFile
     database table to get this value instead.
 
@@ -74,16 +83,40 @@ def get_latest_repoint_file():
     all_files = []
     for page in pages:
         if "Contents" in page:
-            all_files.extend([obj["Key"] for obj in page["Contents"]])
+            # list of (s3 key, datetime)
+            # Note: obj["LastModified"] is already a datetime object from boto3
+            all_files.extend(
+                [
+                    (
+                        obj["Key"],
+                        obj["LastModified"].replace(minute=0, second=0, microsecond=0),
+                    )
+                    for obj in page["Contents"]
+                ]
+            )
 
-    if not all_files:
-        logger.warning("No files found in the repoint directory.")
-        return None
+    if len(all_files) < 2:
+        raise ValueError("Not enough repointing files to determine download interval.")
 
     # Sort files by key (filename); adjust if you want to sort by LastModified instead
-    last_file = sorted(all_files)[-1]
-    logger.info(f"Last file in directory: {last_file}")
-    return last_file
+    all_files = sorted(all_files, reverse=True)
+    # Keep track of the times we need to query between for packets.
+    # We will query between the previous time we queried and the time
+    # of the last repoint file
+    latest_file, current_time = all_files[0]
+    logger.info(f"Latest repointing file [{latest_file}] at time [{current_time}]")
+
+    for _, previous_file_datetime in all_files[1:]:
+        if previous_file_datetime < current_time - timedelta(hours=1):
+            # This is a repointing file that is earlier than 1-hour before
+            # the latest repointing file, so we can use this as our start time
+            # NOTE: This accounts for if we get several repoint files delivered
+            # within a few seconds of each other.
+            return latest_file, previous_file_datetime, current_time
+    raise ValueError(
+        "No repointing files found outside of 1-hour before this repoint."
+        f" Latest file time: {current_time}"
+    )
 
 
 def lambda_handler(event, context):
@@ -105,8 +138,28 @@ def lambda_handler(event, context):
     """
     setup_environment()
 
-    repointing_key = get_latest_repoint_file()
-    imap_data_access.config["DATA_DIR"]
+    # If we were triggered by an s3 repointing event, download ENA data
+    if "Records" in event:
+        event_repoint_key = event["Records"][0]["s3"]["object"]["key"]
+        download_ena_data(event_repoint_key)
+    else:
+        download_insitu_data()
+
+    return {"statusCode": 200, "body": "Packet downloader finished."}
+
+
+def download_ena_data(event_repoint_key):
+    """Download data for ENA instruments based upon repointing files."""
+    repointing_key, start_time, end_time = get_latest_repoint_file_and_query_times()
+    if repointing_key != event_repoint_key:
+        # We likely got triggered with a few events at once, but we only
+        # want to process the latest repointing file
+        logger.info(
+            "Repointing file in event does not match latest repointing file. "
+            "Skipping downloads."
+        )
+        return
+
     repointing_file = imap_data_access.config["DATA_DIR"] / Path(repointing_key).name
     # Download the repointing file from S3 for use in the repointing downloads
     S3_CLIENT.download_file(
@@ -115,9 +168,21 @@ def lambda_handler(event, context):
         Filename=repointing_file,
     )
 
-    # ENA imagers group by repointing
-    repointing_instruments = {"glows", "hi", "lo", "ultra"}
+    logger.info(f"Downloading data from {start_time} to {end_time}")
+    for instrument in REPOINTING_INSTRUMENTS:
+        logger.info("Downloading data for instrument: %s", instrument)
+        # Download based on repointing
+        webpoda.download_repointing_data(
+            instrument=instrument,
+            start_time=start_time,
+            end_time=end_time,
+            repointing_file=repointing_file,
+            upload_to_server=True,
+        )
 
+
+def download_insitu_data():
+    """Download data for in-situ instruments based upon time intervals."""
     # TODO: Update start_time and end_time based upon the actual downlink times
     #       once those come in. Currently it is every 6-hours on a cron schedule.
     now = datetime.now(timezone.utc)
@@ -127,24 +192,12 @@ def lambda_handler(event, context):
     start_time = end_time - timedelta(hours=6)
     logger.info(f"Downloading data from {start_time} to {end_time}")
 
-    for instrument in webpoda.INSTRUMENT_APIDS:
+    # Loop over all non-repointing instruments and download data
+    for instrument in set(webpoda.INSTRUMENT_APIDS) - REPOINTING_INSTRUMENTS:
         logger.info("Downloading data for instrument: %s", instrument)
-        if instrument in repointing_instruments:
-            # Download based on repointing
-            webpoda.download_repointing_data(
-                instrument=instrument,
-                start_time=start_time,
-                end_time=end_time,
-                repointing_file=repointing_file,
-                upload_to_server=True,
-            )
-        else:
-            # Download based on time
-            webpoda.download_daily_data(
-                instrument=instrument,
-                start_time=start_time,
-                end_time=end_time,
-                upload_to_server=True,
-            )
-
-    return {"statusCode": 200, "body": "Packets downloaded and L0 files created."}
+        webpoda.download_daily_data(
+            instrument=instrument,
+            start_time=start_time,
+            end_time=end_time,
+            upload_to_server=True,
+        )

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/packet_downloader.py
@@ -119,35 +119,6 @@ def get_latest_repoint_file_and_query_times():
     )
 
 
-def lambda_handler(event, context):
-    """Lambda handler to download raw packet data and create L0 files.
-
-    The lambda function is triggered based upon a cron job indicating new
-    data is available and should be fetched. Currently, this is downloading
-    6-hours of data on a cron-based schedule. In the future, this should be
-    updated to be triggered based upon the arrival of files or notifications
-    about the end of contacts and a database tracking what data has been
-    downloaded.
-
-    Parameters
-    ----------
-    event : dict
-        The JSON formatted document with the source s3 event.
-    context : obj
-        The context object for the lambda function
-    """
-    setup_environment()
-
-    # If we were triggered by an s3 repointing event, download ENA data
-    if "Records" in event:
-        event_repoint_key = event["Records"][0]["s3"]["object"]["key"]
-        download_ena_data(event_repoint_key)
-    else:
-        download_insitu_data()
-
-    return {"statusCode": 200, "body": "Packet downloader finished."}
-
-
 def download_ena_data(event_repoint_key):
     """Download data for ENA instruments based upon repointing files."""
     repointing_key, start_time, end_time = get_latest_repoint_file_and_query_times()
@@ -201,3 +172,32 @@ def download_insitu_data():
             end_time=end_time,
             upload_to_server=True,
         )
+
+
+def lambda_handler(event, context):
+    """Lambda handler to download raw packet data and create L0 files.
+
+    The lambda function is triggered based upon a cron job indicating new
+    data is available and should be fetched, or repointing files arriving.
+    Currently, this is downloading 6-hours of data on a cron-based schedule.
+    In the future, this could be based on notifications
+    about the end of contacts and a database tracking what data has been
+    downloaded.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the source s3 event.
+    context : obj
+        The context object for the lambda function
+    """
+    setup_environment()
+
+    # If we were triggered by an s3 repointing event, download ENA data
+    if "Records" in event:
+        event_repoint_key = event["Records"][0]["s3"]["object"]["key"]
+        download_ena_data(event_repoint_key)
+    else:
+        download_insitu_data()
+
+    return {"statusCode": 200, "body": "Packet downloader finished."}


### PR DESCRIPTION
This adds back the repointing job trigger with a few modifications:
* Only runs on the "latest" file that gets delivered (avoids duplicate potential jobs if we get 3 repointing files delivered at the same time)
* Downloads packets between the last repointing file more than one hour ago and this current one (all packet ingest times during that period)
* Separates out the insitu logic from the repointing-based logic

The ENA teams need repoint files to produce their files, so we want to add a different trigger based on repoint files arriving for them. Sometimes we get delivered several repoint files in quick succession and we don't want to kick off each of those jobs every time so we put in a check on only running the job with the latest repoint file in the bucket and flooring the times to the nearest hour for what data we are querying between.