### PR TITLE
Update timeout duration for batch jobs

### DIFF
--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -145,5 +145,5 @@ class ProcessingConstruct(Construct):
             f"ProcessingJob-{job_name}",
             job_definition_name=f"ProcessingJob-{job_name}",
             container=container_definition,
-            timeout=cdk.Duration.hours(2),
+            timeout=cdk.Duration.minutes(150),
         )

--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -145,5 +145,5 @@ class ProcessingConstruct(Construct):
             f"ProcessingJob-{job_name}",
             job_definition_name=f"ProcessingJob-{job_name}",
             container=container_definition,
-            timeout=cdk.Duration.minutes(150),
+            timeout=cdk.Duration.hours(3),
         )


### PR DESCRIPTION
# Change Summary
Some of the MAG L1D batch jobs are timing out. Our current timeout is 2 hours, the normal processing is 1.5 hours, so I wanted to see if it was taking just barely over 2 hours. If this timeout doesn't fix it, then I think the next step is checking on optimizations to make the processing faster. 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
- Move batch job timeout from 2 hours to 2.5 hours

Related to imap_processing issue [#2518](https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/2518)