### PR TITLE
FIX: Insert into table requires time_utc sort key to be present

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -556,10 +556,14 @@ def insert_kernels(dependency_inputs, algorithm_table):
     spice_input = dependency_inputs.processing_input[0]
     spice_kernels = dict(zip(spice_input.source, spice_input.filename_list))
 
+    if algorithm_table.table_name == "ialirt-algorithm-table":
+        time_key = "met_in_utc"
+    else:
+        time_key = "time_utc"
     kernel_item = {
         "apid": 478,
         "met": int(met),
-        "met_in_utc": met_to_utc(met).split(".")[0],
+        time_key: met_to_utc(met).split(".")[0],
         "ttj2000ns": int(met_to_ttj2000ns(met)),
         "instrument": "spice",
         "last_modified": last_modified_utc,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def setup_dynamodb():
     """Initialize DynamoDB resource and create table."""
     os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
     os.environ["INGEST_TABLE"] = "imap-ingest-table"
-    os.environ["ALGORITHM_TABLE"] = "imap-algorithm-table"
+    os.environ["ALGORITHM_TABLE"] = "ialirt-algorithm-table"
 
     with mock_dynamodb():
         # Initialize DynamoDB resource


### PR DESCRIPTION
# Change Summary

## Overview

The algorithms have their time key reformatted in the process_algorithms function when inserting into the different tables, but the SPICE keys didn't get swapped. We need to swap the SPICE key as well, depending on the table name we are inserting into. I think this is the only thing missing as we have the "instrument": "spice" already in there.