### PR TITLE
MNT: Increase ephemeral storage of packet downloader

### DIFF
--- a/sds_data_manager/constructs/packet_downloader_lambda_construct.py
+++ b/sds_data_manager/constructs/packet_downloader_lambda_construct.py
@@ -68,6 +68,9 @@ class PacketDownloaderLambda(Construct):
             # We are downloading data, so make sure we have a longer timeout here
             timeout=cdk.Duration.minutes(15),
             memory_size=2048,
+            # Some packet files can be large depending on how long it has been since
+            # the last downlink. Increase the ephemeral /tmp size to accomodate this.
+            ephemeral_storage_size=cdk.Size.gibibytes(2),
             # Environment variables - API key will be retrieved from SSM at runtime
             environment={
                 "IMAP_DATA_ACCESS_URL": data_access_url,


### PR DESCRIPTION
# Change Summary

Increase size of /tmp storage for packet downloader since we've had intermittent failures with disk space getting taken up.

closes #1051
