### PR TITLE
MNT: Add more derates dependencies

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -742,6 +742,11 @@ lo, l1a, histogram, lo, l1b, monitorrates, HARD, DOWNSTREAM
 lo, l1a, spin, lo, l1b, monitorrates, HARD, DOWNSTREAM
 lo, l1a, histogram, lo, l1b, histogramrates, HARD, DOWNSTREAM
 lo, l1a, spin, lo, l1b, histogramrates, HARD, DOWNSTREAM
+repoint, repoint, historical, lo, l1b, derates, HARD, DOWNSTREAM
+spacecraft_clock, spice, historical, lo, l1b, de, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, lo, l1b, de, HARD_NO_TRIGGER, DOWNSTREAM
+lo, ancillary, sweep-table, lo, l1b, derates, HARD, DOWNSTREAM
+lo, ancillary, esa-mode-lut, lo, l1b, derates, HARD, DOWNSTREAM
 lo, l1b, de, lo, l1b, derates, HARD, DOWNSTREAM
 lo, l1a, spin, lo, l1b, derates, HARD, DOWNSTREAM
 lo, l1b, nhk, lo, l1b, derates, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -743,8 +743,8 @@ lo, l1a, spin, lo, l1b, monitorrates, HARD, DOWNSTREAM
 lo, l1a, histogram, lo, l1b, histogramrates, HARD, DOWNSTREAM
 lo, l1a, spin, lo, l1b, histogramrates, HARD, DOWNSTREAM
 repoint, repoint, historical, lo, l1b, derates, HARD, DOWNSTREAM
-spacecraft_clock, spice, historical, lo, l1b, de, HARD_NO_TRIGGER, DOWNSTREAM
-leapseconds, spice, historical, lo, l1b, de, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, lo, l1b, derates, HARD_NO_TRIGGER, DOWNSTREAM
+leapseconds, spice, historical, lo, l1b, derates, HARD_NO_TRIGGER, DOWNSTREAM
 lo, ancillary, sweep-table, lo, l1b, derates, HARD, DOWNSTREAM
 lo, ancillary, esa-mode-lut, lo, l1b, derates, HARD, DOWNSTREAM
 lo, l1b, de, lo, l1b, derates, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

I finally had something I could test with locally, so I was editing the command locally with dependencies until it failed to find the minimal set. I think this is it currently. We could review later if we actually need all of these because I don't quite understand why the other rates products don't need these.

Additionally, the current ancillary file in production was called `esa-mod-lut` with a missing "e", so I re-uploaded that as `esa-mode-lut` so that it works as expected within all the code trying to grab that ancillary dependency.