### PR TITLE
I-ALiRT - allow packets and archive to be downloaded by users with api key

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/download_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/download_api.py
@@ -32,6 +32,8 @@ def is_released(s3_key):
     if "test_data" in s3_key:
         # Default to released for any test data files for our CI testing
         return True
+    if s3_key.startswith(("packets/", "archive/")):
+        return True
     try:
         filename = os.path.basename(s3_key)
         file_obj = imap_data_access.file_validation.generate_imap_file_path(filename)


### PR DESCRIPTION
# Change Summary

## Overview
Allow for packets and archive directories in s3 to be downloaded.

## Updated Files
- download_api.py
   - Allow for packets and archive directories in s3 to be downloaded.
