### PR TITLE
I-ALiRT quick bugfix with API

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -47,7 +47,7 @@ class DecimalEncoder(json.JSONEncoder):
         if isinstance(obj, Decimal):
             # - If the Decimal is an integer, return int
             # - Otherwise, float rounded to 3 decimal places
-            if obj % 1 == 0:
+            if obj == obj.to_integral_value():
                 return int(obj)
             return round(float(obj), 3)
 


### PR DESCRIPTION
# Change Summary

## Overview
I-ALiRT quick bugfix with API - 

**Had this error:**
obj = Decimal("-1E31")
obj % 1
Traceback (most recent call last):
  File "<input>", line 1, in <module>
decimal.InvalidOperation: [<class 'decimal.DivisionImpossible'>]

**Changed it to:**
obj.to_integral_value()
Decimal('-1E+31')