### PR TITLE
I-ALiRT - add authorization for noaa

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -294,6 +294,9 @@ class IalirtApiManager(Construct):
             # and DynamoDB queries are often CPU-bound due to
             # JSON parsing and network serialization.
             memory_size=2048,
+            # Prevents a bad actor from excessive use.
+            # Means number of lambdas that can be used simultaneously.
+            reserved_concurrent_executions=300,
             environment={
                 "DATA_TABLE": data_table.table_name,
                 "REGION": env.region,
@@ -309,4 +312,33 @@ class IalirtApiManager(Construct):
             "GET",
             ialirt_db_query_formatted_handler,
             auth_route_prefixes,
+        )
+
+        ialirt_db_query_priority = lambda_.Function(
+            self,
+            "IAlirtDbQueryApiPriority",
+            function_name="ialirt-db-query-priority-handler",
+            code=code,
+            handler="IAlirtCode.ialirt_data_query_api.lambda_handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            timeout=cdk.Duration.minutes(1),
+            # Lambda allocates CPU proportionally to memory,
+            # and DynamoDB queries are often CPU-bound due to
+            # JSON parsing and network serialization.
+            memory_size=2048,
+            environment={
+                "DATA_TABLE": data_table.table_name,
+                "REGION": env.region,
+            },
+        )
+
+        # Grant the lambda function read/write permissions on the DynamoDB table.
+        data_table.grant_read_data(ialirt_db_query_priority)
+
+        add_stable_route(
+            api,
+            "/space-weather-priority",
+            "GET",
+            ialirt_db_query_priority,
+            restricted_route_prefixes,
         )

--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -253,35 +253,6 @@ class IalirtApiManager(Construct):
             lambda_function=catalog_api,
         )
 
-        ialirt_db_query_handler = lambda_.Function(
-            self,
-            "IAlirtDbQueryApiHandler",
-            function_name="ialirt-db-query-handler",
-            code=code,
-            handler="IAlirtCode.ialirt_db_query_api.lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
-            timeout=cdk.Duration.minutes(1),
-            # Lambda allocates CPU proportionally to memory,
-            # and DynamoDB queries are often CPU-bound due to
-            # JSON parsing and network serialization.
-            memory_size=2048,  # MB
-            environment={
-                "ALGORITHM_TABLE": algorithm_table.table_name,
-                "REGION": env.region,
-            },
-        )
-
-        # Grant the lambda function read/write permissions on the DynamoDB table.
-        algorithm_table.grant_read_data(ialirt_db_query_handler)
-
-        add_stable_route(
-            api,
-            "/ialirt-db-query",
-            "GET",
-            ialirt_db_query_handler,
-            restricted_route_prefixes,
-        )
-
         ialirt_db_query_formatted_handler = lambda_.Function(
             self,
             "IAlirtDbQueryApiFormattedHandler",

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -19,8 +19,8 @@ dynamodb = boto3.resource("dynamodb", region_name=region)
 table = dynamodb.Table(table_name)
 
 FULL_SCOPES = {
+    "read",
     "full",
-    "ialirt_scientist",
 }
 
 # Read-only scopes (can read but not write)

--- a/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
+++ b/sds_data_manager/lambda_code/authorization/lambda_api_key_authorizer.py
@@ -51,6 +51,7 @@ def _is_authorized(scope, path, http_method):
     if (
         path.startswith("/ialirt-download/logs")
         or path.startswith("/ialirt-download/packets/")
+        or path.startswith("/space-weather-priority")
     ) and scope not in (
         "full",
         "read",

--- a/tests/infrastructure/test_api_key_dynamodb.py
+++ b/tests/infrastructure/test_api_key_dynamodb.py
@@ -112,10 +112,10 @@ def test_scope_restrictions(dynamodb_table):
         "2024-01-01T00:00:00",
     )
 
-    # Test access to ialirt-db-query with read scope (should be allowed)
+    # Test access to spaceweather-priority with read scope (should be allowed)
     event = {
         "headers": {"x-api-key": read_only_key},
-        "rawPath": "/ialirt-db-query/test",
+        "rawPath": "/space-weather-priority/test",
         "requestContext": {"http": {"method": "GET"}},
     }
     result = lambda_handler(event, {})


### PR DESCRIPTION
# Change Summary

## Overview
NOAA and possibly other major space weather forecasters would like to have a separate endpoint to access spaceweather in the case of heavy loads during a solar event. 

## Updated Files
- alirt_api_manager_construct.py
   - Limited the number of times a lambda can be pinged simultaneously to 300 to prevent back actors.
   - Remove old database query api
   - Add priority endpoint
- lambda_api_key_authorizer.py
   - Change permissions to read/full to align with the rest of the SDC
   - Add restriction for unauthorized users for priority api
- ialirt_data_query_api.py
   - Change scopes to "read" and "full"

## Important
- Before this is merged I need to update credentials in database.