### PR TITLE
Add required SPICE kernels to SWE L3 dependencies

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1028,6 +1028,9 @@ science_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
+planetary_ephemeris, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
+planetary_constants, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 
 # <---- ULTRA Dependencies ---->
 


### PR DESCRIPTION
# Change Summary

## Overview
We found that some SWE L3 calculations need additional kernels to be provided as dependencies.

## Updated Files
- dependency_config.csv
   - Add 3 new SPICE kernels as requirements for SWE L3