### PR TITLE
FIX: MAG L1d needs spin as a dependency for processing

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -790,6 +790,7 @@ ephemeris_reconstructed, spice, historical, mag, l1d, norm-srf, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_constants, spice, historical, mag, l1d, norm-srf, HARD_NO_TRIGGER, DOWNSTREAM
+spin, spin, historical, mag, l1d, norm-srf, HARD, DOWNSTREAM
 
 # L1C/L1B -> L2
 # MAG L2 and L1D look pretty similar.


### PR DESCRIPTION
# Change Summary

## Overview

Adds the spin tables as a dependency for L1d.

Follows the same naming convention of `norm-srf` without changing to `dsrf`, which can be updated if needed in #1005 

closes #1006