### PR TITLE
IDEX l1b predicted ephemeris

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -573,6 +573,7 @@ spin, spin, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 leapseconds, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
+ephemeris_predicted, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview
The IDEX team requested that we process l1b as soon as possible with the predicted ephemeris kernel even if the ephemeris reconstructed is not available yet. Once we get the reconstructed kernel, then they would like it to be reprocessed. The ephemeris reconstructed kernel is listed as a hard dependency already, meaning that once the new one is ingested it will trigger reprocessing. 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - Add ephemeris predicted. Add it as a HARD_NO_TRIGGER because we only want to reprocess it if an ephemeris reconstructed kernel gets ingested. 

