### PR TITLE
I-ALiRT - fix old api

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_db_query_api.py
@@ -18,42 +18,20 @@ dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
 
-def process_item_types(item: dict) -> dict:
-    """Convert Decimal values to int/float for known fields.
+class DecimalEncoder(json.JSONEncoder):
+    """Convert Decimals to floats."""
 
-    Parameters
-    ----------
-    item : dict
-        The item in the dictionary.
+    def default(self, obj):
+        """Override JSON encoding for Decimal values."""
+        if isinstance(obj, Decimal):
+            # - If the Decimal is an integer, return int
+            # - Otherwise, float rounded to 3 decimal places
+            if obj % 1 == 0:
+                return int(obj)
+            return round(float(obj), 3)
 
-    Returns
-    -------
-    result : dict
-        Properly formatted parameters.
-    """
-    result = {}
-
-    for key, value in item.items():
-        # Vectors fields
-        if isinstance(value, list):
-            result[key] = [int(v) if v % 1 == 0 else round(float(v), 3) for v in value]
-        # Dictionary fields
-        elif isinstance(value, dict):
-            nested = {}
-            for k, v in value.items():
-                if isinstance(v, Decimal):
-                    nested[k] = int(v) if v % 1 == 0 else round(float(v), 3)
-                else:
-                    nested[k] = v
-            result[key] = nested
-        # Scalar fields
-        elif isinstance(value, Decimal):
-            result[key] = int(value) if value % 1 == 0 else round(float(value), 3)
-
-        else:
-            result[key] = value
-
-    return result
+        # Let the base class raise for other unsupported types
+        return super().default(obj)
 
 
 def lambda_handler(event, context):  # noqa: PLR0912
@@ -198,14 +176,13 @@ def lambda_handler(event, context):  # noqa: PLR0912
 
     # --- Process items ---
     items = response.get("Items", [])
-    processed_items = [process_item_types(item) for item in items]
     t5 = time.perf_counter()
 
     # --- Serialize to JSON ---
-    json_body = json.dumps(processed_items)
+    json_body = json.dumps(items, cls=DecimalEncoder)
     t6 = time.perf_counter()
 
-    num_items = len(processed_items)
+    num_items = len(items)
 
     text = (
         f"Param parse: {t2 - t1:.3f}s | KeyCondition setup: {t3 - t2:.3f}s | "

--- a/tests/lambda_endpoints/test_ialirt_db_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_db_query_api.py
@@ -274,12 +274,23 @@ def test_process_item_types(ialirt_db_query_api_module):
             "mag_B_magnitude": Decimal("0.22"),
             "met_in_utc": "2025-06-20T08:00:00",  # string should stay unchanged
             "mag_hk_status": {"pri_isvalid": True, "hkn8v5": Decimal("3680")},
+            "codice_hi_h": [
+                [
+                    [
+                        [Decimal("10"), Decimal("12")],
+                        [Decimal("11"), Decimal("14")],
+                    ],
+                ]
+            ],
         }
     ]
 
-    processed_items = [
-        ialirt_db_query_api_module.process_item_types(item) for item in items
-    ]
+    # Use JSON encoder to process Decimals instead of process_item_types
+    json_output = json.dumps(
+        items,
+        cls=ialirt_db_query_api_module.DecimalEncoder,
+    )
+    processed_items = json.loads(json_output)
 
     assert processed_items == [
         {
@@ -290,5 +301,6 @@ def test_process_item_types(ialirt_db_query_api_module):
             "mag_B_magnitude": 0.22,
             "met_in_utc": "2025-06-20T08:00:00",
             "mag_hk_status": {"pri_isvalid": True, "hkn8v5": 3680},
+            "codice_hi_h": [[[[10, 12], [11, 14]]]],
         }
     ]


### PR DESCRIPTION
# Change Summary

## Overview
The CODICE-Hi 4D data structure broke the old api. MAG is currently using that api although they have plans to make an update to the new one. This is a quick fix so they can take time to migrate.

## Updated Files
- alirt_db_query_api.py
   - Update to account for change in CoDICE-Hi 4D data structure

Note:

I see this error: [ERROR] TypeError: unsupported operand type(s) for %: 'list' and 'int' Traceback (most recent call last): File "/var/task/IAlirtCode/ialirt_db_query_api.py", line 201, in lambda_handler processed_items = [process_item_types(item) for item in items] File "/var/task/IAlirtCode/ialirt_db_query_api.py", line 39, in process_item_types result[key] = [int(v) if v % 1 == 0 else round(float(v), 3) for v in value] 

For: curl -H "x-api-key: $IALIRT_API_KEY" "https://ialirt.imap-mission.com/api-key/ialirt-db-query?met_in_utc_start=2025-12-11T00:00:00"

Previous queries prior to yesterday work fine.