### PR TITLE
MNT: Keep processing I-ALiRT instruments catching errors

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -288,50 +288,71 @@ def process_algorithms(combined: xr.Dataset, algorithm_table, table_name):
         ("swapi", process_swapi_ialirt),
     ]
 
+    # Collect any errors during processing to raise at the end
+    processing_errors = []
+
     for instrument, process_func in processors:
-        if instrument == "swe":
-            logger.info("Processing SWE.")
-            download_path = get_ancillary(instrument, "l1b-in-flight-cal")
-            logger.info("swe l1b-in-flight-cal: %s", download_path)
-            result = process_func(combined, [download_path])
-        elif instrument == "mag":
-            logger.info("Processing MAG.")
-            download_path = get_ancillary(instrument, "ialirt-calibration")
-            parts = download_path.stem.split("_")
-            date_str = parts[-2]
-            input_files = AncillaryInput(download_path.name)
-            ialirt_calibration_data = MagAncillaryCombiner(input_files, date_str)
+        try:
+            if instrument == "swe":
+                logger.info("Processing SWE.")
+                download_path = get_ancillary(instrument, "l1b-in-flight-cal")
+                logger.info("swe l1b-in-flight-cal: %s", download_path)
+                result = process_func(combined, [download_path])
+            elif instrument == "mag":
+                logger.info("Processing MAG.")
+                download_path = get_ancillary(instrument, "ialirt-calibration")
+                parts = download_path.stem.split("_")
+                date_str = parts[-2]
+                input_files = AncillaryInput(download_path.name)
+                ialirt_calibration_data = MagAncillaryCombiner(input_files, date_str)
 
-            logger.info("mag ialirt-calibration: %s", download_path)
-            download_path = get_ancillary(instrument, "l1b-calibration")
-            logger.info("mag l1b-calibration: %s", download_path)
-            l1b_calibration_data = load_cdf(download_path)
-            result = process_func(
-                combined, l1b_calibration_data, ialirt_calibration_data.combined_dataset
-            )
-        elif instrument == "codicelo":
-            logger.info("Processing CoDICE-Lo.")
-            result, _ = process_func(combined)
-        elif instrument == "codicehi":
-            logger.info("Processing CoDICE-Hi.")
-            _, result = process_func(combined)
-        elif instrument == "swapi":
-            logger.info("Processing SWAPI.")
-            download_path = get_ancillary(instrument, "esa-unit-conversion")
-            logger.info("swapi esa-unit-conversion: %s", download_path)
-            calibration_data = pd.read_csv(download_path)
-            result = process_func(combined, calibration_data)
-        else:
-            logger.info("Processing HIT.")
-            result = process_func(combined)
-
-        logger.info("%s result: %s", instrument, result)
-
-        if any(result) and all(result):
-            if table_name == "ialirt-algorithm-table":
-                insert_data(result, algorithm_table, instrument)
+                logger.info("mag ialirt-calibration: %s", download_path)
+                download_path = get_ancillary(instrument, "l1b-calibration")
+                logger.info("mag l1b-calibration: %s", download_path)
+                l1b_calibration_data = load_cdf(download_path)
+                result = process_func(
+                    combined,
+                    l1b_calibration_data,
+                    ialirt_calibration_data.combined_dataset,
+                )
+            elif instrument == "codicelo":
+                logger.info("Processing CoDICE-Lo.")
+                result, _ = process_func(combined)
+            elif instrument == "codicehi":
+                logger.info("Processing CoDICE-Hi.")
+                _, result = process_func(combined)
+            elif instrument == "swapi":
+                logger.info("Processing SWAPI.")
+                download_path = get_ancillary(instrument, "esa-unit-conversion")
+                logger.info("swapi esa-unit-conversion: %s", download_path)
+                calibration_data = pd.read_csv(download_path)
+                result = process_func(combined, calibration_data)
             else:
-                insert_formatted_data(result, algorithm_table, instrument)
+                logger.info("Processing HIT.")
+                result = process_func(combined)
+
+            logger.info("%s result: %s", instrument, result)
+
+            if any(result) and all(result):
+                if table_name == "ialirt-algorithm-table":
+                    insert_data(result, algorithm_table, instrument)
+                else:
+                    insert_formatted_data(result, algorithm_table, instrument)
+
+        except Exception as e:
+            error_msg = f"Error processing {instrument}: {e!s}"
+            logger.error(error_msg, exc_info=True)
+            processing_errors.append((instrument, e))
+            # Continue to next instrument
+
+    # If there were any processing errors, raise them at the end
+    if processing_errors:
+        error_summary = "; ".join(
+            [f"{instr}: {err!s}" for instr, err in processing_errors]
+        )
+        raise RuntimeError(
+            f"Failed to process {len(processing_errors)} instrument(s): {error_summary}"
+        )
 
 
 def insert_data(data: list[dict], algorithm_table, instrument: str):


### PR DESCRIPTION
We want to keep processing as we go through the instrument loop so that one instrument doesn't stop another one from processing. We accumulate the errors and raise at the end if there are any logging all relevant errors during the process.

closes #993 
