### PR TITLE
Update cadence job triggering

### DIFF
--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -167,14 +167,17 @@ class BatchStarterLambda(Construct):
         # expression. E.g., we cannot specify "rate(91.2 days)" for 3 months.
         # TODO First job date should be 3 months after phase e start date.
         #   TODO determine exact phase e start date.
-        first_job = datetime.datetime(2026, 5, 1)
+        first_map_jobs = datetime.datetime(2026, 5, 1)
+        # 1mo jobs are not map jobs. We want them to start earlier. E.g. IDEX l2b is
+        # a 1 month cadence job.
+        first_1mo_jobs = datetime.datetime(2026, 1, 1)
         today = datetime.datetime.now()
         cadence_strs = ["1mo", "3mo", "6mo", "1yr"]
         for cadence_str in cadence_strs:
             cadence = CadenceDays.str_lookup(cadence_str)
             # Calculate interval in minutes
             interval_minutes = int(cadence.value * 24 * 60)
-
+            first_job = first_1mo_jobs if cadence_str == "1mo" else first_map_jobs
             # Calculate the next run time based on the first job date and the cadence
             next_run = calculate_next_run(first_job, today, interval_minutes)
             scheduler.CfnSchedule(

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -2,12 +2,16 @@
 
 import datetime
 
-import aws_cdk as cdk
-from aws_cdk import Duration, Environment, aws_events
+from aws_cdk import Duration, Environment
 from aws_cdk import aws_ec2 as ec2
-from aws_cdk import aws_iam as iam
+from aws_cdk import (
+    aws_iam as iam,
+)
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_s3 as s3
+from aws_cdk import (
+    aws_scheduler as scheduler,
+)
 from aws_cdk import aws_secretsmanager as secrets
 from aws_cdk import aws_sqs as sqs
 from aws_cdk.aws_lambda_event_sources import SqsEventSource
@@ -137,103 +141,95 @@ class BatchStarterLambda(Construct):
         )
 
         # Set up eventBridge rules to trigger batch starter lambda.
-        # create one permission for Cadence rules and one for Scheduled rules
-        self.instrument_lambda.add_permission(
-            "AllowEventBridgeInvokeCadence",
-            principal=iam.ServicePrincipal("events.amazonaws.com"),
-            action="lambda:InvokeFunction",
-            source_arn=f"arn:aws:events:{env.region}:{env.account}:rule/ProcessingCadenceJob*",
-        )
+        # create a permission for Scheduled rules
         self.instrument_lambda.add_permission(
             "AllowEventBridgeInvokeScheduled",
             principal=iam.ServicePrincipal("events.amazonaws.com"),
             action="lambda:InvokeFunction",
             source_arn=f"arn:aws:events:{env.region}:{env.account}:rule/ProcessingScheduledJob*",
         )
+        # Create IAM role for EventBridge Scheduler
+        scheduler_role = iam.Role(
+            scope=scope,
+            id="SchedulerExecutionRole",
+            assumed_by=iam.ServicePrincipal("scheduler.amazonaws.com"),
+        )
+
+        self.instrument_lambda.grant_invoke(scheduler_role)
+
         # Many l2 jobs create maps and need 3-12 months worth of data to run.
         # Create eventBridge rules to trigger:
         #    - 3 month map jobs (every 365.25 / 4 days)
         #    - 6 month map jobs (every 365.25 / 2 days)
         #    - 1 year map jobs (every 365.25 days)
-        # Note: each map job trigger will have its own eventBridge rule, because we need
-        # them to run every x days starting from the same date (t0).
+        # Note: We are defining the schedules to run at minute-level intervals because
+        # AWS EventBridge Scheduler does not allow for decimal values in the rate
+        # expression. E.g., we cannot specify "rate(91.2 days)" for 3 months.
         # TODO First job date should be 3 months after phase e start date.
         #   TODO determine exact phase e start date.
         first_job = datetime.datetime(2026, 5, 1)
-        t0_date = first_job - datetime.timedelta(days=CadenceDays.THREE_MONTHS)
         today = datetime.datetime.now()
-        # Create rules for 15 years (far beyond what we expect as a precaution)
-        # AWS event bridge supports up to 500 rules, so this is well within the limit.
-        total_days = CadenceDays.ONE_YEAR * 15
-        for i in range(1, int(total_days // CadenceDays.THREE_MONTHS.value)):
-            date = t0_date + datetime.timedelta(days=CadenceDays.THREE_MONTHS.value * i)
-            if date < today:
-                # Skip dates that are in the past. This might be the case if we are
-                # deploying this construct after the t0_date.
-                continue
-            string_date = date.strftime("%Y%m%d")
-            cron_exp = (
-                f"cron({date.minute} {date.hour} {date.day} {date.month} ? {date.year})"
-            )
-            # TODO retry count is set to 185???
-            aws_events.CfnRule(
+        cadence_strs = ["1mo", "3mo", "6mo", "1yr"]
+        for cadence_str in cadence_strs:
+            cadence = CadenceDays.str_lookup(cadence_str)
+            # Calculate interval in minutes
+            interval_minutes = int(cadence.value * 24 * 60)
+
+            # Calculate the next run time based on the first job date and the cadence
+            next_run = calculate_next_run(first_job, today, interval_minutes)
+            scheduler.CfnSchedule(
                 scope=scope,
-                id=f"ProcessingCadenceJob3month_{string_date}",
-                name=f"ProcessingCadenceJob3month_{string_date}",
-                description=f"Trigger 'batch starter' processing job on {string_date}",
-                schedule_expression=cron_exp,
+                id=f"ProcessingCadenceJob_{cadence.name}",
+                name=f"ProcessingCadenceJob_{cadence.name}",
+                schedule_expression=f"rate({interval_minutes} minutes)",
+                # Start the schedule at the next calculated occurrence
+                start_date=next_run.strftime("%Y-%m-%dT%H:%M:%S"),
+                flexible_time_window=scheduler.CfnSchedule.FlexibleTimeWindowProperty(
+                    mode="OFF"
+                ),
+                target=scheduler.CfnSchedule.TargetProperty(
+                    arn=self.instrument_lambda.function_arn,
+                    role_arn=scheduler_role.role_arn,
+                    input=f'{{"cadence": "{cadence_str}"}}',
+                    retry_policy=scheduler.CfnSchedule.RetryPolicyProperty(
+                        maximum_retry_attempts=185
+                    ),
+                ),
                 state="ENABLED",
-                targets=[
-                    aws_events.CfnRule.TargetProperty(
-                        arn=self.instrument_lambda.function_arn,
-                        id=f"Target{string_date}",
-                        input=cdk.Fn.sub('{"cadence": "3mo"}'),
-                    )
-                ],
             )
-        for i in range(1, int(total_days // CadenceDays.SIX_MONTHS.value)):
-            date = t0_date + datetime.timedelta(days=CadenceDays.SIX_MONTHS.value * i)
-            string_date = date.strftime("%Y%m%d")
-            if date < today:
-                continue
-            cron_exp = (
-                f"cron({date.minute} {date.hour} {date.day} {date.month} ? {date.year})"
-            )
-            aws_events.CfnRule(
-                scope=scope,
-                id=f"ProcessingCadenceJob6month_{string_date}",
-                name=f"ProcessingCadenceJob6month_{string_date}",
-                description=f"Trigger 'batch starter' processing job on {string_date}",
-                schedule_expression=cron_exp,
-                state="ENABLED",
-                targets=[
-                    aws_events.CfnRule.TargetProperty(
-                        arn=self.instrument_lambda.function_arn,
-                        id=f"Target{string_date}",
-                        input=cdk.Fn.sub('{"cadence": "6mo"}'),
-                    )
-                ],
-            )
-        for i in range(1, int(total_days // CadenceDays.ONE_YEAR.value)):
-            date = t0_date + datetime.timedelta(days=CadenceDays.ONE_YEAR.value * i)
-            string_date = date.strftime("%Y%m%d")
-            if date < today:
-                continue
-            cron_exp = (
-                f"cron({date.minute} {date.hour} {date.day} {date.month} ? {date.year})"
-            )
-            aws_events.CfnRule(
-                scope=scope,
-                id=f"ProcessingCadenceJob1year_{string_date}",
-                name=f"ProcessingCadenceJob1year_{string_date}",
-                description=f"Trigger 'batch starter' processing job on {string_date}",
-                schedule_expression=cron_exp,
-                state="ENABLED",
-                targets=[
-                    aws_events.CfnRule.TargetProperty(
-                        arn=self.instrument_lambda.function_arn,
-                        id=f"Target{string_date}",
-                        input=cdk.Fn.sub('{"cadence": "1yr"}'),
-                    )
-                ],
-            )
+
+
+def calculate_next_run(first_job, today, interval_minutes):
+    """Calculate the next run time for a scheduled job.
+
+    This function is necessary because AWS EventBridge Scheduler does not support
+    starting a schedule at a date in the past. Therefore, we need to calculate
+    the next occurrence of the schedule if we are already past the "first job" date.
+
+    Parameters
+    ----------
+    first_job : datetime.datetime
+        The date of the first job.
+    today : datetime.datetime
+        The current date.
+    interval_minutes : int
+        The interval in minutes for the cadence.
+
+    Returns
+    -------
+    datetime.datetime
+        The next run date.
+    """
+    # If today is before the first job, return the first job date as the next run date
+    if today < first_job:
+        return first_job
+    else:
+        # Calculate how many minutes have passed since the first job
+        delta = (today - first_job).total_seconds() / 60
+        # Calculate how many cadence events have passed since the first job
+        events_passed = int(delta // interval_minutes)
+        # Calculate the next run date
+        next_run = first_job + datetime.timedelta(
+            minutes=(events_passed + 1) * interval_minutes
+        )
+        return next_run

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -165,7 +165,7 @@ class BatchStarterLambda(Construct):
         # Note: We are defining the schedules to run at minute level intervals because
         # AWS EventBridge Scheduler does not allow for decimal values in the rate
         # expression. E.g., we cannot specify "rate(91.2 days)" for 3 months.
-        phase_e_start_date = datetime.datetime(2026, 2, 0, tzinfo=datetime.timezone.utc)
+        phase_e_start_date = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
         first_map_jobs = phase_e_start_date + datetime.timedelta(
             days=CadenceDays.THREE_MONTHS.value
         )
@@ -183,6 +183,17 @@ class BatchStarterLambda(Construct):
             next_run = calculate_next_run(first_job, today, interval_minutes)
             # Format date as yyyy-MM-ddTHH:mm:ss.SSSZ (with milliseconds)
             start_date_str = next_run.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+            # Create a dead letter queue for failed scheduled events
+            dlq = sqs.Queue(
+                self,
+                f"DLQ_{cadence_obj.name.lower()}",
+                queue_name=f"ProcessingCadenceJob_{cadence_obj.name.lower()}_failed_jobs_dlq",
+            )
+            # Grand permissions to allow scheduler to send messages to the DLQ
+            # TODO set up an alarm for the DLQ so that we are notified if there are
+            #  failed scheduled events
+            dlq.grant_send_messages(scheduler_role)
             scheduler.CfnSchedule(
                 scope=scope,
                 id=f"ProcessingCadenceJob_{cadence_obj.name.lower()}",
@@ -196,9 +207,12 @@ class BatchStarterLambda(Construct):
                 target=scheduler.CfnSchedule.TargetProperty(
                     arn=self.instrument_lambda.function_arn,
                     role_arn=scheduler_role.role_arn,
+                    dead_letter_config=scheduler.CfnSchedule.DeadLetterConfigProperty(
+                        dlq.queue_arn
+                    ),
                     input=f'{{"cadence": "{label}"}}',
                     retry_policy=scheduler.CfnSchedule.RetryPolicyProperty(
-                        maximum_retry_attempts=185
+                        maximum_retry_attempts=10
                     ),
                 ),
                 state="ENABLED",

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -167,11 +167,11 @@ class BatchStarterLambda(Construct):
         # expression. E.g., we cannot specify "rate(91.2 days)" for 3 months.
         # TODO First job date should be 3 months after phase e start date.
         #   TODO determine exact phase e start date.
-        first_map_jobs = datetime.datetime(2026, 5, 1)
+        first_map_jobs = datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc)
         # 1mo jobs are not map jobs. We want them to start earlier. E.g. IDEX l2b is
         # a 1 month cadence job.
-        first_1mo_jobs = datetime.datetime(2026, 1, 1)
-        today = datetime.datetime.now()
+        first_1mo_jobs = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        today = datetime.datetime.now(tz=datetime.timezone.utc)
         cadence_strs = ["1mo", "3mo", "6mo", "1yr"]
         for cadence_str in cadence_strs:
             cadence = CadenceDays.str_lookup(cadence_str)
@@ -180,13 +180,15 @@ class BatchStarterLambda(Construct):
             first_job = first_1mo_jobs if cadence_str == "1mo" else first_map_jobs
             # Calculate the next run time based on the first job date and the cadence
             next_run = calculate_next_run(first_job, today, interval_minutes)
+            # Format date as yyyy-MM-ddTHH:mm:ss.SSSZ (with milliseconds)
+            start_date_str = next_run.strftime("%Y-%m-%dT%H:%M:%S.000Z")
             scheduler.CfnSchedule(
                 scope=scope,
-                id=f"ProcessingCadenceJob_{cadence.name}",
-                name=f"ProcessingCadenceJob_{cadence.name}",
+                id=f"ProcessingCadenceJob_{cadence.name.lower()}",
+                name=f"ProcessingCadenceJob_{cadence.name.lower()}",
                 schedule_expression=f"rate({interval_minutes} minutes)",
                 # Start the schedule at the next calculated occurrence
-                start_date=next_run.strftime("%Y-%m-%dT%H:%M:%S"),
+                start_date=start_date_str,
                 flexible_time_window=scheduler.CfnSchedule.FlexibleTimeWindowProperty(
                     mode="OFF"
                 ),

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -172,7 +172,7 @@ class BatchStarterLambda(Construct):
         # a 1 month cadence job.
         first_1mo_jobs = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
         today = datetime.datetime.now(tz=datetime.timezone.utc)
-        cadence_strs = ["1mo", "3mo", "6mo", "1yr"]
+        cadence_strs = CadenceDays.str_lookup()
         for cadence_str in cadence_strs:
             cadence = CadenceDays.str_lookup(cadence_str)
             # Calculate interval in minutes

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -208,7 +208,7 @@ class BatchStarterLambda(Construct):
                     arn=self.instrument_lambda.function_arn,
                     role_arn=scheduler_role.role_arn,
                     dead_letter_config=scheduler.CfnSchedule.DeadLetterConfigProperty(
-                        dlq.queue_arn
+                        arn=dlq.queue_arn
                     ),
                     input=f'{{"cadence": "{label}"}}',
                     retry_policy=scheduler.CfnSchedule.RetryPolicyProperty(

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -172,20 +172,20 @@ class BatchStarterLambda(Construct):
         # a 1 month cadence job.
         first_1mo_jobs = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
         today = datetime.datetime.now(tz=datetime.timezone.utc)
-        cadence_strs = CadenceDays.str_lookup()
-        for cadence_str in cadence_strs:
-            cadence = CadenceDays.str_lookup(cadence_str)
+        # loop through dictionary of cadence labels and their corresponding CadenceDays
+        # enum objects
+        for label, cadence_obj in CadenceDays.str_lookup().items():
             # Calculate interval in minutes
-            interval_minutes = int(cadence.value * 24 * 60)
-            first_job = first_1mo_jobs if cadence_str == "1mo" else first_map_jobs
+            interval_minutes = int(cadence_obj.value * 24 * 60)
+            first_job = first_1mo_jobs if label == "1mo" else first_map_jobs
             # Calculate the next run time based on the first job date and the cadence
             next_run = calculate_next_run(first_job, today, interval_minutes)
             # Format date as yyyy-MM-ddTHH:mm:ss.SSSZ (with milliseconds)
             start_date_str = next_run.strftime("%Y-%m-%dT%H:%M:%S.000Z")
             scheduler.CfnSchedule(
                 scope=scope,
-                id=f"ProcessingCadenceJob_{cadence.name.lower()}",
-                name=f"ProcessingCadenceJob_{cadence.name.lower()}",
+                id=f"ProcessingCadenceJob_{cadence_obj.name.lower()}",
+                name=f"ProcessingCadenceJob_{cadence_obj.name.lower()}",
                 schedule_expression=f"rate({interval_minutes} minutes)",
                 # Start the schedule at the next calculated occurrence
                 start_date=start_date_str,
@@ -195,7 +195,7 @@ class BatchStarterLambda(Construct):
                 target=scheduler.CfnSchedule.TargetProperty(
                     arn=self.instrument_lambda.function_arn,
                     role_arn=scheduler_role.role_arn,
-                    input=f'{{"cadence": "{cadence_str}"}}',
+                    input=f'{{"cadence": "{label}"}}',
                     retry_policy=scheduler.CfnSchedule.RetryPolicyProperty(
                         maximum_retry_attempts=185
                     ),

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -162,12 +162,13 @@ class BatchStarterLambda(Construct):
         #    - 3 month map jobs (every 365.25 / 4 days)
         #    - 6 month map jobs (every 365.25 / 2 days)
         #    - 1 year map jobs (every 365.25 days)
-        # Note: We are defining the schedules to run at minute-level intervals because
+        # Note: We are defining the schedules to run at minute level intervals because
         # AWS EventBridge Scheduler does not allow for decimal values in the rate
         # expression. E.g., we cannot specify "rate(91.2 days)" for 3 months.
-        # TODO First job date should be 3 months after phase e start date.
-        #   TODO determine exact phase e start date.
-        first_map_jobs = datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc)
+        phase_e_start_date = datetime.datetime(2026, 2, 0, tzinfo=datetime.timezone.utc)
+        first_map_jobs = phase_e_start_date + datetime.timedelta(
+            days=CadenceDays.THREE_MONTHS.value
+        )
         # 1mo jobs are not map jobs. We want them to start earlier. E.g. IDEX l2b is
         # a 1 month cadence job.
         first_1mo_jobs = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -115,7 +115,7 @@ class CadenceDays(float, Enum):
         return VALID_CADENCE_STRS
 
     @classmethod
-    def str_lookup(cls, cadence_str: Optional[str]):
+    def str_lookup(cls, cadence_str: Optional[str] = None):
         """Get a CadenceDays value from a string.
 
         Parameters
@@ -126,8 +126,11 @@ class CadenceDays(float, Enum):
 
         Returns
         -------
-        CadenceDays, list[CadenceDays]
-            The corresponding CadenceDays enum value.
+        CadenceDays, dict[str, CadenceDays]
+            The corresponding CadenceDays enum value. If cadence_str is None,
+            then a dictionary of valid cadence strings and their corresponding
+            CadenceDays enum values is returned.
+
         """
         lookup = {
             "1mo": cls.ONE_MONTH,
@@ -136,7 +139,7 @@ class CadenceDays(float, Enum):
             "1yr": cls.ONE_YEAR,
         }
         if not cadence_str:
-            return list(lookup.values())
+            return lookup
 
         if cadence_str not in cls.valid_cadence_str():
             raise ValueError(

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -115,30 +115,35 @@ class CadenceDays(float, Enum):
         return VALID_CADENCE_STRS
 
     @classmethod
-    def str_lookup(cls, cadence_str: str):
+    def str_lookup(cls, cadence_str: Optional[str]):
         """Get a CadenceDays value from a string.
 
         Parameters
         ----------
-        cadence_str : str
-            The cadence string (e.g. "1mo", "3mo", "6mo", "1yr").
+        cadence_str : str, optional
+            The cadence string (e.g. "1mo", "3mo", "6mo", "1yr"). If not provided,
+            the function will return the list of valid cadence strings.
 
         Returns
         -------
-        CadenceDays
+        CadenceDays, list[CadenceDays]
             The corresponding CadenceDays enum value.
         """
+        lookup = {
+            "1mo": cls.ONE_MONTH,
+            "3mo": cls.THREE_MONTHS,
+            "6mo": cls.SIX_MONTHS,
+            "1yr": cls.ONE_YEAR,
+        }
+        if not cadence_str:
+            return list(lookup.values())
+
         if cadence_str not in cls.valid_cadence_str():
             raise ValueError(
                 f"Invalid cadence: {cadence_str}. Valid cadences are:"
                 f" {cls.valid_cadence_str}"
             )
-        return {
-            "1mo": cls.ONE_MONTH,
-            "3mo": cls.THREE_MONTHS,
-            "6mo": cls.SIX_MONTHS,
-            "1yr": cls.ONE_YEAR,
-        }[cadence_str]
+        return lookup[cadence_str]
 
 
 def determine_job_version(

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -144,7 +144,7 @@ class CadenceDays(float, Enum):
         if cadence_str not in cls.valid_cadence_str():
             raise ValueError(
                 f"Invalid cadence: {cadence_str}. Valid cadences are:"
-                f" {cls.valid_cadence_str}"
+                f" {cls.valid_cadence_str()}"
             )
         return lookup[cadence_str]
 

--- a/tests/infrastructure/test_instrument_lambda_construct.py
+++ b/tests/infrastructure/test_instrument_lambda_construct.py
@@ -1,0 +1,83 @@
+"""Test the indexer lambda."""
+
+import pytest
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_rds as rds
+from aws_cdk.assertions import Template
+
+from sds_data_manager.constructs.api_gateway_construct import ApiGateway
+from sds_data_manager.constructs.data_bucket_construct import DataBucketConstruct
+from sds_data_manager.constructs.database_construct import SdpDatabase
+from sds_data_manager.constructs.instrument_lambdas import BatchStarterLambda
+from sds_data_manager.constructs.networking_construct import NetworkingConstruct
+
+
+@pytest.fixture
+def template(stack, env, code):
+    """Indexer lambda setup."""
+    data_bucket = DataBucketConstruct(stack, "indexer-data-bucket", env=env)
+    networking_construct = NetworkingConstruct(stack, "Networking")
+    test_security_group = ec2.SecurityGroup(
+        stack, "TestSecurityGroup", vpc=networking_construct.vpc
+    )
+    apigw = ApiGateway(
+        stack,
+        construct_id="Api-manager-ApigwTest",
+    )
+    rds_size = "SMALL"
+    rds_class = "BURSTABLE3"
+    rds_storage = 200
+    database_construct = SdpDatabase(
+        stack,
+        "RDS",
+        vpc=networking_construct.vpc,
+        engine_version=rds.PostgresEngineVersion.VER_15_3,
+        instance_size=ec2.InstanceSize[rds_size],
+        instance_class=ec2.InstanceClass[rds_class],
+        max_allocated_storage=rds_storage,
+        username="imap",
+        secret_name="sdp-database-creds-rds",  # noqa
+        database_name="imapdb",
+        code=code,
+        layers=[],
+    )
+    BatchStarterLambda(
+        stack,
+        construct_id="batch-starter-construct",
+        env=env,
+        api=apigw,
+        data_bucket=data_bucket.data_bucket,
+        code=code,
+        rds_construct=database_construct,
+        rds_security_group=test_security_group,
+        vpc=networking_construct.vpc,
+        sqs_queues=[],
+        layers=[],
+    )
+    template = Template.from_stack(stack)
+    return template
+
+
+def test_batch_starter_resources(template):
+    """Ensure the template has appropriate IAM roles."""
+    template.resource_count_is("AWS::IAM::Role", 7)
+    # 2 for RDS stack + 1 for BatchStarterLambda + 1 for API Gateway + 1 for
+    # bucket notifications
+    template.resource_count_is("AWS::Lambda::Function", 5)
+
+    # Ensure that there are 4 cadence event bridge schedules
+    template.resource_count_is("AWS::Scheduler::Schedule", 4)
+
+    # Verify that each of the expected cadence Rules exists
+    schedules = template.find_resources("AWS::Scheduler::Schedule")
+    schedule_names = [props["Properties"]["Name"] for props in schedules.values()]
+
+    expected_schedules = [
+        "ProcessingCadenceJob_one_month",
+        "ProcessingCadenceJob_three_months",
+        "ProcessingCadenceJob_six_months",
+        "ProcessingCadenceJob_one_year",
+    ]
+
+    for schedule in expected_schedules:
+        assert schedule in schedule_names


### PR DESCRIPTION
# Change Summary

closes #1057
## Overview
This PR simplifies the cadence job triggering. Before we created a single EventBridge rule for each of the cadence jobs. We were getting close to our resource limit for cloudFormation. Instead of individual rules we now create one schedule rule for each cadence. 

See issue for more details. 

## Updated Files
- sds_data_manager/constructs/instrument_lambdas.py
   - Create one Rule for each cadence type including 1mo. 
   - Create function to calculate the next run based off of the start date. If the date we are deploying is after the start date we need to handle that. 

## Testing

