### PR TITLE
Update L3 mag dependencies to use despun frame product

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -41,7 +41,7 @@ codice, l3a, lo-partial-densities, codice, l3a, lo-sw-abundances, HARD, DOWNSTRE
 codice, l2, hi-direct-events, codice, l3a, hi-direct-events, HARD, DOWNSTREAM
 codice, ancillary, tof-lookup, codice, l3a, hi-direct-events, HARD, DOWNSTREAM
 
-mag, l1d, norm-mago, codice, l3b, hi-pitch-angle, HARD, DOWNSTREAM
+mag, l1d, norm-dsrf, codice, l3b, hi-pitch-angle, HARD, DOWNSTREAM
 codice, l2, hi-sectored, codice, l3b, hi-pitch-angle, HARD, DOWNSTREAM
 
 codice, l3a, lo-direct-events, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
@@ -543,7 +543,7 @@ hit, ancillary, l1b-to-l2-summed-dt2-factors, hit, l2, summed-intensity, HARD, D
 hit, ancillary, l1b-to-l2-summed-dt3-factors, hit, l2, summed-intensity, HARD, DOWNSTREAM
 
 hit, l2, macropixel-intensity, hit, l3, macropixel, HARD, DOWNSTREAM
-mag, l1d, norm-mago, hit, l3, macropixel, HARD, DOWNSTREAM
+mag, l1d, norm-dsrf, hit, l3, macropixel, HARD, DOWNSTREAM
 
 hit, l1a, direct-events, hit, l3, direct-events, HARD, DOWNSTREAM
 hit, ancillary, range-2A-cosine-lookup, hit, l3, direct-events, HARD, DOWNSTREAM
@@ -918,7 +918,7 @@ swe, l1b, sci, swe, l3, sci, HARD, DOWNSTREAM
 swe, l2, sci, swe, l3, sci, HARD, DOWNSTREAM
 swe, ancillary, config, swe, l3, sci, HARD, DOWNSTREAM
 swapi, l3a, proton-sw, swe, l3, sci, HARD, DOWNSTREAM
-mag, l1d, norm-mago, swe, l3, sci, HARD, DOWNSTREAM
+mag, l1d, norm-dsrf, swe, l3, sci, HARD, DOWNSTREAM
 imap_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM


### PR DESCRIPTION
Hello @maxinelasp, we updated the L3 dependencies to use the new descriptor for L1d mag data. We currently use the 'vectors' variable, is that still correct for the norm-dsrf product? 