### PR TITLE
I-ALiRT - add time query buffer

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive.py
@@ -106,8 +106,10 @@ def lambda_handler(event, context):
     )  # 00:00 UTC
     one_week = seven_days_ago + timedelta(days=1)  # next midnight
 
-    start_iso = seven_days_ago.isoformat()
-    end_iso = one_week.isoformat()
+    buffer = timedelta(minutes=5)
+
+    start_iso = (seven_days_ago - buffer).isoformat()
+    end_iso = (one_week + buffer).isoformat()
 
     all_items = []
     for inst in INSTRUMENTS:


### PR DESCRIPTION
# Change Summary

## Overview
Sometimes the instrument epoch values can be slightly outside of the range of the spacecraft epoch values. Therefore I added a 5 minute buffer to each side of the database query.

## Updated Files
- ialirt_archive.py
   - Added a 5 minute buffer to each side of the database query.
