### PR TITLE
I-ALiRT - api update

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -187,10 +187,18 @@ class IalirtApiManager(Construct):
         )
 
         add_stable_route(
-            api, "/ialirt-download", "GET", download_api, restricted_route_prefixes
+            api,
+            "/ialirt-download",
+            "GET",
+            download_api,
+            ["", "/authorized", "/api-key"],
         )
         add_stable_route(
-            api, "/ialirt-download", "HEAD", download_api, restricted_route_prefixes
+            api,
+            "/ialirt-download",
+            "HEAD",
+            download_api,
+            ["", "/authorized", "/api-key"],
         )
 
         # catalog API lambda

--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -191,14 +191,14 @@ class IalirtApiManager(Construct):
             "/ialirt-download",
             "GET",
             download_api,
-            ["", "/authorized", "/api-key"],
+            auth_route_prefixes,
         )
         add_stable_route(
             api,
             "/ialirt-download",
             "HEAD",
             download_api,
-            ["", "/authorized", "/api-key"],
+            auth_route_prefixes,
         )
 
         # catalog API lambda

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/download_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/download_api.py
@@ -132,6 +132,14 @@ def lambda_handler(event, context):
     region = os.getenv("REGION")
     filepath = path_params
 
+    if not is_authenticated_user(event) and (
+        filepath.startswith("logs/") or filepath.startswith("packets/")
+    ):
+        return http_response(
+            status_code=403,
+            body="I-ALiRT logs and packet data are not publicly downloadable.",
+        )
+
     # The default presigned url signature does not include the region information
     # within the signature and we should be hitting the actual s3 region endpoint
     # to avoid any 307 redirects. (Generally only an issue on newly created buckets


### PR DESCRIPTION
# Change Summary

## Overview
I would like to make all I-ALiRT downloads public except logs and packets. In those cases I want to use the api_keys.

## Updated Files
- ialirt_api_manager_construct.py
   - Add "" to stable route so public can access the data
- download_api.py
   - Check for authenticated if logs or packets