### PR TITLE
I-ALiRT - Conceal certain HIT products and set public release date

### DIFF
--- a/sds_data_manager/constructs/api_gateway_construct.py
+++ b/sds_data_manager/constructs/api_gateway_construct.py
@@ -3,8 +3,8 @@
 Sets up api gateway, creates routes, and creates methods that are linked to the
 lambda function.
 
-An example of the format of the url: https://api.prod.imap-mission.com/query
-https://ialirt.prod.imap-mission.com/ialirt-log-query
+An example of the format of the url: https://api.imap-mission.com/query
+https://ialirt.imap-mission.com/ialirt-log-query
 """
 
 from typing import Optional

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -18,6 +18,18 @@ region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
 dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
+FULL_SCOPES = {
+    "full",
+    "ialirt_scientist",
+}
+
+RESTRICTED_FIELDS = {
+    "hit_h_a_side_low_en",
+    "hit_h_a_side_med_en",
+    "hit_h_b_side_low_en",
+    "hit_h_b_side_med_en",
+}
+
 
 class BadTimeError(Exception):
     """Raised when the time filters are invalid."""
@@ -132,6 +144,35 @@ def _error(code: int, message: str) -> dict:
     }
 
 
+def filter_items_by_scope(items: list[dict], scope: str) -> list[dict]:
+    """Hide selected HIT fields for scopes that are not full HIT.
+
+    Parameters
+    ----------
+    items : list[dict]
+        Items returned from DynamoDB.
+    scope : str
+        Scope string from the API key authorizer.
+
+    Returns
+    -------
+    filtered_items: list[dict]
+        Items list.
+    """
+    # If caller has full HIT access, do nothing
+    if scope in FULL_SCOPES:
+        return items
+
+    filtered_items = [
+        {k: v for k, v in item.items() if k not in RESTRICTED_FIELDS}
+        if item.get("instrument") == "hit"
+        else item
+        for item in items
+    ]
+
+    return filtered_items
+
+
 def lambda_handler(event, context):
     """Create metadata and add it to the database.
 
@@ -150,6 +191,12 @@ def lambda_handler(event, context):
 
     """
     params = event.get("queryStringParameters") or {}
+
+    # If there is an api-key used, retrieve the scope.
+    request_ctx = event.get("requestContext", {})
+    auth = request_ctx.get("authorizer", {})
+    auth_ctx = auth.get("lambda", {})
+    scope = auth_ctx.get("scope", "")
 
     # --- Determine key condition ---
     allowed_params = {
@@ -226,6 +273,8 @@ def lambda_handler(event, context):
         query_time_total += t2 - t1
 
     t3 = time.perf_counter()
+
+    items = filter_items_by_scope(items, scope)
 
     json_body = json.dumps(
         {

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -26,7 +26,8 @@ FULL_SCOPES = {
 RESTRICTED_FIELDS = {
     "hit_e_a_side_high_en",
     "hit_e_b_side_high_en",
-    "hit_h_a_side_high_enhit_h_b_side_high_en",
+    "hit_h_a_side_high_en",
+    "hit_h_b_side_high_en",
 }
 
 PUBLIC_CUTOFF_UTC = "2026-02-01T00:00:00"

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -24,10 +24,9 @@ FULL_SCOPES = {
 }
 
 RESTRICTED_FIELDS = {
-    "hit_h_a_side_low_en",
-    "hit_h_a_side_med_en",
-    "hit_h_b_side_low_en",
-    "hit_h_b_side_med_en",
+    "hit_e_a_side_high_en",
+    "hit_e_b_side_high_en",
+    "hit_h_a_side_high_enhit_h_b_side_high_en",
 }
 
 PUBLIC_CUTOFF_UTC = "2026-02-01T00:00:00"

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -30,6 +30,8 @@ RESTRICTED_FIELDS = {
     "hit_h_b_side_med_en",
 }
 
+PUBLIC_CUTOFF_UTC = "2026-02-01T00:00:00"
+
 
 class BadTimeError(Exception):
     """Raised when the time filters are invalid."""
@@ -53,7 +55,7 @@ class DecimalEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
-def apply_time_filters(params: dict, query_kwargs: dict) -> tuple:
+def apply_time_filters(params: dict, query_kwargs: dict, has_api_key: bool) -> tuple:
     """Apply the filters for time.
 
     Parameters
@@ -62,6 +64,8 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> tuple:
         Event parameters.
     query_kwargs : dict
         Query keyword arguments.
+    has_api_key : bool
+        Whether or not user used api key.
 
     Returns
     -------
@@ -95,6 +99,9 @@ def apply_time_filters(params: dict, query_kwargs: dict) -> tuple:
 
     start = start_dt.strftime("%Y-%m-%dT%H:%M:%S")
     end = end_dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+    if not has_api_key and start < PUBLIC_CUTOFF_UTC:
+        raise BadTimeError("API key required for data prior to 2026-02-01T00:00:00")
 
     key_expr &= Key("time_utc").between(start, end)
     query_kwargs["KeyConditionExpression"] = key_expr
@@ -197,6 +204,7 @@ def lambda_handler(event, context):
     auth = request_ctx.get("authorizer", {})
     auth_ctx = auth.get("lambda", {})
     scope = auth_ctx.get("scope", "")
+    has_api_key = bool(auth)
 
     # --- Determine key condition ---
     allowed_params = {
@@ -245,7 +253,7 @@ def lambda_handler(event, context):
 
         try:
             query_kwargs, range_start, range_end = apply_time_filters(
-                params, query_kwargs
+                params, query_kwargs, has_api_key
             )
         except BadTimeError as e:
             return _error(400, str(e))

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -171,10 +171,7 @@ def filter_items_by_scope(items: list[dict], scope: str) -> list[dict]:
         return items
 
     filtered_items = [
-        {k: v for k, v in item.items() if k not in RESTRICTED_FIELDS}
-        if item.get("instrument") == "hit"
-        else item
-        for item in items
+        {k: v for k, v in item.items() if k not in RESTRICTED_FIELDS} for item in items
     ]
 
     return filtered_items
@@ -277,12 +274,12 @@ def lambda_handler(event, context):
             f"{range_end} took {t2 - t1} s"
         )
         raw_items = response.get("Items", [])
+        if instrument == "hit":
+            raw_items = filter_items_by_scope(raw_items, scope)
         items.extend(raw_items)
         query_time_total += t2 - t1
 
     t3 = time.perf_counter()
-
-    items = filter_items_by_scope(items, scope)
 
     json_body = json.dumps(
         {

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -35,6 +35,7 @@ from imap_processing.spice.geometry import (
 )
 from imap_processing.spice.time import (
     et_to_met,
+    et_to_ttj2000ns,
     met_to_sclkticks,
     met_to_ttj2000ns,
     met_to_utc,
@@ -569,6 +570,7 @@ def insert_formatted_data(
     spacecraft = {
         "instrument": "spacecraft",
         "time_utc": min_time,
+        "ttj2000ns": int(et_to_ttj2000ns(et)),
         "sc_position_GSM": [Decimal(str(val)) for val in gsm_state[0, :3]],
         "sc_velocity_GSM": [Decimal(str(val)) for val in gsm_state[0, 3:]],
         "sc_position_GSE": [Decimal(str(val)) for val in gse_state[0, :3]],

--- a/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
+++ b/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
@@ -8,7 +8,7 @@ dynamodb = boto3.resource("dynamodb")
 table = dynamodb.Table("imap-sdc-api-keys")
 
 
-def lambda_handler(event, context):  # noqa: PLR0911
+def lambda_handler(event, context):
     """Get the API Key from the request header and check if it is valid."""
     api_key = event.get("headers", {}).get("x-api-key", None)
 
@@ -35,13 +35,7 @@ def lambda_handler(event, context):  # noqa: PLR0911
         "ialirt_scientist",
     ):
         return {"isAuthorized": False}
-    if path.startswith("/space-weather") and scope not in (
-        "ialirt_db",
-        "full",
-        "ialirt_external_partner",
-        "ialirt_scientist",
-    ):
-        return {"isAuthorized": False}
+
     if path.startswith("/ialirt-download") and scope not in (
         "full",
         "ialirt_external_partner",

--- a/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
+++ b/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
@@ -49,4 +49,10 @@ def lambda_handler(event, context):  # noqa: PLR0911
     ):
         return {"isAuthorized": False}
 
-    return {"isAuthorized": True, "context": {"apiKey": api_key}}
+    return {
+        "isAuthorized": True,
+        "context": {
+            "apiKey": api_key,
+            "scope": scope,
+        },
+    }

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -307,3 +307,35 @@ def test_process_item_types(ialirt_data_query_api_module):
             "mag_hk_status": {"pri_isvalid": True, "hkn8v5": 3680},
         }
     ]
+
+
+def test_filter_items_by_scope_restricted(ialirt_data_query_api_module):
+    """Test filter_items_by_scope_restricted."""
+    filter_items = ialirt_data_query_api_module.filter_items_by_scope
+
+    # Input items
+    items = [
+        {
+            "instrument": "hit",
+            "hit_h_a_side_low_en": 10,
+            "hit_h_a_side_med_en": 20,
+            "hit_e_a_side_med_en": 30,  # should remain
+            "time_utc": "2025-11-22T05:30:00",
+        },
+        {
+            "instrument": "mag",
+            "Bx": 1.0,
+            "By": 2.0,
+        },
+    ]
+
+    filtered_items = filter_items(items, scope="")  # restricted user
+
+    expected_hit_items = {
+        "instrument": "hit",
+        "hit_e_a_side_med_en": 30,
+        "time_utc": "2025-11-22T05:30:00",
+    }
+
+    assert filtered_items[1] == items[1]
+    assert filtered_items[0] == expected_hit_items

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -5,6 +5,7 @@ import json
 import os
 from datetime import datetime, timezone
 from decimal import Decimal
+from unittest import mock
 
 import pytest
 from boto3.dynamodb.conditions import Key
@@ -19,22 +20,22 @@ def data_table(setup_data_table):
     sample_data = [
         {
             "instrument": "mag",
-            "time_utc": "2021-01-01T00:00:00",
+            "time_utc": "2027-01-01T00:00:00",
             "data": "item1",
         },
         {
             "instrument": "mag_hk",
-            "time_utc": "2021-01-02T00:00:00",
+            "time_utc": "2027-01-02T00:00:00",
             "data": "item2",
         },
         {
             "instrument": "hit",
-            "time_utc": "2021-01-03T00:00:00",
+            "time_utc": "2027-01-03T00:00:00",
             "data": "item3",
         },
         {
             "instrument": "spice",
-            "time_utc": "2021-01-04T00:00:00",
+            "time_utc": "2027-01-04T00:00:00",
             "data": "item4",
         },
         {
@@ -101,7 +102,7 @@ def test_apply_time_filters_between(ialirt_data_query_api_module):
     query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
 
     # Call the function
-    ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
+    ialirt_data_query_api_module.apply_time_filters(params, query_kwargs, True)
 
     # Get internal structure
     expr = query_kwargs["KeyConditionExpression"]
@@ -131,7 +132,7 @@ def test_apply_time_filters_gte(ialirt_data_query_api_module):
     params = {"time_utc_start": "2025-10-01T10:00:00Z"}
     query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
 
-    ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
+    ialirt_data_query_api_module.apply_time_filters(params, query_kwargs, True)
 
     # Inspect the internal structure of the KeyConditionExpression
     expr = query_kwargs["KeyConditionExpression"]
@@ -158,7 +159,7 @@ def test_apply_time_filters_error(ialirt_data_query_api_module):
     params = {"time_utc_end": "2025-10-01T11:00:00Z"}
     query_kwargs = {"KeyConditionExpression": Key("instrument").eq("hit")}
 
-    result = ialirt_data_query_api_module.apply_time_filters(params, query_kwargs)
+    result = ialirt_data_query_api_module.apply_time_filters(params, query_kwargs, True)
 
     # This should be an error dict
     assert result[1] == "2025-10-01T10:00:00"
@@ -170,8 +171,8 @@ def test_query_with_utc_range(data_table, ialirt_data_query_api_module):
     # met_in_utc_end=<met_in_utc_end>
     event = {
         "queryStringParameters": {
-            "met_in_utc_start": "2021-01-01T00:00:00",
-            "met_in_utc_end": "2021-01-03T00:00:00",
+            "met_in_utc_start": "2027-01-01T00:00:00",
+            "met_in_utc_end": "2027-01-03T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
@@ -184,7 +185,7 @@ def test_query_with_utc_start(data_table, ialirt_data_query_api_module):
     # GET <invoke url>/query?utc_start=<utc_start>
     event = {
         "queryStringParameters": {
-            "met_in_utc_start": "2021-01-03T00:00:00",
+            "met_in_utc_start": "2027-01-03T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
@@ -192,7 +193,7 @@ def test_query_with_utc_start(data_table, ialirt_data_query_api_module):
 
     utc = sorted(data["time_utc"] for data in items["data"])
 
-    assert "2021-01-03T00:00:00" in utc
+    assert "2027-01-03T00:00:00" in utc
 
 
 def test_query_with_utc_end(data_table, ialirt_data_query_api_module):
@@ -200,12 +201,12 @@ def test_query_with_utc_end(data_table, ialirt_data_query_api_module):
     # GET <invoke url>/query?met_in_utc_end=<met_in_utc_end>
     event = {
         "queryStringParameters": {
-            "met_in_utc_end": "2021-01-03T00:00:00",
+            "met_in_utc_end": "2027-01-03T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
     items = json.loads(response["body"])
-    assert items["data"][0]["time_utc"] == "2021-01-03T00:00:00"
+    assert items["data"][0]["time_utc"] == "2027-01-03T00:00:00"
 
 
 def test_query_results(data_table, ialirt_data_query_api_module):
@@ -213,7 +214,7 @@ def test_query_results(data_table, ialirt_data_query_api_module):
     # GET <invoke url>/query?met_start=<met_start>&met_end=<met_end>
     event = {
         "queryStringParameters": {
-            "met_in_utc_start": "2021-01-05T00:00:00",
+            "met_in_utc_start": "2027-01-05T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
@@ -223,11 +224,11 @@ def test_query_results(data_table, ialirt_data_query_api_module):
 
 def test_query_with_multiple_filters(data_table, ialirt_data_query_api_module):
     """Test query with multiple filters."""
-    # GET <invoke url>/query?instrument=mag&met_in_utc_start=2021-01-01T00:00:00
+    # GET <invoke url>/query?instrument=mag&met_in_utc_start=2027-01-01T00:00:00
     event = {
         "queryStringParameters": {
             "instrument": "mag",
-            "met_in_utc_start": "2021-01-01T00:00:00",
+            "met_in_utc_start": "2027-01-01T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
@@ -238,14 +239,14 @@ def test_query_with_multiple_filters(data_table, ialirt_data_query_api_module):
 
 def test_query_with_different_time_queries(data_table, ialirt_data_query_api_module):
     """Test query API with multiple filters."""
-    # GET <invoke url>/query?instrument=hit&time_utc_start=2021-01-02T00:00:00&
-    # time_utc_end=2021-01-03T00:00:00&
-    # met_in_utc_start=2021-01-02T00:00:00.
+    # GET <invoke url>/query?instrument=hit&time_utc_start=2027-01-02T00:00:00&
+    # time_utc_end=2027-01-03T00:00:00&
+    # met_in_utc_start=2027-01-02T00:00:00.
     event = {
         "queryStringParameters": {
-            "time_utc_start": "2021-01-02T00:00:00",
-            "time_utc_end": "2021-01-03T00:00:00",
-            "met_in_utc_start": "2021-01-02T00:00:00",
+            "time_utc_start": "2027-01-02T00:00:00",
+            "time_utc_end": "2027-01-03T00:00:00",
+            "met_in_utc_start": "2027-01-02T00:00:00",
         }
     }
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
@@ -268,13 +269,22 @@ def test_query_with_invalid_parameters(data_table, ialirt_data_query_api_module)
     assert json.loads(response["body"]) == expected_message
 
 
-def test_query_with_no_parameters(data_table, ialirt_data_query_api_module):
+@mock.patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_data_query_api.datetime")
+def test_query_with_no_parameters(
+    mock_datetime, data_table, ialirt_data_query_api_module
+):
     """Test query with no parameters."""
     # GET <invoke url>/query.
+    mock_datetime.now.return_value = datetime(2026, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
+
     event = {"queryStringParameters": None}
     response = ialirt_data_query_api_module.lambda_handler(event, context=None)
 
-    assert json.loads(response["body"])["data"][0]["instrument"] == "mag"
+    assert response == {
+        "statusCode": 400,
+        "body": '{"message": "API key required for data prior to 2026-02-01T00:00:00"}',
+        "headers": {"Content-Type": "application/json"},
+    }
 
 
 def test_process_item_types(ialirt_data_query_api_module):

--- a/tests/lambda_endpoints/test_ialirt_data_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_data_query_api.py
@@ -327,8 +327,8 @@ def test_filter_items_by_scope_restricted(ialirt_data_query_api_module):
     items = [
         {
             "instrument": "hit",
-            "hit_h_a_side_low_en": 10,
-            "hit_h_a_side_med_en": 20,
+            "hit_e_a_side_high_en": 10,
+            "hit_e_b_side_high_en": 20,
             "hit_e_a_side_med_en": 30,  # should remain
             "time_utc": "2025-11-22T05:30:00",
         },

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -330,7 +330,12 @@ def test_reformat_data_no_hk():
     "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.str_to_et",
     return_value=12345.0,
 )
+@patch(
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.et_to_ttj2000ns",
+    return_value=759175836184000000,
+)
 def test_insert_formatted_data(
+    mock_et_to_ttj2000ns,
     mock_str_to_et,
     mock_imap_state,
     setup_data_table,


### PR DESCRIPTION
# Change Summary

## Overview
Conceal certain HIT products and set public release date.

## Updated Files
- Minor docstring change
   - api_gateway_construct.py
- lambda_api_key_authorizer.py
   - Remove restrictions to database so that they are managed now by the lambda based on release date
- ialirt_data_query_api.py
   - Filters data products that the HIT team does not want to be released based on the scope of the api-key. Adds a release date so that users without an api key cannot see prior data.

## Testing
test_ialirt_data_query_api.py