### PR TITLE
Update cadence job first trigger date

### DIFF
--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -157,8 +157,9 @@ class BatchStarterLambda(Construct):
         #    - 1 year map jobs (every 365.25 days)
         # Note: each map job trigger will have its own eventBridge rule, because we need
         # them to run every x days starting from the same date (t0).
-        # TODO what would be a good start date?
-        first_job = datetime.datetime(2026, 1, 1)
+        # TODO First job date should be 3 months after phase e start date.
+        #   TODO determine exact phase e start date.
+        first_job = datetime.datetime(2026, 5, 1)
         t0_date = first_job - datetime.timedelta(days=CadenceDays.THREE_MONTHS)
         today = datetime.datetime.now()
         # Create rules for 15 years (far beyond what we expect as a precaution)


### PR DESCRIPTION
# Change Summary

## Overview
Currently the first map job is scheduled to trigger on jan 1st. It should actually be three months after the start of phase E. I am not sure exactly what that date is, but for now this PR pushes the start date out until we can determine the correct date. 

## Updated Files
-sds_data_manager/constructs/instrument_lambdas.py
   - Update the first cadence job start date
