### PR TITLE
BUG: SPICE trigger dependencies

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -51,6 +51,14 @@ BATCH_JOB_RETRY_STRATEGY = {
 SQS_CLIENT = boto3.client("sqs", region_name="us-west-2")
 
 
+def spacecraft_pointing_attitude_job(job_node: dict) -> bool:
+    """Determine if the job node is a spacecraft pointing-attitude job."""
+    return (
+        job_node["data_source"] == "spacecraft"
+        and job_node["descriptor"] == "pointing-attitude"
+    )
+
+
 def cadence_to_datetime_range(
     cadence: str,
     start_date: Optional[datetime.datetime] = None,
@@ -445,10 +453,7 @@ def submit_all_jobs(
 
     # Handle special case reprocessing jobs.
     logger.info(f"All required dependencies found for the dependency: {job_node}")
-    if (
-        job_node["data_source"] == "spacecraft"
-        and job_node["descriptor"] == "pointing-attitude"
-    ):
+    if spacecraft_pointing_attitude_job(job_node):
         serialized_deps = upstream_dependencies.serialize()
         job_version = determine_job_version(
             session=session,
@@ -787,13 +792,19 @@ def s3_processing_event(session, events):
             job.pop("relationship")
 
             # by default, we want to filter the upstream dependencies only if the
-            # trigger file is an ancillary file.
-            # Ancillary files can trigger multiple jobs for the
+            # trigger file is an ancillary file or SPICE file.
+            # Ancillary and SPICE files can trigger multiple jobs for the
             # same instrument, data level, and descriptor but with different start
             # dates. Once we know the start dates for the job, we "filter" the upstream
             # dependencies to only include those valid for that date.
+
+            # If the job is spacecraft pointing-attitude job, do not filter
+            # dependencies because there are no upstream science dependencies for this
+            # job.
             filter_dependencies = False
-            if isinstance(file_obj, AncillaryFilePath):
+            if isinstance(
+                file_obj, (AncillaryFilePath, SPICEFilePath)
+            ) and not spacecraft_pointing_attitude_job(job):
                 filter_dependencies = True
 
             # Pass along the repointing number if the file is a science file.
@@ -893,10 +904,7 @@ def bulk_reprocessing_event(session, events):
             # dependencies, meaning there is only one pointing-attitude job per
             # reprocessing call. Therefore, dependencies should not be filtered
             # after the initial upstream dependency query in "submit_all_jobs".
-            if (
-                job["data_source"] == "spacecraft"
-                and job["descriptor"] == "pointing-attitude"
-            ):
+            if spacecraft_pointing_attitude_job(job):
                 filter_dependencies = False
             else:
                 filter_dependencies = True

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -791,21 +791,21 @@ def s3_processing_event(session, events):
 
             job.pop("relationship")
 
-            # by default, we want to filter the upstream dependencies only if the
-            # trigger file is an ancillary file or SPICE file.
-            # Ancillary and SPICE files can trigger multiple jobs for the
-            # same instrument, data level, and descriptor but with different start
-            # dates. Once we know the start dates for the job, we "filter" the upstream
-            # dependencies to only include those valid for that date.
+            # Do not filter the upstream dependencies if the trigger file is
+            # ScienceFilePath. Ancillary, SPICE, spin, and repoint files can trigger
+            # multiple jobs for the same instrument, data level, and descriptor but
+            # with different start dates. Once we know the start dates for the job, we
+            # "filter" the upstream dependencies to only include those valid for that
+            # date.
 
             # If the job is spacecraft pointing-attitude job, do not filter
             # dependencies because there are no upstream science dependencies for this
             # job.
-            filter_dependencies = False
+            filter_dependencies = True
             if isinstance(
-                file_obj, (AncillaryFilePath, SPICEFilePath)
-            ) and not spacecraft_pointing_attitude_job(job):
-                filter_dependencies = True
+                file_obj, ScienceFilePath
+            ) or spacecraft_pointing_attitude_job(job):
+                filter_dependencies = False
 
             # Pass along the repointing number if the file is a science file.
             repoint = (

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, call, patch
 
 import imap_data_access
 import pytest
+from imap_data_access import SpinInput
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     ScienceInput,
@@ -331,6 +332,120 @@ def test_lambda_handler_multiple_events(session, s3_client):
     ):
         lambda_handler(multiple_events, context)
         assert mock_batch_client.submit_job.call_count == 2
+
+
+def test_lambda_handler_spice_event(session):
+    """Tests ``lambda_handler`` function when triggerd by an spice file."""
+    _static_spice_files(session)
+    # Test that the correct dependencies are gathered when a spice ingest
+    # triggers the lambda.
+    # Swe l2 needs l1b and spin files.
+    # Add db records to satisfy dependencies.
+    records = [
+        # Add two science files to ensure there are two jobs submitted
+        ScienceFiles(
+            file_path="/path/to/imap_swe_l1b_sci_20250429_v001.cdf",
+            instrument="swe",
+            data_level="l1b",
+            descriptor="sci",
+            start_date=datetime(2025, 4, 29),
+            version="v001",
+            extension="cdf",
+            ingestion_date=datetime.strptime(
+                "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+            ),
+        ),
+        ScienceFiles(
+            file_path="/path/to/imap_swe_l1b_sci_20250430_v001.cdf",
+            instrument="swe",
+            data_level="l1b",
+            descriptor="sci",
+            start_date=datetime(2025, 4, 30),
+            version="v001",
+            extension="cdf",
+            ingestion_date=datetime.strptime(
+                "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+            ),
+        ),
+        SpinFiles(
+            file_path="/imap/spice/spin/imap_2025_119_2025_121_01.spin.csv",
+            start_date=datetime(2025, 4, 29),
+            end_date=datetime(2025, 4, 30),
+            version="01",
+            ingestion_date=datetime.now(),
+        ),
+    ]
+    session.add_all(records)
+    session.commit()
+
+    events = {
+        "Records": [
+            {
+                "body": '{"detail": '
+                '{"object": {"key": '
+                '"imap_2025_119_2025_121_01.spin.csv"}}'
+                "}"
+            }
+        ]
+    }
+
+    context = {"context": "sample_context"}
+    with (
+        patch.object(batch_starter, "BATCH_CLIENT", Mock()) as mock_batch_client,
+        patch.object(batch_starter, "generate_queue_url", return_value=False),
+    ):
+        lambda_handler(events, context)
+        # There should be 2 different jobs submitted for the two swe l1b files
+        assert mock_batch_client.submit_job.call_count == 2
+        # Assert_called_with only works on the last call
+        # Check that the last call is what we expect with the correct dependencies
+
+        mock_batch_client.submit_job.assert_called_with(
+            jobName="swe-l2-sci-job-2",
+            jobQueue="ProcessingJobQueue",
+            jobDefinition="ProcessingJob-swe",
+            containerOverrides={
+                "command": [
+                    "--instrument",
+                    "swe",
+                    "--data-level",
+                    "l2",
+                    "--descriptor",
+                    "sci",
+                    "--start-date",
+                    "20250430",
+                    "--version",
+                    "v001",
+                    "--dependency",
+                    "imap_swe_l2_sci-d3646148_20250430_v001.json",
+                    "--upload-to-sdc",
+                ]
+            },
+            retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
+        )
+    # Assert that the try_to_submit_job function was called with the correct
+    # upstream dependencies
+    # There should be two calls to try_to_submit_job, one for each swe l1b file
+    # Each job should have the same spin file dependency, but different
+    # science file dependencies.
+    # We check the last call here.
+    expected_dependencies = ProcessingInputCollection(
+        SpinInput("imap_2025_119_2025_121_01.spin.csv"),
+        ScienceInput("imap_swe_l1b_sci_20250430_v001.cdf"),
+    )
+    with (
+        patch.object(batch_starter, "try_to_submit_job") as mock_submit,
+        patch.object(batch_starter, "generate_queue_url", return_value=False),
+    ):
+        lambda_handler(events, context)
+        mock_submit.assert_called_with(
+            session,
+            {"data_source": "swe", "data_type": "l2", "descriptor": "sci"},
+            "20250430",
+            "v001",
+            expected_dependencies.serialize(),
+            repoint=None,
+        )
 
 
 def test_lambda_handler_ancillary_event(session):


### PR DESCRIPTION
# Change Summary

## Overview
Tenzin noticed a bug in swe l2:

`There is another thing going on with SWE L2 processing. Sometimes, job gets more than one science files. I think that’s happening because spin file kicked off the batch starter and found few files waiting.`

This was happening because the dependencies should be "filtered" if the trigger file was a SPICE, Spin, Ancillary or Repoint file. Basically anything but a Science file. Science files have an exact date associated with them. The rest can have a range and therefore, can trigger multiple jobs. The flow should be: 

1. SPICE, Spin, Ancillary or Repoint  triggered batch starter
2. get upstream science files in that date range
3. For each upstream science file "filter" the dependencies for only ones needed for the start date of that science file

This will also help reduce the large metakernel queries that are timing out. 


## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
   - spacecraft_pointing_attitude_job :small helper function for repeated code
   - Filter dependencies for all file triggers except science

## Testing
Add a test for a spice event
