### PR TITLE
MNT: Add ephemeris dependency to lo pointing set

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -764,7 +764,7 @@ lo, ancillary, esa-mode-lut, lo, l1b, derates, HARD, DOWNSTREAM
 
 lo, l1a, star, lo, l1b, prostar, HARD, DOWNSTREAM
 lo, l1b, nhk, lo, l1b, prostar, HARD, DOWNSTREAM
-spin, spin, historical, lo, l1b, prostar, HARD, DOWNSTREAM
+lo, l1b, spin, lo, l1b, prostar, HARD, DOWNSTREAM
 repoint, repoint, historical, lo, l1b, prostar, HARD, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1b, derates, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, lo, l1b, derates, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -782,6 +782,9 @@ imap_frames, spice, historical, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM
 pointing_attitude, spice, historical, lo, l1c, pset, HARD, DOWNSTREAM
 science_frames, spice, historical, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM
+ephemeris_reconstructed, spice, historical, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM
+ephemeris_predicted, spice, best, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM
+ephemeris_90days, spice, best, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM
 
 # TODO: Maps for 5-7 days need to be defined. deg resolution for those maps are currently N/A in Lo mapping product sheet.
 


### PR DESCRIPTION
# Change Summary

Adding ephemeris. Do we want to have the reconstructed version as a hard dependency if that would cause a delay in 2 weeks? Or do we want to remove that and just go with the best available predicts which should be fine.