### PR TITLE
I-ALiRT - open database to public

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -281,5 +281,5 @@ class IalirtApiManager(Construct):
             "/space-weather",
             "GET",
             ialirt_db_query_formatted_handler,
-            restricted_route_prefixes,
+            auth_route_prefixes,
         )


### PR DESCRIPTION
# Change Summary

## Overview
This opens the database to the public (note the lambda takes care of credentials so HK, data before Feb 1, and certain HIT products are restricted still)

