### PR TITLE
Increase Lo job memory

### DIFF
--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -112,7 +112,7 @@ class ProcessingConstruct(Construct):
         # TODO : optimize ULTRA l1a to use less resources
         cpu = 4
         memory = cdk.Size.gibibytes(16)
-        if "ultra" in job_name:
+        if "ultra" or "lo" in job_name:
             cpu = 8
             memory = cdk.Size.gibibytes(48)
         # Create the job definition

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -113,7 +113,7 @@ class ProcessingConstruct(Construct):
         # TODO : optimize ULTRA and Lo l1a to use less resources
         cpu = 4
         memory = cdk.Size.gibibytes(16)
-        if "ultra" in job_name or "lo_l1a" in job_name:
+        if "ultra" in job_name or "lo" in job_name:
             cpu = 8
             memory = cdk.Size.gibibytes(48)
         # Create the job definition

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -113,7 +113,7 @@ class ProcessingConstruct(Construct):
         # TODO : optimize ULTRA and Lo l1a to use less resources
         cpu = 4
         memory = cdk.Size.gibibytes(16)
-        if "ultra" or "lo" in job_name:
+        if "ultra" in job_name or "lo_l1a" in job_name:
             cpu = 8
             memory = cdk.Size.gibibytes(48)
         # Create the job definition

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -108,8 +108,9 @@ class ProcessingConstruct(Construct):
             empty_on_delete=True,
             removal_policy=cdk.RemovalPolicy.DESTROY,
         )
-        # Ultra jobs need more resources than others. Specifically, ULTRA l1a
-        # TODO : optimize ULTRA l1a to use less resources
+        # Ultra and Lo jobs need more resources than others. Specifically, ULTRA and
+        # Lo l1a
+        # TODO : optimize ULTRA and Lo l1a to use less resources
         cpu = 4
         memory = cdk.Size.gibibytes(16)
         if "ultra" or "lo" in job_name:


### PR DESCRIPTION
# Change Summary

## Overview
In the processing construct, Lo's memory is increased the same as Ultra's. Lo jobs will have 48GB. This is needed, at least temporarily, due to Lo's L1A processing where the decommutation using derived values is exceeding the 16GB limit.