### PR TITLE
FIX: Add codice LUT to I-ALiRT processing function

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -267,7 +267,7 @@ def parse_packets(filenames: list, bucket: str, download_dir: Path, apid=478):
     return combined
 
 
-def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):
+def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):  # noqa: PLR0915
     """Process the algorithms and insert data, as needed.
 
     Parameters
@@ -317,10 +317,14 @@ def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):
                 )
             elif instrument == "codicelo":
                 logger.info("Processing CoDICE-Lo.")
-                result, _ = process_func(combined)
+                download_path = get_ancillary(instrument, "l1a-sci-lut")
+                logger.info("codice sci-lut: %s", download_path)
+                result, _ = process_func(combined, download_path)
             elif instrument == "codicehi":
                 logger.info("Processing CoDICE-Hi.")
-                _, result = process_func(combined)
+                download_path = get_ancillary(instrument, "l1a-sci-lut")
+                logger.info("codice sci-lut: %s", download_path)
+                _, result = process_func(combined, download_path)
             elif instrument == "swapi":
                 logger.info("Processing SWAPI.")
                 download_path = get_ancillary(instrument, "esa-unit-conversion")


### PR DESCRIPTION
This aligns the processing function with the expected imap_processing signature from https://github.com/IMAP-Science-Operations-Center/imap_processing/pull/2348

@laspsandoval there aren't any codice ancillary files in production, so this will still fail I think. Do you have the LUTs?

closes #992