### PR TITLE
I-ALiRT - Improvements for DynamoDB API

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,5 +133,5 @@ python sds_data_manager/lambda_code/authorization/manage_api_keys.py remove <key
 python sds_data_manager/lambda_code/authorization/manage_api_keys.py update_permission <owner> <email> <scope>
 AWS_PROFILE=imap-sdc-dev AWS_DEFAULT_REGION=us-west-2 \
   python sds_data_manager/lambda_code/authorization/manage_api_keys.py \
-      add "First Last" "user@example.com"
+      add "First Last" "user@example.com" "full"
 ```

--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -24,6 +24,7 @@ class IalirtApiManager(Construct):
         vpc,
         layers: list,
         algorithm_table: ddb.Table,
+        data_table: ddb.Table,
         account_name: str = "dev",
         **kwargs,
     ) -> None:
@@ -49,6 +50,8 @@ class IalirtApiManager(Construct):
             List of Lambda layers arns
         algorithm_table : obj
             The algorithm DynamoDB table
+        data_table : object
+            The data DynamoDB Table
         account_name : str
             The account name. Eg. 'prod' or 'dev'
         kwargs : dict
@@ -249,7 +252,7 @@ class IalirtApiManager(Construct):
             "IAlirtDbQueryApiFormattedHandler",
             function_name="ialirt-db-query-formatted-handler",
             code=code,
-            handler="IAlirtCode.ialirt_db_query_api_formatted.lambda_handler",
+            handler="IAlirtCode.ialirt_data_query_api.lambda_handler",
             runtime=lambda_.Runtime.PYTHON_3_12,
             timeout=cdk.Duration.minutes(1),
             # Lambda allocates CPU proportionally to memory,
@@ -257,13 +260,13 @@ class IalirtApiManager(Construct):
             # JSON parsing and network serialization.
             memory_size=2048,
             environment={
-                "ALGORITHM_TABLE": algorithm_table.table_name,
+                "DATA_TABLE": data_table.table_name,
                 "REGION": env.region,
             },
         )
 
         # Grant the lambda function read/write permissions on the DynamoDB table.
-        algorithm_table.grant_read_data(ialirt_db_query_formatted_handler)
+        data_table.grant_read_data(ialirt_db_query_formatted_handler)
 
         add_stable_route(
             api,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -13,7 +13,7 @@ from boto3.dynamodb.conditions import Key
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-table_name = os.environ.get("ALGORITHM_TABLE")
+table_name = os.environ.get("DATA_TABLE")
 region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
 dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
@@ -45,7 +45,7 @@ def _error(code, message):
     }
 
 
-def build_next_url(event, last_evaluated_key, query_params):
+def build_next_url(event, last_evaluated_key):
     """Build the next URL for pagination.
 
     Parameters
@@ -183,7 +183,7 @@ def lambda_handler(event, context):
     encoded_lek = json.dumps(last_evaluated_key) if last_evaluated_key else None
     has_more = last_evaluated_key is not None
 
-    next_url = build_next_url(event, last_evaluated_key, params)
+    next_url = build_next_url(event, last_evaluated_key)
 
     json_body = json.dumps(
         {

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -174,12 +174,7 @@ def lambda_handler(event, context):
         items.extend(response.get("Items", []))
         query_time_total += t2 - t1
 
-    last_evaluated_key = response.get("LastEvaluatedKey")
-
     t3 = time.perf_counter()
-
-    encoded_lek = json.dumps(last_evaluated_key) if last_evaluated_key else None
-    has_more = last_evaluated_key is not None
 
     json_body = json.dumps(
         {
@@ -187,8 +182,6 @@ def lambda_handler(event, context):
                 "count": len(items),
                 "type": meta_type,
                 "instrument": meta_instrument,
-                "has_more": has_more,
-                "last_evaluated_key": encoded_lek,
             },
             "data": items,
         },

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -5,6 +5,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode, quote_plus
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -44,6 +45,36 @@ def _error(code, message):
     }
 
 
+def build_next_url(event, last_evaluated_key, query_params):
+    """Build the next URL for pagination.
+
+    Parameters
+    ----------
+    event : dict
+        The Lambda event object.
+    last_evaluated_key : dict
+        The last evaluated key from DynamoDB query.
+
+    Returns
+    -------
+    next_url : str
+        The URL for the next page of results.
+    """
+    query_params = event.get("queryStringParameters", {})
+    if last_evaluated_key:
+        query_params["last_evaluated_key"] = quote_plus(json.dumps(last_evaluated_key))
+
+    query_string = urlencode(query_params)
+
+    headers = event.get("headers", {})
+    host = headers.get("host", "")
+    path = event.get("requestContext", {}).get("path", "")
+
+    next_url = f"https://{host}{path}?{query_string}"
+
+    return next_url
+
+
 def lambda_handler(event, context):
     """Create metadata and add it to the database.
 
@@ -79,12 +110,14 @@ def lambda_handler(event, context):
         return _error(400, f"Unexpected parameters: {', '.join(unexpected)}")
 
     if not params.get("instrument"):
-        logger.info("No instrument specified, defaulting to all instruments")
         meta_instrument = "all"
         meta_type = "science"
-    elif params["instrument"] == "spice" or params["instrument"].endswith("hk"):
-        meta_instrument = "none"
-        meta_type = params["instrument"]
+    elif params["instrument"] == "spice":
+        meta_instrument = "spice"
+        meta_type = "spice"
+    elif params["instrument"].endswith("hk"):
+        meta_instrument = params["instrument"]
+        meta_type = "hk"
     else:
         meta_instrument = params["instrument"]
         meta_type = "science"
@@ -107,9 +140,6 @@ def lambda_handler(event, context):
     for instrument in instruments:
         key_expr = Key("instrument").eq(instrument)
         query_kwargs = {"KeyConditionExpression": key_expr}
-
-        if params.get("last_evaluated_key"):
-            query_kwargs["ExclusiveStartKey"] = json.loads(params["last_evaluated_key"])
 
         if any(
             param in params
@@ -136,6 +166,10 @@ def lambda_handler(event, context):
             query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
                 one_minute_ago.isoformat(), now.isoformat()
             )
+
+        if params.get("last_evaluated_key") and len(instruments) == 1:
+            query_kwargs["ExclusiveStartKey"] = json.loads(params["last_evaluated_key"])
+
         t1 = time.perf_counter()
         response = table.query(**query_kwargs)
         t2 = time.perf_counter()
@@ -145,18 +179,29 @@ def lambda_handler(event, context):
     last_evaluated_key = response.get("LastEvaluatedKey")
 
     t3 = time.perf_counter()
+
+    encoded_lek = json.dumps(last_evaluated_key) if last_evaluated_key else None
+    has_more = last_evaluated_key is not None
+
+    next_url = build_next_url(event, last_evaluated_key, params)
+
     json_body = json.dumps(
         {
             "meta": {
                 "count": len(items),
                 "type": meta_type,
                 "instrument": meta_instrument,
-                "last_evaluated_key": last_evaluated_key,
+                "has_more": has_more,
+                "last_evaluated_key": encoded_lek,
             },
+            "links": {
+                "next": next_url
+            } if has_more else {},
             "data": items,
         },
         default=str,
     )
+
     t4 = time.perf_counter()
 
     logger.info(

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
-from urllib.parse import quote_plus, unquote_plus, urlencode
+from urllib.parse import unquote_plus
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -40,12 +40,22 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> Key:
     end = params.get("time_utc_end") or params.get("met_in_utc_end")
 
     if start and end:
-        key_expr &= Key("time_utc").between(start, end)
+        start_dt = datetime.fromisoformat(start)
+        end_dt = datetime.fromisoformat(end)
+        if end_dt - start_dt > timedelta(days=1):
+            return _error(400, "Start and end time cannot exceed 1 day apart.")
     elif start:
-        key_expr &= Key("time_utc").gte(start)
-    else:
-        return _error(400, "End time provided without start time")
+        # Calculate end to be 1 day later.
+        start_dt = datetime.fromisoformat(start)
+        end_dt = start_dt + timedelta(days=1)
+        end = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
+    elif end:
+        # Calculate start to be 1 day earlier.
+        end_dt = datetime.fromisoformat(end)
+        start_dt = end_dt - timedelta(days=1)
+        start = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
 
+    key_expr &= Key("time_utc").between(start, end)
     query_kwargs["KeyConditionExpression"] = key_expr
 
     return key_expr
@@ -73,37 +83,7 @@ def _error(code: int, message: str) -> dict:
     }
 
 
-def build_next_url(event: dict, last_evaluated_key: dict) -> str:
-    """Build the next URL for pagination.
-
-    Parameters
-    ----------
-    event : dict
-        The Lambda event object.
-    last_evaluated_key : dict
-        The last evaluated key from DynamoDB query.
-
-    Returns
-    -------
-    next_url : str
-        The URL for the next page of results.
-    """
-    query_params = event.get("queryStringParameters") or {}
-    if last_evaluated_key:
-        query_params["last_evaluated_key"] = quote_plus(json.dumps(last_evaluated_key))
-
-    query_string = urlencode(query_params)
-
-    headers = event.get("headers", {})
-    host = headers.get("host", "")
-    path = event.get("requestContext", {}).get("path", "")
-
-    next_url = f"https://{host}{path}?{query_string}"
-
-    return next_url
-
-
-def lambda_handler(event, context):  # noqa: PLR0915
+def lambda_handler(event, context):
     """Create metadata and add it to the database.
 
     This function is an event handler for s3 ingest bucket.
@@ -121,7 +101,6 @@ def lambda_handler(event, context):  # noqa: PLR0915
 
     """
     params = event.get("queryStringParameters") or {}
-    self_url = build_next_url(event, None)
 
     # --- Determine key condition ---
     allowed_params = {
@@ -215,10 +194,6 @@ def lambda_handler(event, context):  # noqa: PLR0915
     encoded_lek = json.dumps(last_evaluated_key) if last_evaluated_key else None
     has_more = last_evaluated_key is not None
 
-    links = {"self": self_url}
-    if has_more and last_evaluated_key:
-        links["next"] = build_next_url(event, last_evaluated_key)
-
     json_body = json.dumps(
         {
             "meta": {
@@ -228,7 +203,6 @@ def lambda_handler(event, context):  # noqa: PLR0915
                 "has_more": has_more,
                 "last_evaluated_key": encoded_lek,
             },
-            "links": links,
             "data": items,
         },
         default=str,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -18,7 +18,7 @@ dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
 
-def apply_time_filters(params: dict, query_kwargs: dict) -> None:
+def apply_time_filters(params: dict, query_kwargs: dict) -> tuple | None:
     """Apply the filters for time.
 
     Parameters
@@ -30,7 +30,12 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> None:
 
     Returns
     -------
-    None : None
+    query_kwargs : dict
+        The updated key expression with time filters applied.
+    start : str
+        Start time.
+    end : str
+        End time.
     """
     key_expr = query_kwargs["KeyConditionExpression"]
 
@@ -41,7 +46,7 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> None:
         start_dt = datetime.fromisoformat(start)
         end_dt = datetime.fromisoformat(end)
         if end_dt - start_dt > timedelta(days=1):
-            return _error(400, "Start and end time cannot exceed 1 day apart.")
+            return None
     elif start:
         # Calculate end to be 1 hour later.
         start_dt = datetime.fromisoformat(start)
@@ -56,7 +61,7 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> None:
     key_expr &= Key("time_utc").between(start, end)
     query_kwargs["KeyConditionExpression"] = key_expr
 
-    return None
+    return query_kwargs, start, end
 
 
 def _error(code: int, message: str) -> dict:
@@ -151,10 +156,12 @@ def lambda_handler(event, context):
                 "met_in_utc_end",
             )
         ):
-            err = apply_time_filters(params, query_kwargs)
+            query_kwargs, range_start, range_end = apply_time_filters(
+                params, query_kwargs
+            )
             # Checks if there was an error.
-            if err:
-                return err
+            if None:
+                return _error(400, "Start and end time cannot exceed 1 day apart.")
         else:
             # Get latest 1 hour if not specified.
             logger.info(
@@ -166,10 +173,16 @@ def lambda_handler(event, context):
             query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
                 one_hour_ago.isoformat(), now.isoformat()
             )
+            range_start = one_hour_ago.isoformat()
+            range_end = now.isoformat()
 
         t1 = time.perf_counter()
         response = table.query(**query_kwargs)
         t2 = time.perf_counter()
+        logger.info(
+            f"Querying {instrument} between {range_start} and "
+            f"{range_end} took {t2 - t1} s"
+        )
         items.extend(response.get("Items", []))
         query_time_total += t2 - t1
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -24,7 +24,7 @@ class BadTimeError(Exception):
     pass
 
 
-def apply_time_filters(params: dict, query_kwargs: dict) -> tuple | None:
+def apply_time_filters(params: dict, query_kwargs: dict) -> tuple:
     """Apply the filters for time.
 
     Parameters
@@ -59,6 +59,9 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> tuple | None:
         start_dt = end_dt - timedelta(hours=1)
     else:
         raise BadTimeError("Invalid or missing time filters")
+
+    if abs(end_dt - start_dt) > timedelta(days=1):
+        raise BadTimeError("Start and end time cannot exceed 1 day apart.")
 
     start = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
     end = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
@@ -185,11 +188,6 @@ def lambda_handler(event, context):
                 query_kwargs, range_start, range_end = apply_time_filters(
                     params, query_kwargs
                 )
-                if abs(
-                    datetime.fromisoformat(range_end)
-                    - datetime.fromisoformat(range_start)
-                ) > timedelta(days=1):
-                    return _error(400, "Start and end time cannot exceed 1 day apart.")
             else:
                 # Get latest 1 hour if not specified.
                 logger.info(

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -5,7 +5,6 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
-from urllib.parse import unquote_plus
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -109,7 +108,6 @@ def lambda_handler(event, context):
         "time_utc_end",
         "met_in_utc_start",  # for backward compatibility
         "met_in_utc_end",  # for backward compatibility
-        "last_evaluated_key",
     }
 
     # Ensure allowed parameters
@@ -137,10 +135,6 @@ def lambda_handler(event, context):
         if requested_instrument
         else ["hit", "mag", "codice_lo", "codice_hi", "swapi", "swe"]
     )
-
-    # Pagination only allowed for one instrument
-    if len(instruments) > 1 and params.get("last_evaluated_key"):
-        return _error(400, "Pagination is only supported when querying one instrument")
 
     items = []
     query_time_total = 0
@@ -172,12 +166,6 @@ def lambda_handler(event, context):
             one_hour_ago = now - timedelta(hours=1)
             query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
                 one_hour_ago.isoformat(), now.isoformat()
-            )
-
-        if params.get("last_evaluated_key"):
-            raw_last_evaluated_key = params["last_evaluated_key"]
-            query_kwargs["ExclusiveStartKey"] = json.loads(
-                unquote_plus(raw_last_evaluated_key)
             )
 
         t1 = time.perf_counter()

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -18,6 +18,12 @@ dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
 
+class BadTimeError(Exception):
+    """Raised when the time filters are invalid."""
+
+    pass
+
+
 def apply_time_filters(params: dict, query_kwargs: dict) -> tuple | None:
     """Apply the filters for time.
 
@@ -45,22 +51,14 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> tuple | None:
     if start and end:
         start_dt = validate_time(start)
         end_dt = validate_time(end)
-        if start_dt is None or end_dt is None:
-            return None
     elif start:
-        # Calculate end to be 1 hour later.
         start_dt = validate_time(start)
-        if start_dt is None:
-            return None
         end_dt = start_dt + timedelta(hours=1)
     elif end:
-        # Calculate start to be 1 hour earlier.
         end_dt = validate_time(end)
-        if end_dt is None:
-            return None
         start_dt = end_dt - timedelta(hours=1)
     else:
-        return None
+        raise BadTimeError("Invalid or missing time filters")
 
     start = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
     end = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
@@ -87,8 +85,8 @@ def validate_time(ts: str):
     """
     try:
         return datetime.fromisoformat(ts)
-    except Exception:
-        return None
+    except Exception as e:
+        raise BadTimeError("Invalid time format") from e
 
 
 def _error(code: int, message: str) -> dict:
@@ -174,37 +172,41 @@ def lambda_handler(event, context):
         key_expr = Key("instrument").eq(instrument)
         query_kwargs = {"KeyConditionExpression": key_expr}
 
-        if any(
-            param in params
-            for param in (
-                "time_utc_start",
-                "time_utc_end",
-                "met_in_utc_start",
-                "met_in_utc_end",
-            )
-        ):
-            result = apply_time_filters(params, query_kwargs)
-            if result is None:
-                return _error(400, "Invalid time format: expected YYYY-MM-DDTHH:MM:SS")
-            query_kwargs, range_start, range_end = result
-            # Checks if the max time range is exceeded.
-            if abs(
-                datetime.fromisoformat(range_end) - datetime.fromisoformat(range_start)
-            ) > timedelta(days=1):
-                return _error(400, "Start and end time cannot exceed 1 day apart.")
-        else:
-            # Get latest 1 hour if not specified.
-            logger.info(
-                "No time range specified, defaulting to last 1 hour for instrument: %s",
-                instrument,
-            )
-            now = datetime.now(timezone.utc)
-            one_hour_ago = now - timedelta(hours=1)
-            query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
-                one_hour_ago.isoformat(), now.isoformat()
-            )
-            range_start = one_hour_ago.isoformat()
-            range_end = now.isoformat()
+        try:
+            if any(
+                param in params
+                for param in (
+                    "time_utc_start",
+                    "time_utc_end",
+                    "met_in_utc_start",
+                    "met_in_utc_end",
+                )
+            ):
+                query_kwargs, range_start, range_end = apply_time_filters(
+                    params, query_kwargs
+                )
+                if abs(
+                    datetime.fromisoformat(range_end)
+                    - datetime.fromisoformat(range_start)
+                ) > timedelta(days=1):
+                    return _error(400, "Start and end time cannot exceed 1 day apart.")
+            else:
+                # Get latest 1 hour if not specified.
+                logger.info(
+                    "No time range specified, "
+                    "defaulting to last 1 hour for instrument: %s",
+                    instrument,
+                )
+                now = datetime.now(timezone.utc)
+                one_hour_ago = now - timedelta(hours=1)
+                query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
+                    one_hour_ago.isoformat(), now.isoformat()
+                )
+                range_start = one_hour_ago.isoformat()
+                range_end = now.isoformat()
+
+        except BadTimeError as e:
+            return _error(400, str(e))
 
         t1 = time.perf_counter()
         response = table.query(**query_kwargs)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -1,11 +1,11 @@
-"""I-ALiRT Database Query lambda."""
+"""I-ALiRT Data Query lambda."""
 
 import json
 import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
-from urllib.parse import quote_plus, urlencode, unquote_plus
+from urllib.parse import quote_plus, unquote_plus, urlencode
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -19,7 +19,21 @@ dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
 
-def apply_time_filters(params, query_kwargs):
+def apply_time_filters(params: dict, query_kwargs: dict) -> Key:
+    """Apply the filters for time.
+
+    Parameters
+    ----------
+    params : dict
+        Event parameters.
+    query_kwargs : dict
+        Query keyword arguments.
+
+    Returns
+    -------
+    key_expr : Key
+        The updated key expression with time filters applied.
+    """
     key_expr = query_kwargs["KeyConditionExpression"]
 
     start = params.get("time_utc_start") or params.get("met_in_utc_start")
@@ -37,7 +51,21 @@ def apply_time_filters(params, query_kwargs):
     return key_expr
 
 
-def _error(code, message):
+def _error(code: int, message: str) -> dict:
+    """Create error dictionary.
+
+    Parameters
+    ----------
+    code : int
+        Error code.
+    message : str
+        The error message.
+
+    Returns
+    -------
+    error : dict
+        The error dictionary.
+    """
     return {
         "statusCode": code,
         "body": json.dumps({"message": message}),
@@ -45,7 +73,7 @@ def _error(code, message):
     }
 
 
-def build_next_url(event, last_evaluated_key):
+def build_next_url(event: dict, last_evaluated_key: dict) -> str:
     """Build the next URL for pagination.
 
     Parameters
@@ -75,7 +103,7 @@ def build_next_url(event, last_evaluated_key):
     return next_url
 
 
-def lambda_handler(event, context):
+def lambda_handler(event, context):  # noqa: PLR0915
     """Create metadata and add it to the database.
 
     This function is an event handler for s3 ingest bucket.
@@ -93,6 +121,7 @@ def lambda_handler(event, context):
 
     """
     params = event.get("queryStringParameters") or {}
+    self_url = build_next_url(event, None)
 
     # --- Determine key condition ---
     allowed_params = {
@@ -169,7 +198,9 @@ def lambda_handler(event, context):
 
         if params.get("last_evaluated_key"):
             raw_last_evaluated_key = params["last_evaluated_key"]
-            query_kwargs["ExclusiveStartKey"] = json.loads(unquote_plus(raw_last_evaluated_key))
+            query_kwargs["ExclusiveStartKey"] = json.loads(
+                unquote_plus(raw_last_evaluated_key)
+            )
 
         t1 = time.perf_counter()
         response = table.query(**query_kwargs)
@@ -184,7 +215,9 @@ def lambda_handler(event, context):
     encoded_lek = json.dumps(last_evaluated_key) if last_evaluated_key else None
     has_more = last_evaluated_key is not None
 
-    next_url = build_next_url(event, last_evaluated_key)
+    links = {"self": self_url}
+    if has_more and last_evaluated_key:
+        links["next"] = build_next_url(event, last_evaluated_key)
 
     json_body = json.dumps(
         {
@@ -195,7 +228,7 @@ def lambda_handler(event, context):
                 "has_more": has_more,
                 "last_evaluated_key": encoded_lek,
             },
-            "links": {"next": next_url} if has_more else {},
+            "links": links,
             "data": items,
         },
         default=str,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -18,7 +18,7 @@ dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
 
-def apply_time_filters(params: dict, query_kwargs: dict) -> Key:
+def apply_time_filters(params: dict, query_kwargs: dict) -> None:
     """Apply the filters for time.
 
     Parameters
@@ -30,8 +30,7 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> Key:
 
     Returns
     -------
-    key_expr : Key
-        The updated key expression with time filters applied.
+    None : None
     """
     key_expr = query_kwargs["KeyConditionExpression"]
 
@@ -57,7 +56,7 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> Key:
     key_expr &= Key("time_utc").between(start, end)
     query_kwargs["KeyConditionExpression"] = key_expr
 
-    return key_expr
+    return None
 
 
 def _error(code: int, message: str) -> dict:
@@ -152,10 +151,10 @@ def lambda_handler(event, context):
                 "met_in_utc_end",
             )
         ):
-            result = apply_time_filters(params, query_kwargs)
+            err = apply_time_filters(params, query_kwargs)
             # Checks if there was an error.
-            if isinstance(result, dict):
-                return result
+            if err:
+                return err
         else:
             # Get latest 1 hour if not specified.
             logger.info(

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -58,7 +58,11 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> tuple:
         end_dt = validate_time(end)
         start_dt = end_dt - timedelta(hours=1)
     else:
-        raise BadTimeError("Invalid or missing time filters")
+        # Get latest 1 hour if not specified.
+        logger.info("No time range specified, defaulting to last 1 hour.")
+        now = datetime.now(timezone.utc)
+        start_dt = now - timedelta(hours=1)
+        end_dt = now
 
     if abs(end_dt - start_dt) > timedelta(days=1):
         raise BadTimeError("Start and end time cannot exceed 1 day apart.")
@@ -176,33 +180,9 @@ def lambda_handler(event, context):
         query_kwargs = {"KeyConditionExpression": key_expr}
 
         try:
-            if any(
-                param in params
-                for param in (
-                    "time_utc_start",
-                    "time_utc_end",
-                    "met_in_utc_start",
-                    "met_in_utc_end",
-                )
-            ):
-                query_kwargs, range_start, range_end = apply_time_filters(
-                    params, query_kwargs
-                )
-            else:
-                # Get latest 1 hour if not specified.
-                logger.info(
-                    "No time range specified, "
-                    "defaulting to last 1 hour for instrument: %s",
-                    instrument,
-                )
-                now = datetime.now(timezone.utc)
-                one_hour_ago = now - timedelta(hours=1)
-                query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
-                    one_hour_ago.isoformat(), now.isoformat()
-                )
-                range_start = one_hour_ago.isoformat()
-                range_end = now.isoformat()
-
+            query_kwargs, range_start, range_end = apply_time_filters(
+                params, query_kwargs
+            )
         except BadTimeError as e:
             return _error(400, str(e))
 

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import time
 from datetime import datetime, timezone, timedelta
 
 import boto3
@@ -85,6 +86,8 @@ def lambda_handler(event, context):
     )
 
     items = []
+    last_evaluated = []
+    query_time_total = 0
 
     for instrument in instruments:
         key_expr = Key("instrument").eq(instrument)
@@ -104,14 +107,28 @@ def lambda_handler(event, context):
             query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
                 one_minute_ago.isoformat(), now.isoformat()
             )
+        t1 = time.perf_counter()
         response = table.query(**query_kwargs)
+        t2 = time.perf_counter()
         items.extend(response.get("Items", []))
+        query_time_total += (t2 - t1)
+        last_evaluated_key = response.get("LastEvaluatedKey")
+
+    t3 = time.perf_counter()
+    json_body = json.dumps({
+            "meta": {"count": len(items)},
+            "data": items,
+        })
+    t4 = time.perf_counter()
+
+    logger.info(
+        f"Query total: {query_time_total:.3f}s | "
+        f"JSON build: {t4 - t3:.3f}s | "
+        f"Items: {len(items)}"
+    )
 
     return {
         "statusCode": 200,
         "headers": {"Content-Type": "application/json"},
-        "body": json.dumps({
-            "meta": {"count": len(items)},
-            "data": items,
-        })
+        "body": json_body
     }

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -45,14 +45,14 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> Key:
         if end_dt - start_dt > timedelta(days=1):
             return _error(400, "Start and end time cannot exceed 1 day apart.")
     elif start:
-        # Calculate end to be 1 day later.
+        # Calculate end to be 1 hour later.
         start_dt = datetime.fromisoformat(start)
-        end_dt = start_dt + timedelta(days=1)
+        end_dt = start_dt + timedelta(hours=1)
         end = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
     elif end:
-        # Calculate start to be 1 day earlier.
+        # Calculate start to be 1 hour earlier.
         end_dt = datetime.fromisoformat(end)
-        start_dt = end_dt - timedelta(days=1)
+        start_dt = end_dt - timedelta(hours=1)
         start = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
 
     key_expr &= Key("time_utc").between(start, end)
@@ -163,16 +163,15 @@ def lambda_handler(event, context):
             if isinstance(result, dict):
                 return result
         else:
-            # Get latest 1 minute if not specified.
+            # Get latest 1 hour if not specified.
             logger.info(
-                "No time range specified, defaulting to last "
-                "1 minute for instrument: %s",
+                "No time range specified, defaulting to last 1 hour for instrument: %s",
                 instrument,
             )
             now = datetime.now(timezone.utc)
-            one_minute_ago = now - timedelta(minutes=1)
+            one_hour_ago = now - timedelta(hours=1)
             query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
-                one_minute_ago.isoformat(), now.isoformat()
+                one_hour_ago.isoformat(), now.isoformat()
             )
 
         if params.get("last_evaluated_key"):

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -1,0 +1,164 @@
+"""I-ALiRT Database Query lambda."""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone, timedelta
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+table_name = os.environ.get("ALGORITHM_TABLE")
+region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+dynamodb = boto3.resource("dynamodb", region_name=region)
+table = dynamodb.Table(table_name)
+
+def query_times(params, key_expr, query_kwargs):
+    time_prefixes = {"met", "met_in_utc", "last_modified"}
+    used_time_prefixes = {
+        param.split("_start")[0].split("_end")[0]
+        for param in params
+        if any(param.startswith(prefix) for prefix in time_prefixes)
+    }
+
+    if len(used_time_prefixes) > 1:
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                {
+                    "message": "Cannot query multiple time keys "
+                               "(met, met_in_utc, last_modified)"
+                }
+            ),
+        }
+
+    if (
+            ("met_start" in params and "met_end" in params)
+            or ("met_in_utc_start" in params and "met_in_utc_end" in params)
+            or ("last_modified_start" in params and "last_modified_end" in params)
+    ):
+        if "met_start" in params:
+            time_key = "met"
+        elif "met_in_utc_start" in params:
+            time_key = "met_in_utc"
+        else:
+            time_key = "last_modified"
+
+        start_value = (
+            int(params[f"{time_key}_start"])
+            if time_key == "met"
+            else params[f"{time_key}_start"]
+        )
+        end_value = (
+            int(params[f"{time_key}_end"])
+            if time_key == "met"
+            else params[f"{time_key}_end"]
+        )
+
+        key_expr &= Key(time_key).between(start_value, end_value)
+
+        if time_key in {"met_in_utc", "last_modified"}:
+            query_kwargs["IndexName"] = time_key
+
+    elif (
+            "met_start" in params
+            or "met_in_utc_start" in params
+            or "last_modified_start" in params
+    ):
+        if "met_start" in params:
+            time_key = "met"
+        elif "met_in_utc_start" in params:
+            time_key = "met_in_utc"
+        else:
+            time_key = "last_modified"
+
+        start_value = (
+            int(params[f"{time_key}_start"])
+            if time_key == "met"
+            else params[f"{time_key}_start"]
+        )
+        key_expr &= Key(time_key).gte(start_value)
+
+        if time_key in {"met_in_utc", "last_modified"}:
+            query_kwargs["IndexName"] = time_key
+
+    elif (
+            "met_end" in params
+            or "met_in_utc_end" in params
+            or "last_modified_end" in params
+    ):
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                {"message": "Cannot query by end time without start time"}
+            ),
+        }
+
+    return key_expr
+
+
+def lambda_handler(event, context):
+    """Create metadata and add it to the database.
+
+    This function is an event handler for s3 ingest bucket.
+    It is also used to ingest data to the DynamoDB table.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process
+    context : LambdaContext
+        This object provides methods and properties that provide
+        information about the invocation, function,
+        and runtime environment.
+
+    """
+
+    # --- Parse event ---
+    params = event.get("queryStringParameters", {})
+
+    if not params:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"message": "No query parameters provided."}),
+        }
+
+    # --- Determine key condition ---
+    allowed_params = {
+        "instrument",
+        "time_utc_start",
+        "time_utc_end",
+        "met_in_utc_start", # To keep continuity with other API.
+        "met_in_utc_end", # To keep continuity with other API.
+    }
+
+    unexpected_params = set(params.keys()) - allowed_params
+    if unexpected_params:
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                {"message": f"Unexpected parameters: {', '.join(unexpected_params)}"}
+            ),
+        }
+
+    if not params.get("instrument"):
+        instruments = ["hit", "mag", "codice_lo", "codice_hi", "swapi", "swe"]
+    else:
+        instruments = [params["instrument"]]
+
+    for instrument in instruments:
+        key_expr = Key("instrument").eq(instrument)
+        query_kwargs = {"KeyConditionExpression": key_expr}
+
+        if params:
+            key_expr = query_times(params, key_expr, query_kwargs)
+            response = table.query(**query_kwargs)
+        else:
+            now = datetime.now(timezone.utc)
+            one_minute_ago = now - timedelta(minutes=1)
+            key_expr &= Key("met_in_utc").between(one_minute_ago, now)
+

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -16,31 +16,22 @@ region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
 dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
-def apply_time_filters(params, key_expr, query_kwargs):
-    time_prefixes = {"met_in_utc", "time_utc"}
-    used_time_prefixes = {
-        param.split("_start")[0].split("_end")[0]
-        for param in params
-        if any(param.startswith(prefix) for prefix in time_prefixes)
-    }
+def apply_time_filters(params, query_kwargs):
+    key_expr = query_kwargs["KeyConditionExpression"]
 
-    if len(used_time_prefixes) > 1:
-        return _error(400, "Cannot query multiple time keys (met_in_utc, time_utc)")
-
-    time_key = used_time_prefixes.pop()
-    start = params.get(f"{time_key}_start")
-    end = params.get(f"{time_key}_end")
+    start = params.get("time_utc_start") or params.get("met_in_utc_start")
+    end = params.get("time_utc_end") or params.get("met_in_utc_end")
 
     if start and end:
-        key_expr &= Key(time_key).between(start, end)
+        key_expr &= Key("time_utc").between(start, end)
     elif start:
-        key_expr &= Key(time_key).gte(start)
+        key_expr &= Key("time_utc").gte(start)
     else:
         return _error(400, "End time provided without start time")
 
     query_kwargs["KeyConditionExpression"] = key_expr
 
-    return
+    return key_expr
 
 
 def _error(code, message):
@@ -99,14 +90,17 @@ def lambda_handler(event, context):
         key_expr = Key("instrument").eq(instrument)
         query_kwargs = {"KeyConditionExpression": key_expr}
 
-        if any(param.endswith("_start") or param.endswith("_end") for param in params):
-            apply_time_filters(params, key_expr, query_kwargs)
+        if any(param in params for param in ("time_utc_start", "time_utc_end",
+                                     "met_in_utc_start", "met_in_utc_end")):
+            result = apply_time_filters(params, query_kwargs)
+            # Checks if there was an error.
+            if isinstance(result, dict):
+                return result
         else:
             # Get latest 1 minute if not specified.
             logger.info("No time range specified, defaulting to last 1 minute for instrument: %s", instrument)
             now = datetime.now(timezone.utc)
             one_minute_ago = now - timedelta(minutes=1)
-            key_expr &= Key("met_in_utc").between(one_minute_ago, now)
             query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
                 one_minute_ago.isoformat(), now.isoformat()
             )

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
-from urllib.parse import urlencode, quote_plus
+from urllib.parse import quote_plus, urlencode
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -60,7 +60,7 @@ def build_next_url(event, last_evaluated_key):
     next_url : str
         The URL for the next page of results.
     """
-    query_params = event.get("queryStringParameters", {})
+    query_params = event.get("queryStringParameters") or {}
     if last_evaluated_key:
         query_params["last_evaluated_key"] = quote_plus(json.dumps(last_evaluated_key))
 
@@ -92,7 +92,7 @@ def lambda_handler(event, context):
         and runtime environment.
 
     """
-    params = event.get("queryStringParameters", {})
+    params = event.get("queryStringParameters") or {}
 
     # --- Determine key condition ---
     allowed_params = {
@@ -194,9 +194,7 @@ def lambda_handler(event, context):
                 "has_more": has_more,
                 "last_evaluated_key": encoded_lek,
             },
-            "links": {
-                "next": next_url
-            } if has_more else {},
+            "links": {"next": next_url} if has_more else {},
             "data": items,
         },
         default=str,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -16,8 +16,8 @@ region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
 dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
-def query_times(params, key_expr, query_kwargs):
-    time_prefixes = {"met", "met_in_utc", "last_modified"}
+def apply_time_filters(params, key_expr, query_kwargs):
+    time_prefixes = {"met_in_utc", "time_utc"}
     used_time_prefixes = {
         param.split("_start")[0].split("_end")[0]
         for param in params
@@ -25,79 +25,30 @@ def query_times(params, key_expr, query_kwargs):
     }
 
     if len(used_time_prefixes) > 1:
-        return {
-            "statusCode": 400,
-            "body": json.dumps(
-                {
-                    "message": "Cannot query multiple time keys "
-                               "(met, met_in_utc, last_modified)"
-                }
-            ),
-        }
+        return _error(400, "Cannot query multiple time keys (met_in_utc, time_utc)")
 
-    if (
-            ("met_start" in params and "met_end" in params)
-            or ("met_in_utc_start" in params and "met_in_utc_end" in params)
-            or ("last_modified_start" in params and "last_modified_end" in params)
-    ):
-        if "met_start" in params:
-            time_key = "met"
-        elif "met_in_utc_start" in params:
-            time_key = "met_in_utc"
-        else:
-            time_key = "last_modified"
+    time_key = used_time_prefixes.pop()
+    start = params.get(f"{time_key}_start")
+    end = params.get(f"{time_key}_end")
 
-        start_value = (
-            int(params[f"{time_key}_start"])
-            if time_key == "met"
-            else params[f"{time_key}_start"]
-        )
-        end_value = (
-            int(params[f"{time_key}_end"])
-            if time_key == "met"
-            else params[f"{time_key}_end"]
-        )
+    if start and end:
+        key_expr &= Key(time_key).between(start, end)
+    elif start:
+        key_expr &= Key(time_key).gte(start)
+    else:
+        return _error(400, "End time provided without start time")
 
-        key_expr &= Key(time_key).between(start_value, end_value)
+    query_kwargs["KeyConditionExpression"] = key_expr
 
-        if time_key in {"met_in_utc", "last_modified"}:
-            query_kwargs["IndexName"] = time_key
+    return
 
-    elif (
-            "met_start" in params
-            or "met_in_utc_start" in params
-            or "last_modified_start" in params
-    ):
-        if "met_start" in params:
-            time_key = "met"
-        elif "met_in_utc_start" in params:
-            time_key = "met_in_utc"
-        else:
-            time_key = "last_modified"
 
-        start_value = (
-            int(params[f"{time_key}_start"])
-            if time_key == "met"
-            else params[f"{time_key}_start"]
-        )
-        key_expr &= Key(time_key).gte(start_value)
-
-        if time_key in {"met_in_utc", "last_modified"}:
-            query_kwargs["IndexName"] = time_key
-
-    elif (
-            "met_end" in params
-            or "met_in_utc_end" in params
-            or "last_modified_end" in params
-    ):
-        return {
-            "statusCode": 400,
-            "body": json.dumps(
-                {"message": "Cannot query by end time without start time"}
-            ),
-        }
-
-    return key_expr
+def _error(code, message):
+    return {
+        "statusCode": code,
+        "body": json.dumps({"message": message}),
+        "headers": {"Content-Type": "application/json"},
+    }
 
 
 def lambda_handler(event, context):
@@ -117,48 +68,56 @@ def lambda_handler(event, context):
         and runtime environment.
 
     """
-
-    # --- Parse event ---
     params = event.get("queryStringParameters", {})
-
-    if not params:
-        return {
-            "statusCode": 400,
-            "body": json.dumps({"message": "No query parameters provided."}),
-        }
 
     # --- Determine key condition ---
     allowed_params = {
         "instrument",
         "time_utc_start",
         "time_utc_end",
-        "met_in_utc_start", # To keep continuity with other API.
-        "met_in_utc_end", # To keep continuity with other API.
+        "met_in_utc_start", # for backward compatibility
+        "met_in_utc_end", # for backward compatibility
     }
 
-    unexpected_params = set(params.keys()) - allowed_params
-    if unexpected_params:
-        return {
-            "statusCode": 400,
-            "body": json.dumps(
-                {"message": f"Unexpected parameters: {', '.join(unexpected_params)}"}
-            ),
-        }
+    # Ensure allowed parameters
+    unexpected = set(params) - allowed_params
+    if unexpected:
+        return _error(400, f"Unexpected parameters: {', '.join(unexpected)}")
 
     if not params.get("instrument"):
-        instruments = ["hit", "mag", "codice_lo", "codice_hi", "swapi", "swe"]
-    else:
-        instruments = [params["instrument"]]
+        logger.info("No instrument specified, defaulting to all instruments")
+
+    # Get instrument or default to all.
+    instruments = (
+        [params["instrument"]] if params.get("instrument")
+        else ["hit", "mag", "codice_lo", "codice_hi", "swapi", "swe"]
+    )
+
+    items = []
 
     for instrument in instruments:
         key_expr = Key("instrument").eq(instrument)
         query_kwargs = {"KeyConditionExpression": key_expr}
 
-        if params:
-            key_expr = query_times(params, key_expr, query_kwargs)
-            response = table.query(**query_kwargs)
+        if any(param.endswith("_start") or param.endswith("_end") for param in params):
+            apply_time_filters(params, key_expr, query_kwargs)
         else:
+            # Get latest 1 minute if not specified.
+            logger.info("No time range specified, defaulting to last 1 minute for instrument: %s", instrument)
             now = datetime.now(timezone.utc)
             one_minute_ago = now - timedelta(minutes=1)
             key_expr &= Key("met_in_utc").between(one_minute_ago, now)
+            query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
+                one_minute_ago.isoformat(), now.isoformat()
+            )
+        response = table.query(**query_kwargs)
+        items.extend(response.get("Items", []))
 
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({
+            "meta": {"count": len(items)},
+            "data": items,
+        })
+    }

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -18,7 +18,7 @@ dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
 
-def apply_time_filters(params: dict, query_kwargs: dict) -> tuple:
+def apply_time_filters(params: dict, query_kwargs: dict) -> tuple | None:
     """Apply the filters for time.
 
     Parameters
@@ -42,21 +42,53 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> tuple:
     start = params.get("time_utc_start") or params.get("met_in_utc_start")
     end = params.get("time_utc_end") or params.get("met_in_utc_end")
 
-    if start and not end:
+    if start and end:
+        start_dt = validate_time(start)
+        end_dt = validate_time(end)
+        if start_dt is None or end_dt is None:
+            return None
+    elif start:
         # Calculate end to be 1 hour later.
-        start_dt = datetime.fromisoformat(start)
+        start_dt = validate_time(start)
+        if start_dt is None:
+            return None
         end_dt = start_dt + timedelta(hours=1)
-        end = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
-    elif end and not start:
+    elif end:
         # Calculate start to be 1 hour earlier.
-        end_dt = datetime.fromisoformat(end)
+        end_dt = validate_time(end)
+        if end_dt is None:
+            return None
         start_dt = end_dt - timedelta(hours=1)
-        start = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
+    else:
+        return None
+
+    start = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
+    end = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
 
     key_expr &= Key("time_utc").between(start, end)
     query_kwargs["KeyConditionExpression"] = key_expr
 
     return query_kwargs, start, end
+
+
+def validate_time(ts: str):
+    """Validate a timestamp string in ISO 8601 format (YYYY-MM-DDTHH:MM:SS).
+
+    Parameters
+    ----------
+    ts : str
+        The timestamp string to validate.
+
+    Returns
+    -------
+    datetime | None
+        A `datetime` object if the timestamp is valid,
+        or `None` if the format is invalid.
+    """
+    try:
+        return datetime.fromisoformat(ts)
+    except Exception:
+        return None
 
 
 def _error(code: int, message: str) -> dict:
@@ -151,12 +183,13 @@ def lambda_handler(event, context):
                 "met_in_utc_end",
             )
         ):
-            query_kwargs, range_start, range_end = apply_time_filters(
-                params, query_kwargs
-            )
+            result = apply_time_filters(params, query_kwargs)
+            if result is None:
+                return _error(400, "Invalid time format: expected YYYY-MM-DDTHH:MM:SS")
+            query_kwargs, range_start, range_end = result
             # Checks if the max time range is exceeded.
-            if datetime.fromisoformat(range_end) - datetime.fromisoformat(
-                range_start
+            if abs(
+                datetime.fromisoformat(range_end) - datetime.fromisoformat(range_start)
             ) > timedelta(days=1):
                 return _error(400, "Start and end time cannot exceed 1 day apart.")
         else:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -69,6 +69,7 @@ def lambda_handler(event, context):
         "time_utc_end",
         "met_in_utc_start", # for backward compatibility
         "met_in_utc_end", # for backward compatibility
+        "last_evaluated_key"
     }
 
     # Ensure allowed parameters
@@ -85,9 +86,12 @@ def lambda_handler(event, context):
         else ["hit", "mag", "codice_lo", "codice_hi", "swapi", "swe"]
     )
 
+    if len(instruments) > 1 and params.get("last_evaluated_key"):
+        return _error(400, "Pagination is only supported when querying one instrument")
+
     items = []
-    last_evaluated = []
     query_time_total = 0
+    last_evaluated_key = None
 
     for instrument in instruments:
         key_expr = Key("instrument").eq(instrument)
@@ -112,11 +116,13 @@ def lambda_handler(event, context):
         t2 = time.perf_counter()
         items.extend(response.get("Items", []))
         query_time_total += (t2 - t1)
-        last_evaluated_key = response.get("LastEvaluatedKey")
+
+    last_evaluated_key = response.get("LastEvaluatedKey")
 
     t3 = time.perf_counter()
     json_body = json.dumps({
-            "meta": {"count": len(items)},
+            "meta": {"count": len(items),
+                     "last_evaluated_key": last_evaluated_key},
             "data": items,
         })
     t4 = time.perf_counter()

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -16,6 +16,7 @@ table_name = os.environ.get("ALGORITHM_TABLE")
 region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
 dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
+
 
 def apply_time_filters(params, query_kwargs):
     key_expr = query_kwargs["KeyConditionExpression"]
@@ -67,9 +68,8 @@ def lambda_handler(event, context):
         "instrument",
         "time_utc_start",
         "time_utc_end",
-        "met_in_utc_start", # for backward compatibility
-        "met_in_utc_end", # for backward compatibility
-        "last_evaluated_key"
+        "met_in_utc_start",  # for backward compatibility
+        "met_in_utc_end",  # for backward compatibility
     }
 
     # Ensure allowed parameters
@@ -79,33 +79,49 @@ def lambda_handler(event, context):
 
     if not params.get("instrument"):
         logger.info("No instrument specified, defaulting to all instruments")
+        instrument = "all"
+        type = "science"
+    elif params["instrument"] == "spice" or "hk" in params["instrument"]:
+        instrument = "none"
+        type = params["instrument"]
+    else:
+        instrument = params["instrument"]
+        type = "science"
 
     # Get instrument or default to all.
     instruments = (
-        [params["instrument"]] if params.get("instrument")
+        [params["instrument"]]
+        if params.get("instrument")
         else ["hit", "mag", "codice_lo", "codice_hi", "swapi", "swe"]
     )
 
-    if len(instruments) > 1 and params.get("last_evaluated_key"):
-        return _error(400, "Pagination is only supported when querying one instrument")
-
     items = []
     query_time_total = 0
-    last_evaluated_key = None
 
     for instrument in instruments:
         key_expr = Key("instrument").eq(instrument)
         query_kwargs = {"KeyConditionExpression": key_expr}
 
-        if any(param in params for param in ("time_utc_start", "time_utc_end",
-                                     "met_in_utc_start", "met_in_utc_end")):
+        if any(
+            param in params
+            for param in (
+                "time_utc_start",
+                "time_utc_end",
+                "met_in_utc_start",
+                "met_in_utc_end",
+            )
+        ):
             result = apply_time_filters(params, query_kwargs)
             # Checks if there was an error.
             if isinstance(result, dict):
                 return result
         else:
             # Get latest 1 minute if not specified.
-            logger.info("No time range specified, defaulting to last 1 minute for instrument: %s", instrument)
+            logger.info(
+                "No time range specified, defaulting to last "
+                "1 minute for instrument: %s",
+                instrument,
+            )
             now = datetime.now(timezone.utc)
             one_minute_ago = now - timedelta(minutes=1)
             query_kwargs["KeyConditionExpression"] &= Key("time_utc").between(
@@ -115,16 +131,23 @@ def lambda_handler(event, context):
         response = table.query(**query_kwargs)
         t2 = time.perf_counter()
         items.extend(response.get("Items", []))
-        query_time_total += (t2 - t1)
+        query_time_total += t2 - t1
 
     last_evaluated_key = response.get("LastEvaluatedKey")
 
     t3 = time.perf_counter()
-    json_body = json.dumps({
-            "meta": {"count": len(items),
-                     "last_evaluated_key": last_evaluated_key},
+    json_body = json.dumps(
+        {
+            "meta": {
+                "count": len(items),
+                "type": type,
+                "instrument": instrument,
+                "last_evaluated_key": last_evaluated_key,
+            },
             "data": items,
-        })
+        },
+        default=str,
+    )
     t4 = time.perf_counter()
 
     logger.info(
@@ -136,5 +159,5 @@ def lambda_handler(event, context):
     return {
         "statusCode": 200,
         "headers": {"Content-Type": "application/json"},
-        "body": json_body
+        "body": json_body,
     }

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -70,6 +70,7 @@ def lambda_handler(event, context):
         "time_utc_end",
         "met_in_utc_start",  # for backward compatibility
         "met_in_utc_end",  # for backward compatibility
+        "last_evaluated_key",
     }
 
     # Ensure allowed parameters
@@ -79,21 +80,26 @@ def lambda_handler(event, context):
 
     if not params.get("instrument"):
         logger.info("No instrument specified, defaulting to all instruments")
-        instrument = "all"
-        type = "science"
-    elif params["instrument"] == "spice" or "hk" in params["instrument"]:
-        instrument = "none"
-        type = params["instrument"]
+        meta_instrument = "all"
+        meta_type = "science"
+    elif params["instrument"] == "spice" or params["instrument"].endswith("hk"):
+        meta_instrument = "none"
+        meta_type = params["instrument"]
     else:
-        instrument = params["instrument"]
-        type = "science"
+        meta_instrument = params["instrument"]
+        meta_type = "science"
 
     # Get instrument or default to all.
+    requested_instrument = params.get("instrument")
     instruments = (
-        [params["instrument"]]
-        if params.get("instrument")
+        [requested_instrument]
+        if requested_instrument
         else ["hit", "mag", "codice_lo", "codice_hi", "swapi", "swe"]
     )
+
+    # Pagination only allowed for one instrument
+    if len(instruments) > 1 and params.get("last_evaluated_key"):
+        return _error(400, "Pagination is only supported when querying one instrument")
 
     items = []
     query_time_total = 0
@@ -101,6 +107,9 @@ def lambda_handler(event, context):
     for instrument in instruments:
         key_expr = Key("instrument").eq(instrument)
         query_kwargs = {"KeyConditionExpression": key_expr}
+
+        if params.get("last_evaluated_key"):
+            query_kwargs["ExclusiveStartKey"] = json.loads(params["last_evaluated_key"])
 
         if any(
             param in params
@@ -140,8 +149,8 @@ def lambda_handler(event, context):
         {
             "meta": {
                 "count": len(items),
-                "type": type,
-                "instrument": instrument,
+                "type": meta_type,
+                "instrument": meta_instrument,
                 "last_evaluated_key": last_evaluated_key,
             },
             "data": items,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -18,7 +18,7 @@ dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
 
-def apply_time_filters(params: dict, query_kwargs: dict) -> tuple | None:
+def apply_time_filters(params: dict, query_kwargs: dict) -> tuple:
     """Apply the filters for time.
 
     Parameters
@@ -42,17 +42,12 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> tuple | None:
     start = params.get("time_utc_start") or params.get("met_in_utc_start")
     end = params.get("time_utc_end") or params.get("met_in_utc_end")
 
-    if start and end:
-        start_dt = datetime.fromisoformat(start)
-        end_dt = datetime.fromisoformat(end)
-        if end_dt - start_dt > timedelta(days=1):
-            return None
-    elif start:
+    if start and not end:
         # Calculate end to be 1 hour later.
         start_dt = datetime.fromisoformat(start)
         end_dt = start_dt + timedelta(hours=1)
         end = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
-    elif end:
+    elif end and not start:
         # Calculate start to be 1 hour earlier.
         end_dt = datetime.fromisoformat(end)
         start_dt = end_dt - timedelta(hours=1)
@@ -159,8 +154,10 @@ def lambda_handler(event, context):
             query_kwargs, range_start, range_end = apply_time_filters(
                 params, query_kwargs
             )
-            # Checks if there was an error.
-            if None:
+            # Checks if the max time range is exceeded.
+            if datetime.fromisoformat(range_end) - datetime.fromisoformat(
+                range_start
+            ) > timedelta(days=1):
                 return _error(400, "Start and end time cannot exceed 1 day apart.")
         else:
             # Get latest 1 hour if not specified.

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
-from urllib.parse import quote_plus, urlencode
+from urllib.parse import quote_plus, urlencode, unquote_plus
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -167,8 +167,9 @@ def lambda_handler(event, context):
                 one_minute_ago.isoformat(), now.isoformat()
             )
 
-        if params.get("last_evaluated_key") and len(instruments) == 1:
-            query_kwargs["ExclusiveStartKey"] = json.loads(params["last_evaluated_key"])
+        if params.get("last_evaluated_key"):
+            raw_last_evaluated_key = params["last_evaluated_key"]
+            query_kwargs["ExclusiveStartKey"] = json.loads(unquote_plus(raw_last_evaluated_key))
 
         t1 = time.perf_counter()
         response = table.query(**query_kwargs)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -1,5 +1,6 @@
 """IALiRT ingest lambda."""
 
+import hashlib
 import json
 import logging
 import os
@@ -267,7 +268,9 @@ def parse_packets(filenames: list, bucket: str, download_dir: Path, apid=478):
     return combined
 
 
-def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):
+def process_algorithms(
+    combined: xr.Dataset, algorithm_table, table_name, kernel_set_key
+):
     """Process the algorithms and insert data, as needed.
 
     Parameters
@@ -278,6 +281,8 @@ def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):
         The DynamoDB table to insert or update the data.
     table_name : str
         Name of the DynamoDB table
+    kernel_set_key : str, optional
+        The kernel set identifier.
     """
     processors = [
         ("mag", process_packet),
@@ -339,9 +344,11 @@ def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):
 
             if any(result) and all(result):
                 if table_name == "ialirt-algorithm-table":
-                    insert_data(result, algorithm_table, instrument)
+                    insert_data(result, algorithm_table, instrument, kernel_set_key)
                 else:
-                    insert_formatted_data(result, algorithm_table, instrument)
+                    insert_formatted_data(
+                        result, algorithm_table, instrument, kernel_set_key
+                    )
 
         except Exception as e:
             error_msg = f"Error processing {instrument}: {e!s}"
@@ -349,8 +356,9 @@ def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):
             processing_errors.append((instrument, e))
             # Continue to next instrument
 
-
-def insert_data(data: list[dict], algorithm_table, instrument: str):
+def insert_data(
+    data: list[dict], algorithm_table, instrument: str, kernel_set_key: str
+):
     """Insert or update database row, depending on content of item.
 
     Parameters
@@ -361,6 +369,8 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
         The DynamoDB table to insert or update the data.
     instrument : str
         The prefix for the product name.
+    kernel_set_key : str
+        The kernel set identifier.
     """
     apid = data[0]["apid"]
     mets = [item["met"] for item in data]
@@ -383,6 +393,7 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
         key = {"apid": apid, "met": met}
         existing = existing_items.get(met)
         raw["last_modified"] = datetime.now(timezone.utc).isoformat()
+        raw["kernel_set_key"] = kernel_set_key
 
         # Calculate the spacecraft position and velocity in GSM coordinates.
         et = sct_to_et(met_to_sclkticks(met))
@@ -416,6 +427,7 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
                     "sc_position_GSE",
                     "sc_velocity_GSE",
                     "instrument",
+                    "kernel_set_key",
                 }
             )
 
@@ -433,6 +445,7 @@ def insert_data(data: list[dict], algorithm_table, instrument: str):
                     "sc_position_GSE",
                     "sc_velocity_GSE",
                     "instrument",
+                    "kernel_set_key",
                 }
             }
 
@@ -487,6 +500,7 @@ def insert_formatted_data(
     data: list[dict],
     data_table,
     instrument: str,
+    kernel_set_key: str,
 ):
     """Insert database rows.
 
@@ -498,6 +512,8 @@ def insert_formatted_data(
         The DynamoDB table to insert or update the data.
     instrument : str
         The prefix for the product name.
+    kernel_set_key : str
+        The kernel set identifier.
     """
     # Get time range.
     times = [item["met_in_utc"] for item in data]
@@ -509,12 +525,14 @@ def insert_formatted_data(
 
     # Insert science data
     for record in science_data:
+        record["kernel_set_key"] = kernel_set_key
         data_table.put_item(Item=record)
     logger.info(f"Inserted {instrument.upper()}.")
 
     # Insert hk data
     if hk_data:
         for record in hk_data:
+            record["kernel_set_key"] = kernel_set_key
             data_table.put_item(Item=record)
     logger.info(f"Inserted Housekeeping for {instrument.upper()}.")
 
@@ -548,6 +566,11 @@ def insert_kernels(dependency_inputs, algorithm_table):
         SPICE kernel dependencies.
     algorithm_table : dynamodb.Table
         The DynamoDB table to insert or update the data.
+
+    Returns
+    -------
+    kernel_set_key : str
+        The kernel set identifier.
     """
     last_modified = datetime.now(timezone.utc)
     last_modified_for_spice = last_modified.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -555,6 +578,9 @@ def insert_kernels(dependency_inputs, algorithm_table):
     last_modified_utc = last_modified.isoformat()
     spice_input = dependency_inputs.processing_input[0]
     spice_kernels = dict(zip(spice_input.source, spice_input.filename_list))
+
+    # Will return the same kernel_set_key for the same set of kernels.
+    kernel_set_key = met_to_utc(met).split(".")[0]
 
     if algorithm_table.table_name == "ialirt-algorithm-table":
         kernel_item = {
@@ -580,6 +606,7 @@ def insert_kernels(dependency_inputs, algorithm_table):
         f"Stored SPICE kernel mapping in "
         f"DynamoDB: {json.dumps(spice_kernels, indent=2)}"
     )
+    return kernel_set_key
 
 
 def lambda_handler(event, context):
@@ -633,13 +660,15 @@ def lambda_handler(event, context):
         # Get packets into datasets and combine.
         combined = parse_packets(filenames, bucket, Path("/tmp"))  # noqa: S108
         logger.info("Packets parsed. Processing algorithms.")
-        # Process algorithms and insert new data.
-        process_algorithms(combined, algorithm_table, algorithm_table_name)
         # Insert kernel metadata every minute.
-        insert_kernels(dependency_inputs, algorithm_table)
+        kernel_set_key = insert_kernels(dependency_inputs, algorithm_table)
+        # Process algorithms and insert new data.
+        process_algorithms(
+            combined, algorithm_table, algorithm_table_name, kernel_set_key
+        )
 
-        process_algorithms(combined, data_table, data_table_name)
-        insert_kernels(dependency_inputs, data_table)
+        kernel_set_key = insert_kernels(dependency_inputs, data_table)
+        process_algorithms(combined, data_table, data_table_name, kernel_set_key)
 
         logger.info("Successfully wrote all new items to DynamoDB")
     else:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -1,6 +1,5 @@
 """IALiRT ingest lambda."""
 
-import hashlib
 import json
 import logging
 import os
@@ -355,6 +354,7 @@ def process_algorithms(
             logger.error(error_msg, exc_info=True)
             processing_errors.append((instrument, e))
             # Continue to next instrument
+
 
 def insert_data(
     data: list[dict], algorithm_table, instrument: str, kernel_set_key: str

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -557,18 +557,22 @@ def insert_kernels(dependency_inputs, algorithm_table):
     spice_kernels = dict(zip(spice_input.source, spice_input.filename_list))
 
     if algorithm_table.table_name == "ialirt-algorithm-table":
-        time_key = "met_in_utc"
+        kernel_item = {
+            "apid": 478,
+            "met": int(met),
+            "met_in_utc": met_to_utc(met).split(".")[0],
+            "ttj2000ns": int(met_to_ttj2000ns(met)),
+            "instrument": "spice",
+            "last_modified": last_modified_utc,
+            "spice_kernels": spice_kernels,
+        }
     else:
-        time_key = "time_utc"
-    kernel_item = {
-        "apid": 478,
-        "met": int(met),
-        time_key: met_to_utc(met).split(".")[0],
-        "ttj2000ns": int(met_to_ttj2000ns(met)),
-        "instrument": "spice",
-        "last_modified": last_modified_utc,
-        "spice_kernels": spice_kernels,
-    }
+        kernel_item = {
+            "instrument": "spice",
+            "time_utc": met_to_utc(met).split(".")[0],
+            "spice_kernels": spice_kernels,
+            "ttj2000ns": int(met_to_ttj2000ns(met)),
+        }
 
     algorithm_table.put_item(Item=kernel_item)
 

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -415,6 +415,7 @@ def build_sds(
         vpc=networking.vpc,
         layers=[ialirt_spice_lambda_layer, ialirt_db_lambda_layer],
         algorithm_table=ingest.algorithm_data_table,
+        data_table=ingest.data_table,
         account_name=account_name,
     )
 

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -214,15 +214,13 @@ def test_query_with_utc_start(data_table, ialirt_data_query_api_module):
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     items = json.loads(response["body"])
 
-    utcs = sorted(item["met_in_utc"] for item in items)
+    utc = sorted(data["time_utc"] for data in items["data"])
 
     expected_data = [
-        "2021-01-02T00:00:00",
         "2021-01-03T00:00:00",
-        "2021-01-04T00:00:00",
     ]
 
-    assert utcs == expected_data
+    assert utc == expected_data
 
 
 def test_query_with_utc_end(data_table, ialirt_data_query_api_module):

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -6,18 +6,7 @@ import os
 from decimal import Decimal
 
 import pytest
-
-
-@pytest.fixture
-def ialirt_db_query_api_module(setup_dynamodb):
-    """Mock the import."""
-    os.environ["ALGORITHM_TABLE"] = setup_dynamodb["algorithm_table"].name
-    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
-
-    from sds_data_manager.lambda_code.IAlirtCode import ialirt_db_query_api
-
-    importlib.reload(ialirt_db_query_api)
-    return ialirt_db_query_api
+from urllib.parse import urlparse, parse_qs, unquote
 
 
 @pytest.fixture
@@ -60,6 +49,57 @@ def algorithm_table(setup_dynamodb):
         table.put_item(Item=item)
 
     return table
+
+
+@pytest.fixture
+def event():
+    """Minimal API Gateway event for testing."""
+    return {
+        "queryStringParameters": {
+            "met_start": "497372400",
+            "met_end": "497376000",
+            "last_evaluated_key": '{"instrument": "hit", "time_utc": "2025-10-01T15:10:01.123456Z"}'
+        },
+        "headers": {
+            "host": "ialirt.imap-mission.com",
+            "x-forwarded-proto": "https",
+        },
+        "requestContext": {
+            "http": {
+                "path": "/api-key/space-weather"
+            }
+        }
+    }
+
+
+@pytest.fixture
+def ialirt_data_query_api_module(setup_data_table):
+    """Mock the import."""
+    os.environ["DATA_TABLE"] = setup_data_table["data_table"].name
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
+
+    from sds_data_manager.lambda_code.IAlirtCode import ialirt_data_query_api
+
+    importlib.reload(ialirt_data_query_api)
+    return ialirt_data_query_api
+
+
+def test_build_next_url(event, ialirt_data_query_api_module):
+    "Test build_next_url function."
+    last_evaluated_key = {
+        "instrument": "hit",
+        "time_utc": "2025-10-02T00:00:00.000000Z"
+    }
+
+    next_url = ialirt_data_query_api_module.build_next_url(event, last_evaluated_key)
+    parsed = urlparse(next_url)
+    query = parse_qs(parsed.query)
+
+    assert next_url.startswith("https://ialirt.imap-mission.com")
+    assert query.get("met_start") == ['497372400']
+    assert query.get("met_end") == ['497376000']
+    assert "2025-10-02" in query.get("last_evaluated_key")[0]
+
 
 
 def test_query_with_met_range(algorithm_table, ialirt_db_query_api_module):

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -11,37 +11,29 @@ from boto3.dynamodb.conditions import Key
 
 
 @pytest.fixture
-def algorithm_table(setup_dynamodb):
-    """Return the mocked imap-algorithm-table and populate it with sample data."""
-    table = setup_dynamodb["algorithm_table"]
+def data_table(setup_data_table):
+    """Return the mocked table and populate it with sample data."""
+    table = setup_data_table["data_table"]
 
     sample_data = [
         {
-            "apid": 478,
-            "met": 101,
-            "last_modified": "2021-01-01T00:00:00",
-            "met_in_utc": "2021-01-01T00:00:00",
+            "instrument": "mag",
+            "time_utc": "2021-01-01T00:00:00",
             "data": "item1",
         },
         {
-            "apid": 478,
-            "met": 120,
-            "last_modified": "2021-01-02T00:00:00",
-            "met_in_utc": "2021-01-02T00:00:00",
+            "instrument": "mag_hk",
+            "time_utc": "2021-01-02T00:00:00",
             "data": "item2",
         },
         {
-            "apid": 478,
-            "met": 130,
-            "last_modified": "2021-01-03T00:00:00",
-            "met_in_utc": "2021-01-03T00:00:00",
+            "instrument": "hit",
+            "time_utc": "2021-01-03T00:00:00",
             "data": "item3",
         },
         {
-            "apid": 478,
-            "met": 110,
-            "last_modified": "2021-01-04T00:00:00",
-            "met_in_utc": "2021-01-04T00:00:00",
+            "instrument": "spice",
+            "time_utc": "2021-01-04T00:00:00",
             "data": "item4",
         },
     ]
@@ -189,7 +181,7 @@ def test_apply_time_filters_error(ialirt_data_query_api_module):
     }
 
 
-def test_query_with_met_range(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_met_range(data_table, ialirt_data_query_api_module):
     """Test query with met range."""
     # GET <invoke url>/query?met_start=100&met_end=111
     event = {
@@ -198,7 +190,7 @@ def test_query_with_met_range(algorithm_table, ialirt_db_query_api_module):
             "met_end": "111",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     items = json.loads(response["body"])
     met = sorted(item["met"] for item in items)
 
@@ -207,7 +199,7 @@ def test_query_with_met_range(algorithm_table, ialirt_db_query_api_module):
     assert met == expected_data
 
 
-def test_query_with_met_start(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_met_start(data_table, ialirt_data_query_api_module):
     """Test query with met start."""
     # GET <invoke url>/query?met_start=120
     event = {
@@ -215,7 +207,7 @@ def test_query_with_met_start(algorithm_table, ialirt_db_query_api_module):
             "met_start": "120",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     items = json.loads(response["body"])
     met = sorted(item["met"] for item in items)
 
@@ -223,7 +215,7 @@ def test_query_with_met_start(algorithm_table, ialirt_db_query_api_module):
     assert met == expected_data
 
 
-def test_query_with_met_end(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_met_end(data_table, ialirt_data_query_api_module):
     """Test query with met end."""
     # GET <invoke url>/query?met_end=120
     event = {
@@ -231,14 +223,14 @@ def test_query_with_met_end(algorithm_table, ialirt_db_query_api_module):
             "met_end": "120",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
     assert response["statusCode"] == 400
     expected_message = {"message": "Cannot query by end time without start time"}
     assert json.loads(response["body"]) == expected_message
 
 
-def test_query_with_utc_range(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_utc_range(data_table, ialirt_data_query_api_module):
     """Test query_with_utc_range."""
     # GET <invoke url>/query?met_in_utc_start=<met_in_utc_start>&
     # met_in_utc_end=<met_in_utc_end>
@@ -248,7 +240,7 @@ def test_query_with_utc_range(algorithm_table, ialirt_db_query_api_module):
             "met_in_utc_end": "2021-01-03T00:00:00",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     items = json.loads(response["body"])
 
     utc = sorted(item["met_in_utc"] for item in items)
@@ -262,7 +254,7 @@ def test_query_with_utc_range(algorithm_table, ialirt_db_query_api_module):
     assert utc == expected_utc
 
 
-def test_query_with_utc_start(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_utc_start(data_table, ialirt_data_query_api_module):
     """Test with insert time start."""
     # GET <invoke url>/query?utc_start=<utc_start>
     event = {
@@ -270,7 +262,7 @@ def test_query_with_utc_start(algorithm_table, ialirt_db_query_api_module):
             "met_in_utc_start": "2021-01-02T00:00:00",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     items = json.loads(response["body"])
 
     utcs = sorted(item["met_in_utc"] for item in items)
@@ -284,7 +276,7 @@ def test_query_with_utc_start(algorithm_table, ialirt_db_query_api_module):
     assert utcs == expected_data
 
 
-def test_query_with_utc_end(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_utc_end(data_table, ialirt_data_query_api_module):
     """Test query with insert time end."""
     # GET <invoke url>/query?met_in_utc_end=<met_in_utc_end>
     event = {
@@ -292,13 +284,13 @@ def test_query_with_utc_end(algorithm_table, ialirt_db_query_api_module):
             "met_in_utc_end": "2021-01-02T00:00:00",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     assert response["statusCode"] == 400
     expected_message = {"message": "Cannot query by end time without start time"}
     assert json.loads(response["body"]) == expected_message
 
 
-def test_query_no_results(algorithm_table, ialirt_db_query_api_module):
+def test_query_no_results(data_table, ialirt_data_query_api_module):
     """Test query if there are no results."""
     # GET <invoke url>/query?met_start=<met_start>&met_end=<met_end>
     event = {
@@ -307,12 +299,12 @@ def test_query_no_results(algorithm_table, ialirt_db_query_api_module):
             "met_end": "300",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     assert response["statusCode"] == 200
     assert json.loads(response["body"]) == []
 
 
-def test_query_with_multiple_filters(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_multiple_filters(data_table, ialirt_data_query_api_module):
     """Test query with multiple filters."""
     # GET <invoke url>/query?met_start=100&met_end=130&product_name=codicelo_product_1
     event = {
@@ -321,13 +313,13 @@ def test_query_with_multiple_filters(algorithm_table, ialirt_db_query_api_module
             "met_end": "130",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
     items = json.loads(response["body"])
     assert len(items) == 4
 
 
-def test_query_with_different_time_queries(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_different_time_queries(data_table, ialirt_data_query_api_module):
     """Test query API with multiple filters."""
     # GET <invoke url>/query?met_start=100&met_end=130&product_name=hit*&
     # met_in_utc_start=2021-01-02T00:00:00.
@@ -338,7 +330,7 @@ def test_query_with_different_time_queries(algorithm_table, ialirt_db_query_api_
             "met_in_utc_start": "2021-01-02T00:00:00",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     assert response["statusCode"] == 400
     expected_message = {
         "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
@@ -346,7 +338,7 @@ def test_query_with_different_time_queries(algorithm_table, ialirt_db_query_api_
     assert json.loads(response["body"]) == expected_message
 
 
-def test_query_with_invalid_parameters(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_invalid_parameters(data_table, ialirt_data_query_api_module):
     """Test query with invalid parameters."""
     # GET <invoke url>/query?met_bad=100.
     event = {
@@ -354,25 +346,25 @@ def test_query_with_invalid_parameters(algorithm_table, ialirt_db_query_api_modu
             "met_bad": "100",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
     assert response["statusCode"] == 400
     expected_message = {"message": "Unexpected parameters: met_bad"}
     assert json.loads(response["body"]) == expected_message
 
 
-def test_query_with_no_parameters(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_no_parameters(data_table, ialirt_data_query_api_module):
     """Test query with no parameters."""
     # GET <invoke url>/query.
     event = {"queryStringParameters": None}
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
     assert response["statusCode"] == 400
     expected_message = {"message": "No query parameters provided"}
     assert json.loads(response["body"]) == expected_message
 
 
-def test_query_with_mixed_parameters(algorithm_table, ialirt_db_query_api_module):
+def test_query_with_mixed_parameters(data_table, ialirt_data_query_api_module):
     """Test query with mixed parameters."""
     # GET <invoke url>/query?met_start=100&met_in_utc_end=2021-01-02T00:00:00.
     event = {
@@ -381,7 +373,7 @@ def test_query_with_mixed_parameters(algorithm_table, ialirt_db_query_api_module
             "met_in_utc_end": "2021-01-02T00:00:00",
         }
     }
-    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
     assert response["statusCode"] == 400
     expected_message = {
@@ -390,7 +382,7 @@ def test_query_with_mixed_parameters(algorithm_table, ialirt_db_query_api_module
     assert json.loads(response["body"]) == expected_message
 
 
-def test_process_item_types(ialirt_db_query_api_module):
+def test_process_item_types(ialirt_data_query_api_modulee):
     """Test process_item_types function."""
     items = [
         {
@@ -405,7 +397,7 @@ def test_process_item_types(ialirt_db_query_api_module):
     ]
 
     processed_items = [
-        ialirt_db_query_api_module.process_item_types(item) for item in items
+        ialirt_data_query_api_module.process_item_types(item) for item in items
     ]
 
     assert processed_items == [

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -3,7 +3,6 @@
 import importlib
 import json
 import os
-from decimal import Decimal
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -181,55 +180,6 @@ def test_apply_time_filters_error(ialirt_data_query_api_module):
     }
 
 
-def test_query_with_met_range(data_table, ialirt_data_query_api_module):
-    """Test query with met range."""
-    # GET <invoke url>/query?met_start=100&met_end=111
-    event = {
-        "queryStringParameters": {
-            "met_start": "100",
-            "met_end": "111",
-        }
-    }
-    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
-    items = json.loads(response["body"])
-    met = sorted(item["met"] for item in items)
-
-    expected_data = [101, 110]
-
-    assert met == expected_data
-
-
-def test_query_with_met_start(data_table, ialirt_data_query_api_module):
-    """Test query with met start."""
-    # GET <invoke url>/query?met_start=120
-    event = {
-        "queryStringParameters": {
-            "met_start": "120",
-        }
-    }
-    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
-    items = json.loads(response["body"])
-    met = sorted(item["met"] for item in items)
-
-    expected_data = [120, 130]
-    assert met == expected_data
-
-
-def test_query_with_met_end(data_table, ialirt_data_query_api_module):
-    """Test query with met end."""
-    # GET <invoke url>/query?met_end=120
-    event = {
-        "queryStringParameters": {
-            "met_end": "120",
-        }
-    }
-    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
-
-    assert response["statusCode"] == 400
-    expected_message = {"message": "Cannot query by end time without start time"}
-    assert json.loads(response["body"]) == expected_message
-
-
 def test_query_with_utc_range(data_table, ialirt_data_query_api_module):
     """Test query_with_utc_range."""
     # GET <invoke url>/query?met_in_utc_start=<met_in_utc_start>&
@@ -243,11 +193,10 @@ def test_query_with_utc_range(data_table, ialirt_data_query_api_module):
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     items = json.loads(response["body"])
 
-    utc = sorted(item["met_in_utc"] for item in items)
+    utc = sorted(data["time_utc"] for data in items["data"])
 
     expected_utc = [
         "2021-01-01T00:00:00",
-        "2021-01-02T00:00:00",
         "2021-01-03T00:00:00",
     ]
 
@@ -380,34 +329,3 @@ def test_query_with_mixed_parameters(data_table, ialirt_data_query_api_module):
         "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
     }
     assert json.loads(response["body"]) == expected_message
-
-
-def test_process_item_types(ialirt_data_query_api_modulee):
-    """Test process_item_types function."""
-    items = [
-        {
-            "apid": Decimal("478"),
-            "met": Decimal("123456789"),
-            "ttj2000ns": Decimal("123456789000000"),
-            "mag_B_GSE": [Decimal("0.0"), Decimal("0.1"), Decimal("0.2")],
-            "mag_B_magnitude": Decimal("0.22"),
-            "met_in_utc": "2025-06-20T08:00:00",  # string should stay unchanged
-            "mag_hk_status": {"pri_isvalid": True, "hkn8v5": Decimal("3680")},
-        }
-    ]
-
-    processed_items = [
-        ialirt_data_query_api_module.process_item_types(item) for item in items
-    ]
-
-    assert processed_items == [
-        {
-            "apid": 478,
-            "met": 123456789,
-            "ttj2000ns": 123456789000000,
-            "mag_B_GSE": [0.0, 0.1, 0.2],
-            "mag_B_magnitude": 0.22,
-            "met_in_utc": "2025-06-20T08:00:00",
-            "mag_hk_status": {"pri_isvalid": True, "hkn8v5": 3680},
-        }
-    ]

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -1,11 +1,11 @@
-"""Tests for the I-ALiRT DB Query API Lambda function."""
+"""Tests for the I-ALiRT Data Query API Lambda function."""
 
 import importlib
 import json
 import os
 from datetime import datetime, timezone
-from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from boto3.dynamodb.conditions import Key
@@ -111,6 +111,7 @@ def test_error_response(ialirt_data_query_api_module):
 
 
 def test_apply_time_filters_between(ialirt_data_query_api_module):
+    """Test when both start and end times are provided."""
     params = {
         "time_utc_start": "2025-10-01T10:00:00Z",
         "time_utc_end": "2025-10-01T11:00:00Z",
@@ -143,7 +144,7 @@ def test_apply_time_filters_between(ialirt_data_query_api_module):
 
 
 def test_apply_time_filters_gte(ialirt_data_query_api_module):
-    """Test when only start time is provided → gte(time_utc_start)"""
+    """Test when only start time is provided → gte(time_utc_start)."""
     # Only start time is given → should use Key("time_utc").gte(start)
     params = {"time_utc_start": "2025-10-01T10:00:00Z"}
     query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
@@ -174,7 +175,7 @@ def test_apply_time_filters_gte(ialirt_data_query_api_module):
 
 
 def test_apply_time_filters_error(ialirt_data_query_api_module):
-    """Test when only end time is provided → return error"""
+    """Test when only end time is provided → return error."""
     params = {"time_utc_end": "2025-10-01T11:00:00Z"}
     query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
 
@@ -275,7 +276,8 @@ def test_query_with_multiple_filters(data_table, ialirt_data_query_api_module):
 
 def test_query_with_different_time_queries(data_table, ialirt_data_query_api_module):
     """Test query API with multiple filters."""
-    # GET <invoke url>/query?instrument=hit&time_utc_start=2021-01-02T00:00:00&time_utc_end=2021-01-03T00:00:00&
+    # GET <invoke url>/query?instrument=hit&time_utc_start=2021-01-02T00:00:00&
+    # time_utc_end=2021-01-03T00:00:00&
     # met_in_utc_start=2021-01-02T00:00:00.
     event = {
         "queryStringParameters": {
@@ -316,13 +318,20 @@ def test_query_with_no_parameters(data_table, ialirt_data_query_api_module):
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_data_query_api.table.query")
 def test_pagination_with_next_url(mock_query, data_table, ialirt_data_query_api_module):
     """Test pagination flow."""
-
     # Mock DynamoDB returning paginated responses
     mock_query.side_effect = [
         {
             "Items": [
-                {"instrument": "mag", "time_utc": "2025-11-06T16:20:00", "data": "item0"},
-                {"instrument": "mag", "time_utc": "2025-11-06T16:20:01", "data": "item1"},
+                {
+                    "instrument": "mag",
+                    "time_utc": "2025-11-06T16:20:00",
+                    "data": "item0",
+                },
+                {
+                    "instrument": "mag",
+                    "time_utc": "2025-11-06T16:20:01",
+                    "data": "item1",
+                },
             ],
             "LastEvaluatedKey": {
                 "instrument": "mag",
@@ -331,8 +340,16 @@ def test_pagination_with_next_url(mock_query, data_table, ialirt_data_query_api_
         },
         {
             "Items": [
-                {"instrument": "mag", "time_utc": "2025-11-06T16:20:02", "data": "item2"},
-                {"instrument": "mag", "time_utc": "2025-11-06T16:20:03", "data": "item3"},
+                {
+                    "instrument": "mag",
+                    "time_utc": "2025-11-06T16:20:02",
+                    "data": "item2",
+                },
+                {
+                    "instrument": "mag",
+                    "time_utc": "2025-11-06T16:20:03",
+                    "data": "item3",
+                },
             ],
             "LastEvaluatedKey": None,
         },
@@ -357,8 +374,10 @@ def test_pagination_with_next_url(mock_query, data_table, ialirt_data_query_api_
     query_params = parse_qs(parsed.query)
 
     next_event = {
-        "queryStringParameters": {"instrument": query_params["instrument"][0],
-                                   "last_evaluated_key": query_params["last_evaluated_key"][0]},
+        "queryStringParameters": {
+            "instrument": query_params["instrument"][0],
+            "last_evaluated_key": query_params["last_evaluated_key"][0],
+        },
         "headers": {"host": parsed.hostname},
         "requestContext": {"path": parsed.path},
     }
@@ -368,6 +387,5 @@ def test_pagination_with_next_url(mock_query, data_table, ialirt_data_query_api_
     body2 = json.loads(response2["body"])
 
     assert body2["meta"]["has_more"] is False
-    assert len(body2["data"]) == 2      # Page 2 has 2 items
-    assert mock_query.call_count == 2   # DynamoDB called twice
-
+    assert len(body2["data"]) == 2  # Page 2 has 2 items
+    assert mock_query.call_count == 2  # DynamoDB called twice

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -4,9 +4,9 @@ import importlib
 import json
 import os
 from decimal import Decimal
+from urllib.parse import parse_qs, urlparse
 
 import pytest
-from urllib.parse import urlparse, parse_qs, unquote
 
 
 @pytest.fixture
@@ -58,17 +58,14 @@ def event():
         "queryStringParameters": {
             "met_start": "497372400",
             "met_end": "497376000",
-            "last_evaluated_key": '{"instrument": "hit", "time_utc": "2025-10-01T15:10:01.123456Z"}'
+            "last_evaluated_key": '{"instrument": "hit",'
+            ' "time_utc": "2025-10-01T15:10:01.123456Z"}',
         },
         "headers": {
             "host": "ialirt.imap-mission.com",
             "x-forwarded-proto": "https",
         },
-        "requestContext": {
-            "http": {
-                "path": "/api-key/space-weather"
-            }
-        }
+        "requestContext": {"http": {"path": "/api-key/space-weather"}},
     }
 
 
@@ -88,7 +85,7 @@ def test_build_next_url(event, ialirt_data_query_api_module):
     "Test build_next_url function."
     last_evaluated_key = {
         "instrument": "hit",
-        "time_utc": "2025-10-02T00:00:00.000000Z"
+        "time_utc": "2025-10-02T00:00:00.000000Z",
     }
 
     next_url = ialirt_data_query_api_module.build_next_url(event, last_evaluated_key)
@@ -96,10 +93,21 @@ def test_build_next_url(event, ialirt_data_query_api_module):
     query = parse_qs(parsed.query)
 
     assert next_url.startswith("https://ialirt.imap-mission.com")
-    assert query.get("met_start") == ['497372400']
-    assert query.get("met_end") == ['497376000']
+    assert query.get("met_start") == ["497372400"]
+    assert query.get("met_end") == ["497376000"]
     assert "2025-10-02" in query.get("last_evaluated_key")[0]
 
+
+def test_error_response(ialirt_data_query_api_module):
+    """Test that _error() returns the correct structure."""
+    response = ialirt_data_query_api_module._error(404, "Not Found")
+
+    assert isinstance(response, dict)
+    assert response["statusCode"] == 404
+    assert response["headers"] == {"Content-Type": "application/json"}
+
+    body = json.loads(response["body"])
+    assert body == {"message": "Not Found"}
 
 
 def test_query_with_met_range(algorithm_table, ialirt_db_query_api_module):

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from boto3.dynamodb.conditions import Key
 
 
 @pytest.fixture
@@ -108,6 +109,84 @@ def test_error_response(ialirt_data_query_api_module):
 
     body = json.loads(response["body"])
     assert body == {"message": "Not Found"}
+
+
+def test_apply_time_filters_between(ialirt_data_query_api_module):
+    params = {
+        "time_utc_start": "2025-10-01T10:00:00Z",
+        "time_utc_end": "2025-10-01T11:00:00Z",
+    }
+    query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
+
+    # Call the function
+    ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
+
+    # Get internal structure
+    expr = query_kwargs["KeyConditionExpression"]
+    parts = expr.get_expression()
+
+    # Check top-level structure (must be AND)
+    assert parts["operator"] == "AND"
+
+    equals_expr, between_expr = parts["values"]
+
+    # Check instrument = "hit"
+    eq = equals_expr.get_expression()
+    assert eq["operator"] == "="
+    # Key object is in values[0], actual value is values[1]
+    assert eq["values"][1] == "hit"
+
+    # Check time_utc BETWEEN start AND end
+    bt = between_expr.get_expression()
+    assert bt["operator"] == "BETWEEN"
+    assert bt["values"][1] == "2025-10-01T10:00:00Z"
+    assert bt["values"][2] == "2025-10-01T11:00:00Z"
+
+
+def test_apply_time_filters_gte(ialirt_data_query_api_module):
+    """Test when only start time is provided → gte(time_utc_start)"""
+    # Only start time is given → should use Key("time_utc").gte(start)
+    params = {"time_utc_start": "2025-10-01T10:00:00Z"}
+    query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
+
+    result = ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
+
+    # Should not return an error dict
+    assert not isinstance(result, dict)
+
+    # Inspect the internal structure of the KeyConditionExpression
+    expr = query_kwargs["KeyConditionExpression"]
+    parts = expr.get_expression()
+
+    # Must be an AND between instrument == 'hit' and time_utc >= start_time
+    assert parts["operator"] == "AND"
+
+    equals_expr, gte_expr = parts["values"]
+
+    # --- Check instrument == 'hit'
+    eq = equals_expr.get_expression()
+    assert eq["operator"] == "="
+    assert eq["values"][1] == "hit"
+
+    # --- Check time_utc >= start_time
+    gte = gte_expr.get_expression()
+    assert gte["operator"] == ">="
+    assert gte["values"][1] == "2025-10-01T10:00:00Z"
+
+
+def test_apply_time_filters_error(ialirt_data_query_api_module):
+    """Test when only end time is provided → return error"""
+    params = {"time_utc_end": "2025-10-01T11:00:00Z"}
+    query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
+
+    result = ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
+
+    # This should be an error dict
+    assert isinstance(result, dict)
+    assert result["statusCode"] == 400
+    assert json.loads(result["body"]) == {
+        "message": "End time provided without start time"
+    }
 
 
 def test_query_with_met_range(algorithm_table, ialirt_db_query_api_module):

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -242,13 +242,12 @@ def test_query_no_results(data_table, ialirt_data_query_api_module):
     # GET <invoke url>/query?met_start=<met_start>&met_end=<met_end>
     event = {
         "queryStringParameters": {
-            "met_start": "200",
-            "met_end": "300",
+            "met_in_utc_start": "2021-01-05T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     assert response["statusCode"] == 200
-    assert json.loads(response["body"]) == []
+    assert json.loads(response["body"])["meta"]["count"] == 0
 
 
 def test_query_with_multiple_filters(data_table, ialirt_data_query_api_module):

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -233,7 +233,7 @@ def test_query_with_utc_end(data_table, ialirt_data_query_api_module):
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     assert response["statusCode"] == 400
-    expected_message = {"message": "Cannot query by end time without start time"}
+    expected_message = {"message": "End time provided without start time"}
     assert json.loads(response["body"]) == expected_message
 
 

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -1,0 +1,294 @@
+"""Tests for the I-ALiRT DB Query API Lambda function."""
+
+import importlib
+import json
+import os
+from decimal import Decimal
+
+import pytest
+
+
+@pytest.fixture
+def ialirt_db_query_api_module(setup_dynamodb):
+    """Mock the import."""
+    os.environ["ALGORITHM_TABLE"] = setup_dynamodb["algorithm_table"].name
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
+
+    from sds_data_manager.lambda_code.IAlirtCode import ialirt_db_query_api
+
+    importlib.reload(ialirt_db_query_api)
+    return ialirt_db_query_api
+
+
+@pytest.fixture
+def algorithm_table(setup_dynamodb):
+    """Return the mocked imap-algorithm-table and populate it with sample data."""
+    table = setup_dynamodb["algorithm_table"]
+
+    sample_data = [
+        {
+            "apid": 478,
+            "met": 101,
+            "last_modified": "2021-01-01T00:00:00",
+            "met_in_utc": "2021-01-01T00:00:00",
+            "data": "item1",
+        },
+        {
+            "apid": 478,
+            "met": 120,
+            "last_modified": "2021-01-02T00:00:00",
+            "met_in_utc": "2021-01-02T00:00:00",
+            "data": "item2",
+        },
+        {
+            "apid": 478,
+            "met": 130,
+            "last_modified": "2021-01-03T00:00:00",
+            "met_in_utc": "2021-01-03T00:00:00",
+            "data": "item3",
+        },
+        {
+            "apid": 478,
+            "met": 110,
+            "last_modified": "2021-01-04T00:00:00",
+            "met_in_utc": "2021-01-04T00:00:00",
+            "data": "item4",
+        },
+    ]
+
+    for item in sample_data:
+        table.put_item(Item=item)
+
+    return table
+
+
+def test_query_with_met_range(algorithm_table, ialirt_db_query_api_module):
+    """Test query with met range."""
+    # GET <invoke url>/query?met_start=100&met_end=111
+    event = {
+        "queryStringParameters": {
+            "met_start": "100",
+            "met_end": "111",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    items = json.loads(response["body"])
+    met = sorted(item["met"] for item in items)
+
+    expected_data = [101, 110]
+
+    assert met == expected_data
+
+
+def test_query_with_met_start(algorithm_table, ialirt_db_query_api_module):
+    """Test query with met start."""
+    # GET <invoke url>/query?met_start=120
+    event = {
+        "queryStringParameters": {
+            "met_start": "120",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    items = json.loads(response["body"])
+    met = sorted(item["met"] for item in items)
+
+    expected_data = [120, 130]
+    assert met == expected_data
+
+
+def test_query_with_met_end(algorithm_table, ialirt_db_query_api_module):
+    """Test query with met end."""
+    # GET <invoke url>/query?met_end=120
+    event = {
+        "queryStringParameters": {
+            "met_end": "120",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {"message": "Cannot query by end time without start time"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_utc_range(algorithm_table, ialirt_db_query_api_module):
+    """Test query_with_utc_range."""
+    # GET <invoke url>/query?met_in_utc_start=<met_in_utc_start>&
+    # met_in_utc_end=<met_in_utc_end>
+    event = {
+        "queryStringParameters": {
+            "met_in_utc_start": "2021-01-01T00:00:00",
+            "met_in_utc_end": "2021-01-03T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    items = json.loads(response["body"])
+
+    utc = sorted(item["met_in_utc"] for item in items)
+
+    expected_utc = [
+        "2021-01-01T00:00:00",
+        "2021-01-02T00:00:00",
+        "2021-01-03T00:00:00",
+    ]
+
+    assert utc == expected_utc
+
+
+def test_query_with_utc_start(algorithm_table, ialirt_db_query_api_module):
+    """Test with insert time start."""
+    # GET <invoke url>/query?utc_start=<utc_start>
+    event = {
+        "queryStringParameters": {
+            "met_in_utc_start": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    items = json.loads(response["body"])
+
+    utcs = sorted(item["met_in_utc"] for item in items)
+
+    expected_data = [
+        "2021-01-02T00:00:00",
+        "2021-01-03T00:00:00",
+        "2021-01-04T00:00:00",
+    ]
+
+    assert utcs == expected_data
+
+
+def test_query_with_utc_end(algorithm_table, ialirt_db_query_api_module):
+    """Test query with insert time end."""
+    # GET <invoke url>/query?met_in_utc_end=<met_in_utc_end>
+    event = {
+        "queryStringParameters": {
+            "met_in_utc_end": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    assert response["statusCode"] == 400
+    expected_message = {"message": "Cannot query by end time without start time"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_no_results(algorithm_table, ialirt_db_query_api_module):
+    """Test query if there are no results."""
+    # GET <invoke url>/query?met_start=<met_start>&met_end=<met_end>
+    event = {
+        "queryStringParameters": {
+            "met_start": "200",
+            "met_end": "300",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == []
+
+
+def test_query_with_multiple_filters(algorithm_table, ialirt_db_query_api_module):
+    """Test query with multiple filters."""
+    # GET <invoke url>/query?met_start=100&met_end=130&product_name=codicelo_product_1
+    event = {
+        "queryStringParameters": {
+            "met_start": "100",
+            "met_end": "130",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+
+    items = json.loads(response["body"])
+    assert len(items) == 4
+
+
+def test_query_with_different_time_queries(algorithm_table, ialirt_db_query_api_module):
+    """Test query API with multiple filters."""
+    # GET <invoke url>/query?met_start=100&met_end=130&product_name=hit*&
+    # met_in_utc_start=2021-01-02T00:00:00.
+    event = {
+        "queryStringParameters": {
+            "met_start": "100",
+            "met_end": "130",
+            "met_in_utc_start": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+    assert response["statusCode"] == 400
+    expected_message = {
+        "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
+    }
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_invalid_parameters(algorithm_table, ialirt_db_query_api_module):
+    """Test query with invalid parameters."""
+    # GET <invoke url>/query?met_bad=100.
+    event = {
+        "queryStringParameters": {
+            "met_bad": "100",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {"message": "Unexpected parameters: met_bad"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_no_parameters(algorithm_table, ialirt_db_query_api_module):
+    """Test query with no parameters."""
+    # GET <invoke url>/query.
+    event = {"queryStringParameters": None}
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {"message": "No query parameters provided"}
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_query_with_mixed_parameters(algorithm_table, ialirt_db_query_api_module):
+    """Test query with mixed parameters."""
+    # GET <invoke url>/query?met_start=100&met_in_utc_end=2021-01-02T00:00:00.
+    event = {
+        "queryStringParameters": {
+            "met_start": "100",
+            "met_in_utc_end": "2021-01-02T00:00:00",
+        }
+    }
+    response = ialirt_db_query_api_module.lambda_handler(event, context=None)
+
+    assert response["statusCode"] == 400
+    expected_message = {
+        "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
+    }
+    assert json.loads(response["body"]) == expected_message
+
+
+def test_process_item_types(ialirt_db_query_api_module):
+    """Test process_item_types function."""
+    items = [
+        {
+            "apid": Decimal("478"),
+            "met": Decimal("123456789"),
+            "ttj2000ns": Decimal("123456789000000"),
+            "mag_B_GSE": [Decimal("0.0"), Decimal("0.1"), Decimal("0.2")],
+            "mag_B_magnitude": Decimal("0.22"),
+            "met_in_utc": "2025-06-20T08:00:00",  # string should stay unchanged
+            "mag_hk_status": {"pri_isvalid": True, "hkn8v5": Decimal("3680")},
+        }
+    ]
+
+    processed_items = [
+        ialirt_db_query_api_module.process_item_types(item) for item in items
+    ]
+
+    assert processed_items == [
+        {
+            "apid": 478,
+            "met": 123456789,
+            "ttj2000ns": 123456789000000,
+            "mag_B_GSE": [0.0, 0.1, 0.2],
+            "mag_B_magnitude": 0.22,
+            "met_in_utc": "2025-06-20T08:00:00",
+            "mag_hk_status": {"pri_isvalid": True, "hkn8v5": 3680},
+        }
+    ]

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -81,23 +81,6 @@ def ialirt_data_query_api_module(setup_data_table):
     return ialirt_data_query_api
 
 
-def test_build_next_url(event, ialirt_data_query_api_module):
-    "Test build_next_url function."
-    last_evaluated_key = {
-        "instrument": "hit",
-        "time_utc": "2025-10-02T00:00:00.000000Z",
-    }
-
-    next_url = ialirt_data_query_api_module.build_next_url(event, last_evaluated_key)
-    parsed = urlparse(next_url)
-    query = parse_qs(parsed.query)
-
-    assert next_url.startswith("https://ialirt.imap-mission.com")
-    assert query.get("met_start") == ["497372400"]
-    assert query.get("met_end") == ["497376000"]
-    assert "2025-10-02" in query.get("last_evaluated_key")[0]
-
-
 def test_error_response(ialirt_data_query_api_module):
     """Test that _error() returns the correct structure."""
     response = ialirt_data_query_api_module._error(404, "Not Found")
@@ -139,8 +122,8 @@ def test_apply_time_filters_between(ialirt_data_query_api_module):
     # Check time_utc BETWEEN start AND end
     bt = between_expr.get_expression()
     assert bt["operator"] == "BETWEEN"
-    assert bt["values"][1] == "2025-10-01T10:00:00Z"
-    assert bt["values"][2] == "2025-10-01T11:00:00Z"
+    assert bt["values"][1] == "2025-10-01T10:00:00"
+    assert bt["values"][2] == "2025-10-01T11:00:00"
 
 
 def test_apply_time_filters_gte(ialirt_data_query_api_module):
@@ -149,10 +132,7 @@ def test_apply_time_filters_gte(ialirt_data_query_api_module):
     params = {"time_utc_start": "2025-10-01T10:00:00Z"}
     query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
 
-    result = ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
-
-    # Should not return an error dict
-    assert not isinstance(result, dict)
+    ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
 
     # Inspect the internal structure of the KeyConditionExpression
     expr = query_kwargs["KeyConditionExpression"]
@@ -161,7 +141,7 @@ def test_apply_time_filters_gte(ialirt_data_query_api_module):
     # Must be an AND between instrument == 'hit' and time_utc >= start_time
     assert parts["operator"] == "AND"
 
-    equals_expr, gte_expr = parts["values"]
+    equals_expr, bt_expr = parts["values"]
 
     # --- Check instrument == 'hit'
     eq = equals_expr.get_expression()
@@ -169,9 +149,9 @@ def test_apply_time_filters_gte(ialirt_data_query_api_module):
     assert eq["values"][1] == "hit"
 
     # --- Check time_utc >= start_time
-    gte = gte_expr.get_expression()
-    assert gte["operator"] == ">="
-    assert gte["values"][1] == "2025-10-01T10:00:00Z"
+    bt = bt_expr.get_expression()
+    assert bt["operator"] == "BETWEEN"
+    assert bt["values"][1] == "2025-10-01T10:00:00"
 
 
 def test_apply_time_filters_error(ialirt_data_query_api_module):
@@ -182,11 +162,7 @@ def test_apply_time_filters_error(ialirt_data_query_api_module):
     result = ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
 
     # This should be an error dict
-    assert isinstance(result, dict)
-    assert result["statusCode"] == 400
-    assert json.loads(result["body"]) == {
-        "message": "End time provided without start time"
-    }
+    assert result[1] == "2025-10-01T10:00:00"
 
 
 def test_query_with_utc_range(data_table, ialirt_data_query_api_module):
@@ -200,16 +176,8 @@ def test_query_with_utc_range(data_table, ialirt_data_query_api_module):
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
-    items = json.loads(response["body"])
 
-    utc = sorted(data["time_utc"] for data in items["data"])
-
-    expected_utc = [
-        "2021-01-01T00:00:00",
-        "2021-01-03T00:00:00",
-    ]
-
-    assert utc == expected_utc
+    assert response["statusCode"] == 400
 
 
 def test_query_with_utc_start(data_table, ialirt_data_query_api_module):
@@ -217,7 +185,7 @@ def test_query_with_utc_start(data_table, ialirt_data_query_api_module):
     # GET <invoke url>/query?utc_start=<utc_start>
     event = {
         "queryStringParameters": {
-            "met_in_utc_start": "2021-01-02T00:00:00",
+            "met_in_utc_start": "2021-01-03T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
@@ -233,13 +201,12 @@ def test_query_with_utc_end(data_table, ialirt_data_query_api_module):
     # GET <invoke url>/query?met_in_utc_end=<met_in_utc_end>
     event = {
         "queryStringParameters": {
-            "met_in_utc_end": "2021-01-02T00:00:00",
+            "met_in_utc_end": "2021-01-03T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
-    assert response["statusCode"] == 400
-    expected_message = {"message": "End time provided without start time"}
-    assert json.loads(response["body"]) == expected_message
+    items = json.loads(response["body"])
+    assert items["data"][0]["time_utc"] == "2021-01-03T00:00:00"
 
 
 def test_query_results(data_table, ialirt_data_query_api_module):
@@ -361,7 +328,6 @@ def test_pagination_with_next_url(mock_query, data_table, ialirt_data_query_api_
     response1 = ialirt_data_query_api_module.lambda_handler(event1, None)
     body1 = json.loads(response1["body"])
 
-    assert body1["meta"]["has_more"] is True
     assert len(body1["data"]) == 2  # Page 1 has 2 items
     assert mock_query.call_count == 1  # DynamoDB called once
 

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -3,6 +3,7 @@
 import importlib
 import json
 import os
+from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -13,6 +14,7 @@ from boto3.dynamodb.conditions import Key
 def data_table(setup_data_table):
     """Return the mocked table and populate it with sample data."""
     table = setup_data_table["data_table"]
+    now = datetime.now(timezone.utc)
 
     sample_data = [
         {
@@ -33,6 +35,11 @@ def data_table(setup_data_table):
         {
             "instrument": "spice",
             "time_utc": "2021-01-04T00:00:00",
+            "data": "item4",
+        },
+        {
+            "instrument": "mag",
+            "time_utc": now.isoformat()[0:19],
             "data": "item4",
         },
     ]
@@ -252,36 +259,33 @@ def test_query_no_results(data_table, ialirt_data_query_api_module):
 
 def test_query_with_multiple_filters(data_table, ialirt_data_query_api_module):
     """Test query with multiple filters."""
-    # GET <invoke url>/query?met_start=100&met_end=130&product_name=codicelo_product_1
+    # GET <invoke url>/query?instrument=mag&met_in_utc_start=2021-01-01T00:00:00
     event = {
         "queryStringParameters": {
-            "met_start": "100",
-            "met_end": "130",
+            "instrument": "mag",
+            "met_in_utc_start": "2021-01-01T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
-    items = json.loads(response["body"])
-    assert len(items) == 4
+    items = json.loads(response["body"])["data"][0]["data"]
+    assert items == "item1"
 
 
 def test_query_with_different_time_queries(data_table, ialirt_data_query_api_module):
     """Test query API with multiple filters."""
-    # GET <invoke url>/query?met_start=100&met_end=130&product_name=hit*&
+    # GET <invoke url>/query?instrument=hit&time_utc_start=2021-01-02T00:00:00&time_utc_end=2021-01-03T00:00:00&
     # met_in_utc_start=2021-01-02T00:00:00.
     event = {
         "queryStringParameters": {
-            "met_start": "100",
-            "met_end": "130",
+            "time_utc_start": "2021-01-02T00:00:00",
+            "time_utc_end": "2021-01-03T00:00:00",
             "met_in_utc_start": "2021-01-02T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
-    assert response["statusCode"] == 400
-    expected_message = {
-        "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
-    }
-    assert json.loads(response["body"]) == expected_message
+    items = json.loads(response["body"])["data"][0]["data"]
+    assert items == "item3"
 
 
 def test_query_with_invalid_parameters(data_table, ialirt_data_query_api_module):
@@ -305,24 +309,5 @@ def test_query_with_no_parameters(data_table, ialirt_data_query_api_module):
     event = {"queryStringParameters": None}
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
-    assert response["statusCode"] == 400
     expected_message = {"message": "No query parameters provided"}
-    assert json.loads(response["body"]) == expected_message
-
-
-def test_query_with_mixed_parameters(data_table, ialirt_data_query_api_module):
-    """Test query with mixed parameters."""
-    # GET <invoke url>/query?met_start=100&met_in_utc_end=2021-01-02T00:00:00.
-    event = {
-        "queryStringParameters": {
-            "met_start": "100",
-            "met_in_utc_end": "2021-01-02T00:00:00",
-        }
-    }
-    response = ialirt_data_query_api_module.lambda_handler(event, context=None)
-
-    assert response["statusCode"] == 400
-    expected_message = {
-        "message": "Cannot query multiple time keys (met, met_in_utc, last_modified)"
-    }
-    assert json.loads(response["body"]) == expected_message
+    assert json.loads(response["body"])["data"][0]["instrument"] == "mag"

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -5,6 +5,7 @@ import json
 import os
 from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlparse
+from unittest.mock import patch
 
 import pytest
 from boto3.dynamodb.conditions import Key
@@ -309,5 +310,64 @@ def test_query_with_no_parameters(data_table, ialirt_data_query_api_module):
     event = {"queryStringParameters": None}
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
-    expected_message = {"message": "No query parameters provided"}
     assert json.loads(response["body"])["data"][0]["instrument"] == "mag"
+
+
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_data_query_api.table.query")
+def test_pagination_with_next_url(mock_query, data_table, ialirt_data_query_api_module):
+    """Test pagination flow."""
+
+    # Mock DynamoDB returning paginated responses
+    mock_query.side_effect = [
+        {
+            "Items": [
+                {"instrument": "mag", "time_utc": "2025-11-06T16:20:00", "data": "item0"},
+                {"instrument": "mag", "time_utc": "2025-11-06T16:20:01", "data": "item1"},
+            ],
+            "LastEvaluatedKey": {
+                "instrument": "mag",
+                "time_utc": "2025-11-06T16:20:01",
+            },
+        },
+        {
+            "Items": [
+                {"instrument": "mag", "time_utc": "2025-11-06T16:20:02", "data": "item2"},
+                {"instrument": "mag", "time_utc": "2025-11-06T16:20:03", "data": "item3"},
+            ],
+            "LastEvaluatedKey": None,
+        },
+    ]
+
+    # First event: GET <invoke url>/query?instrument=mag
+    event1 = {
+        "queryStringParameters": {"instrument": "mag"},
+        "headers": {"host": "ialirt.imap-mission.com"},
+        "requestContext": {"path": "/api-key/ialirt-db-query"},
+    }
+
+    response1 = ialirt_data_query_api_module.lambda_handler(event1, None)
+    body1 = json.loads(response1["body"])
+
+    assert body1["meta"]["has_more"] is True
+    assert len(body1["data"]) == 2  # Page 1 has 2 items
+    assert mock_query.call_count == 1  # DynamoDB called once
+
+    # Second event: GET <invoke url>/query?instrument=mag&last_evaluated_key=...
+    parsed = urlparse(body1["links"]["next"])
+    query_params = parse_qs(parsed.query)
+
+    next_event = {
+        "queryStringParameters": {"instrument": query_params["instrument"][0],
+                                   "last_evaluated_key": query_params["last_evaluated_key"][0]},
+        "headers": {"host": parsed.hostname},
+        "requestContext": {"path": parsed.path},
+    }
+
+    # Call handler again → second page of data
+    response2 = ialirt_data_query_api_module.lambda_handler(next_event, None)
+    body2 = json.loads(response2["body"])
+
+    assert body2["meta"]["has_more"] is False
+    assert len(body2["data"]) == 2      # Page 2 has 2 items
+    assert mock_query.call_count == 2   # DynamoDB called twice
+

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -225,11 +225,7 @@ def test_query_with_utc_start(data_table, ialirt_data_query_api_module):
 
     utc = sorted(data["time_utc"] for data in items["data"])
 
-    expected_data = [
-        "2021-01-03T00:00:00",
-    ]
-
-    assert utc == expected_data
+    assert "2021-01-03T00:00:00" in utc
 
 
 def test_query_with_utc_end(data_table, ialirt_data_query_api_module):
@@ -246,7 +242,7 @@ def test_query_with_utc_end(data_table, ialirt_data_query_api_module):
     assert json.loads(response["body"]) == expected_message
 
 
-def test_query_no_results(data_table, ialirt_data_query_api_module):
+def test_query_results(data_table, ialirt_data_query_api_module):
     """Test query if there are no results."""
     # GET <invoke url>/query?met_start=<met_start>&met_end=<met_end>
     event = {
@@ -256,7 +252,7 @@ def test_query_no_results(data_table, ialirt_data_query_api_module):
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     assert response["statusCode"] == 200
-    assert json.loads(response["body"])["meta"]["count"] == 0
+    assert json.loads(response["body"])["meta"]["count"] == 1
 
 
 def test_query_with_multiple_filters(data_table, ialirt_data_query_api_module):

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -4,8 +4,6 @@ import importlib
 import json
 import os
 from datetime import datetime, timezone
-from unittest.mock import patch
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 from boto3.dynamodb.conditions import Key
@@ -219,7 +217,7 @@ def test_query_results(data_table, ialirt_data_query_api_module):
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     assert response["statusCode"] == 200
-    assert json.loads(response["body"])["meta"]["count"] == 1
+    assert json.loads(response["body"])["meta"]["count"] == 0
 
 
 def test_query_with_multiple_filters(data_table, ialirt_data_query_api_module):
@@ -276,78 +274,3 @@ def test_query_with_no_parameters(data_table, ialirt_data_query_api_module):
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
     assert json.loads(response["body"])["data"][0]["instrument"] == "mag"
-
-
-@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_data_query_api.table.query")
-def test_pagination_with_next_url(mock_query, data_table, ialirt_data_query_api_module):
-    """Test pagination flow."""
-    # Mock DynamoDB returning paginated responses
-    mock_query.side_effect = [
-        {
-            "Items": [
-                {
-                    "instrument": "mag",
-                    "time_utc": "2025-11-06T16:20:00",
-                    "data": "item0",
-                },
-                {
-                    "instrument": "mag",
-                    "time_utc": "2025-11-06T16:20:01",
-                    "data": "item1",
-                },
-            ],
-            "LastEvaluatedKey": {
-                "instrument": "mag",
-                "time_utc": "2025-11-06T16:20:01",
-            },
-        },
-        {
-            "Items": [
-                {
-                    "instrument": "mag",
-                    "time_utc": "2025-11-06T16:20:02",
-                    "data": "item2",
-                },
-                {
-                    "instrument": "mag",
-                    "time_utc": "2025-11-06T16:20:03",
-                    "data": "item3",
-                },
-            ],
-            "LastEvaluatedKey": None,
-        },
-    ]
-
-    # First event: GET <invoke url>/query?instrument=mag
-    event1 = {
-        "queryStringParameters": {"instrument": "mag"},
-        "headers": {"host": "ialirt.imap-mission.com"},
-        "requestContext": {"path": "/api-key/ialirt-db-query"},
-    }
-
-    response1 = ialirt_data_query_api_module.lambda_handler(event1, None)
-    body1 = json.loads(response1["body"])
-
-    assert len(body1["data"]) == 2  # Page 1 has 2 items
-    assert mock_query.call_count == 1  # DynamoDB called once
-
-    # Second event: GET <invoke url>/query?instrument=mag&last_evaluated_key=...
-    parsed = urlparse(body1["links"]["next"])
-    query_params = parse_qs(parsed.query)
-
-    next_event = {
-        "queryStringParameters": {
-            "instrument": query_params["instrument"][0],
-            "last_evaluated_key": query_params["last_evaluated_key"][0],
-        },
-        "headers": {"host": parsed.hostname},
-        "requestContext": {"path": parsed.path},
-    }
-
-    # Call handler again → second page of data
-    response2 = ialirt_data_query_api_module.lambda_handler(next_event, None)
-    body2 = json.loads(response2["body"])
-
-    assert body2["meta"]["has_more"] is False
-    assert len(body2["data"]) == 2  # Page 2 has 2 items
-    assert mock_query.call_count == 2  # DynamoDB called twice

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -531,7 +531,7 @@ def test_process_algorithms(
         combined=None,
         algorithm_table=algorithm_table,
         table_name="ialirt-algorithm-table",
-        kernel_set_id="test-kernel-set-id",
+        kernel_set_key="test-kernel-set-id",
     )
 
     response = algorithm_table.query(KeyConditionExpression=Key("apid").eq(478))[
@@ -661,7 +661,7 @@ def test_insert_kernels(
     dependency_inputs = MagicMock()
     dependency_inputs.processing_input = [spice_input]
 
-    insert_kernels(dependency_inputs, algorithm_table, "ialirt-algorithm-table")
+    insert_kernels(dependency_inputs, algorithm_table)
 
     response = algorithm_table.query(
         KeyConditionExpression="apid = :a", ExpressionAttributeValues={":a": 478}

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -229,7 +229,7 @@ def test_insert_data(
         },
     ]
 
-    insert_data(test_data, algorithm_table, "hit")
+    insert_data(test_data, algorithm_table, "hit", "test-kernel-set-id")
 
     item1 = algorithm_table.get_item(Key={"apid": 478, "met": 123456})["Item"]
     item2 = algorithm_table.get_item(Key={"apid": 478, "met": 123457})["Item"]
@@ -394,7 +394,7 @@ def test_insert_formatted_data(
         },
     ]
 
-    insert_formatted_data(test_data, data_table, "mag")
+    insert_formatted_data(test_data, data_table, "mag", "test-kernel-set-id")
 
     item1 = data_table.get_item(
         Key={"instrument": "mag", "time_utc": "2021-01-01T00:00:00"}
@@ -531,6 +531,7 @@ def test_process_algorithms(
         combined=None,
         algorithm_table=algorithm_table,
         table_name="ialirt-algorithm-table",
+        kernel_set_id="test-kernel-set-id",
     )
 
     response = algorithm_table.query(KeyConditionExpression=Key("apid").eq(478))[
@@ -660,7 +661,7 @@ def test_insert_kernels(
     dependency_inputs = MagicMock()
     dependency_inputs.processing_input = [spice_input]
 
-    insert_kernels(dependency_inputs, algorithm_table)
+    insert_kernels(dependency_inputs, algorithm_table, "ialirt-algorithm-table")
 
     response = algorithm_table.query(
         KeyConditionExpression="apid = :a", ExpressionAttributeValues={":a": 478}


### PR DESCRIPTION
# Change Summary

## Overview
After the redesign of the DynamoDB and also feedback from various users I am striving to create an api that:

1. Is compatible with the current API since folks are already using it
2. Takes into account really great recommendations from the MAG team: https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/957
3. Aligns with our goals of lower latency
4. Creates a last_evaluated_key so that pagination is simplified for users: https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/944

## Updated Files
- README.md
   - minor update to example
- insert_kernels.py
   - Fixed bug so that new database table the SPICE kernels will be ingested because previously they did not contain the necessary partition and sort key.
   - I also realized that I do not currently have a way to associate the science data with the proper spice kernel. So this is updated.
- ialirt_data_query_api.py
   - This is the API. It should have the following structure below when used. It includes the ability to paginate. It also provides the user with a more structure view of the data (separating metadata from actual data).

```
{
    "statusCode": 200,
    "headers": {
        "Content-Type": "application/json"
    },
    "body": {
        "meta": {
            "count": 2,
            "type": "science",
            "instrument": "mag",
            "has_more": True,
            "last_evaluated_key": '{"instrument": "mag", "time_utc": "2025-11-06T16:20:01"}'
        },
        "links": {
            "self": "https://ialirt.imap-mission.com/api-key/ialirt-db-query?instrument=mag",
            "next": (
                "https://ialirt.imap-mission.com/api-key/ialirt-db-query?"
                "instrument=mag&last_evaluated_key=%7B%22instrument%22%3A%20%22mag%22%2C"
                "%20%22time_utc%22%3A%20%222025-11-06T16%3A20%3A01%22%7D"
            )
        },
        "data": [
            {"instrument": "mag", "time_utc": "2025-11-06T16:20:00", "data": "item0"},
            {"instrument": "mag", "time_utc": "2025-11-06T16:20:01", "data": "item1"}
        ]
    }
}
```


## Testing
- test_ialirt_data_query_api.py
- test_insert_kernels.py