### PR TITLE
ULTRA l1b - add l1a aux as dependency 

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1037,6 +1037,7 @@ spacecraft_clock, spice, historical, ultra, l1a, all, HARD_NO_TRIGGER, DOWNSTREA
 
 # Ultra-45 products
 ultra, l1a, 45sensor-de, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
+ultra, l1a, 45sensor-aux, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-params, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-rates, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-aux,ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
@@ -1137,6 +1138,7 @@ spin, spin, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTR
 
 # Ultra-90 products
 ultra, l1a, 90sensor-de, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
+ultra, l1a, 90sensor-aux, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-params, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-rates, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-aux,ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1083,10 +1083,12 @@ spin, spin, historical, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 
 ultra, l1b, 45sensor-de, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-rates, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, l1a, 45sensor-aux, ultra, l1b, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-params, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-goodtimes, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-de, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-rates, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
+ultra, l1a, 45sensor-aux, ultra, l1b, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-params, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-goodtimes, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 
@@ -1183,10 +1185,12 @@ spin, spin, historical, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
 
 ultra, l1b, 90sensor-de, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-rates, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, l1a, 90sensor-aux, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-params, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1b, 90sensor-goodtimes, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1b, 90sensor-de, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-rates, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
+ultra, l1a, 90sensor-aux, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-params, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1b, 90sensor-goodtimes, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1084,12 +1084,10 @@ spin, spin, historical, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-de, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-rates, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-aux, ultra, l1b, 45sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, l1a, 45sensor-params, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-goodtimes, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-de, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-rates, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-aux, ultra, l1b, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, l1a, 45sensor-params, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-goodtimes, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
@@ -1104,10 +1102,6 @@ ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-spa
 ultra, ancillary, l1b-45sensor-imgparams-lookup, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-static-dead-times, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-45sensor-sc-pointing-theta, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-45sensor-sc-pointing-phi, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-45sensor-sc-pointing-index, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-45sensor-sc-pointing-bsf, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
@@ -1186,12 +1180,10 @@ spin, spin, historical, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
 ultra, l1b, 90sensor-de, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-rates, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-aux, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, l1a, 90sensor-params, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1b, 90sensor-goodtimes, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, l1b, 90sensor-de, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-rates, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-aux, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, l1a, 90sensor-params, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1b, 90sensor-goodtimes, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
@@ -1206,10 +1198,6 @@ ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-spa
 ultra, ancillary, l1b-90sensor-imgparams-lookup, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-static-dead-times, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-90sensor-sc-pointing-theta, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-90sensor-sc-pointing-phi, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-90sensor-sc-pointing-index, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-90sensor-sc-pointing-bsf, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview
Add the aux dataset as a dependency to ultra l1b. This is used for the event time calculation. 

## Updated Files
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
   - Add aux product to ultra 45 and 90 l1b jobs

