### PR TITLE
Break all maps scheduled jobs into smaller scheduled jobs

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_jobs_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_jobs_config.csv
@@ -4,5 +4,9 @@
 cron(20 6 * * ? *), glows, l3b, ion-rate-profile
 
 cron(20 8 * * ? *), lo, l3, all-maps
-cron(20 8 * * ? *), hi, l3, all-maps
-cron(20 8 * * ? *), ultra, l3, all-maps
+cron(20 8 * * ? *), hi, l3, sp-maps
+cron(20 10 * * ? *), hi, l3, hic-maps
+cron(20 8 * * ? *), ultra, l3, u45-maps
+cron(20 8 * * ? *), ultra, l3, u90-maps
+cron(20 8 * * ? *), ultra, l3, ulc-sp-maps
+cron(20 8 * * ? *), ultra, l3, ulc-nsp-maps


### PR DESCRIPTION
# Change Summary

## Overview
Generating all the ultra maps within a single job was leading to the job taking a very long time, and timing out after 2 hours. Now that there are multiple smaller jobs, we hope they timeout anymore.

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/scheduled_jobs_config.csv
   - replaced ultra all-maps job with a few new jobs that each generate a portion of the maps
   - replaced hi all-maps job with a few new jobs that each generate a portion of the maps

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
