### PR TITLE
Add new ancillary dependencies for SWAPI L3a

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -964,6 +964,8 @@ swapi, ancillary, energy-gf-pui-lut, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWN
 swapi, ancillary, instrument-response-lut, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, efficiency-lut, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
+swapi, ancillary, helium-inflow-vector, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
 
 swapi, l2, sci, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 swapi, ancillary, clock-angle-and-flow-deflection-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
@@ -973,6 +975,8 @@ swapi, ancillary, energy-gf-pui-lut, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOW
 swapi, ancillary, instrument-response-lut, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, efficiency-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
+swapi, ancillary, helium-inflow-vector, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
@@ -989,6 +993,8 @@ swapi, ancillary, energy-gf-pui-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, instrument-response-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, efficiency-lut, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
+swapi, ancillary, helium-inflow-vector, swapi, l3a, pui-he, HARD, DOWNSTREAM
+swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, pui-he, HARD, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary
Added new ancillary dependencies "helium-inflow-vector" and "hydrogen-inflow-vector" for all SWAPI L3a processing. The ancillaries are not used in proton-sw, and alpha-sw, but will cause the processor the fail if they are not present, so we have marked those as HARD_NO_TRIGGER. The files are required and used in calculations for the pui-he product.

## Updated Files
- dependency_config.csv
  - Added new ancillary dependencies "helium-inflow-vector" and "hydrogen-inflow-vector" for all SWAPI L3a processing
