### PR TITLE
Speedup for the metakernel

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
 		"ghcr.io/devcontainers/features/desktop-lite:1": {
 			"version": "latest"
 		}, "ghcr.io/devcontainers/features/docker-in-docker:2": {
-			"version": "latest"
+			"version": "latest",
+			"moby": false
 		}
 	},
 	"forwardPorts": [6080],

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
@@ -416,14 +416,22 @@ seconds since J2000.
             if file_interval_start > search_window_start:
                 # <----------- search window --------....
                 #       <----- file coverage --------....
+                if search_window_start < gap_start:
+                    start = gap_start
+                else:
+                    start = search_window_start
                 sub_gaps.extend(
-                    [[search_window_start, file_interval_start]]
+                    [[start, file_interval_start]]
                 )  # Gaps before interval
             if file_interval_end < search_window_end:
                 # ....--- search window --------------->
                 # ....-- file coverage -------->
+                if search_window_end > gap_end:
+                    end = gap_end
+                else:
+                    end = search_window_end
                 sub_gaps.extend(
-                    [[file_interval_end, search_window_end]]
+                    [[file_interval_end, end]]
                 )  # Gaps after interval
 
         return sub_gaps

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
@@ -199,6 +199,9 @@ seconds since J2000.
     def _remove_duplicates_from_sorted_file_list(self, type: str):
         """Remove any duplicate found in self.spice_files[type].
 
+           Loops through the list, and determines which files to
+           keep.
+
         Parameter
         ---------
         type: str
@@ -213,7 +216,7 @@ seconds since J2000.
                 continue
             file_names_to_keep.append(old_file_list[i]["file_name"])
             new_file_list.append(old_file_list[i])
-        
+
         self.spice_files[type] = new_file_list
 
     def _limitstring(self, dirstring, limit, sym):
@@ -309,7 +312,7 @@ seconds since J2000.
                 logger.debug(
                     "File did not cover time range, not adding to metakernal list."
                 )
-                subgap_list=[trange]
+                subgap_list = [trange]
             elif not subgap_list:
                 logger.debug(
                     "File was valid, and no further gaps were found. "

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
@@ -420,9 +420,7 @@ seconds since J2000.
                     start = gap_start
                 else:
                     start = search_window_start
-                sub_gaps.extend(
-                    [[start, file_interval_start]]
-                )  # Gaps before interval
+                sub_gaps.extend([[start, file_interval_start]])  # Gaps before interval
             if file_interval_end < search_window_end:
                 # ....--- search window --------------->
                 # ....-- file coverage -------->
@@ -430,9 +428,7 @@ seconds since J2000.
                     end = gap_end
                 else:
                     end = search_window_end
-                sub_gaps.extend(
-                    [[file_interval_end, end]]
-                )  # Gaps after interval
+                sub_gaps.extend([[file_interval_end, end]])  # Gaps after interval
 
         return sub_gaps
 

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
@@ -341,7 +341,7 @@ seconds since J2000.
         return return_gap_list
 
     @staticmethod
-    def _calculate_gaps(file_intervals, gap_start, gap_end): # noqa: C901, PLR0912, PLR0915
+    def _calculate_gaps(file_intervals, gap_start, gap_end):  # noqa: PLR0912
         """Caclulate the gaps based on file_intervals.
 
         Slide a "window" across the file to determine the intervals

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
@@ -341,7 +341,7 @@ seconds since J2000.
         return return_gap_list
 
     @staticmethod
-    def _calculate_gaps(file_intervals, gap_start, gap_end):
+    def _calculate_gaps(file_intervals, gap_start, gap_end): # noqa: C901, PLR0912, PLR0915
         """Caclulate the gaps based on file_intervals.
 
         Slide a "window" across the file to determine the intervals

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
@@ -259,7 +259,7 @@ seconds since J2000.
         return_gap_list: list[list[int, int]]
             A list of gaps that still remain uncovered
         """
-        trange = [int(trange[0]), int(trange[1])]
+        trange = [trange[0],trange[1]]
         if (trange[1] - trange[0]) < self.minimum_gap_time_to_ignore:
             # Don't even bother if the gap is too small
             return []
@@ -294,6 +294,7 @@ seconds since J2000.
             logger.debug(
                 "The file does not cover our time range and will not be loaded."
             )
+            subgap_list=gap_list
         else:
             logger.debug(
                 "The file start/end time is included in the time range we are "
@@ -312,7 +313,6 @@ seconds since J2000.
                 logger.debug(
                     "File did not cover time range, not adding to metakernal list."
                 )
-                gap_list.extend(subgap_list)
             elif not subgap_list:
                 logger.debug(
                     "File was valid, and no further gaps were found. "
@@ -325,7 +325,6 @@ seconds since J2000.
                     "Adding to metakernal list."
                 )
                 files_to_load.append(best_file)
-                gap_list.extend(subgap_list)
 
         # Now we've checked this file, remove from child function calls
         new_file_list = files_to_check.copy()
@@ -333,7 +332,7 @@ seconds since J2000.
         return_gap_list = []
         # If any more gaps remain, call this function again!
 
-        for g in gap_list:
+        for g in subgap_list:
             return_gap_list.extend(
                 self._find_best_files(
                     g, new_file_list, files_to_load, file_intervals_field
@@ -388,7 +387,7 @@ seconds since J2000.
 
             # Determine the search window
             if (
-                file_interval_start <= gap_start and file_interval_end >= gap_end
+                file_interval_start <= gap_start and file_interval_end >= gap_start
             ) or i == 0:
                 search_window_start = gap_start
             else:

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
@@ -205,20 +205,16 @@ seconds since J2000.
             The type of SPICE file to search search and remove duplicate
             files from
         """
-        indicies_to_delete = []
-        file_list = self.spice_files[type].copy()
-        for i in range(0, len(file_list)):
-            if i in indicies_to_delete:
+        old_file_list = self.spice_files[type].copy()
+        file_names_to_keep = []
+        new_file_list = []
+        for i in range(0, len(old_file_list)):
+            if old_file_list[i]["file_name"] in file_names_to_keep:
                 continue
-            logger.debug(
-                f"Searching for duplicates for file {file_list[i]['file_name']}"
-            )
-            for j in range(i + 1, len(file_list)):
-                if file_list[i]["file_name"] == file_list[j]["file_name"]:
-                    indicies_to_delete.append(j)
-        for i in sorted(set(indicies_to_delete), reverse=True):
-            del file_list[i]
-        self.spice_files[type] = file_list
+            file_names_to_keep.append(old_file_list[i]["file_name"])
+            new_file_list.append(old_file_list[i])
+        
+        self.spice_files[type] = new_file_list
 
     def _limitstring(self, dirstring, limit, sym):
         """Limit a list of strings and add a '+' symbol."""
@@ -259,7 +255,7 @@ seconds since J2000.
         return_gap_list: list[list[int, int]]
             A list of gaps that still remain uncovered
         """
-        trange = [trange[0],trange[1]]
+        trange = [trange[0], trange[1]]
         if (trange[1] - trange[0]) < self.minimum_gap_time_to_ignore:
             # Don't even bother if the gap is too small
             return []
@@ -294,7 +290,7 @@ seconds since J2000.
             logger.debug(
                 "The file does not cover our time range and will not be loaded."
             )
-            subgap_list=gap_list
+            subgap_list = gap_list
         else:
             logger.debug(
                 "The file start/end time is included in the time range we are "
@@ -313,6 +309,7 @@ seconds since J2000.
                 logger.debug(
                     "File did not cover time range, not adding to metakernal list."
                 )
+                subgap_list=[trange]
             elif not subgap_list:
                 logger.debug(
                     "File was valid, and no further gaps were found. "


### PR DESCRIPTION
# Change Summary

## Overview

Sped up the metakernel API significantly, it was searching to fill WAY too many gaps before. It's not super noticeable if each file only has a few gaps, but when there are many gaps per file it was doing a lot of double searching. 

## File changes

sds_data_manager/lambda_code/SDSCode/api_lambdas/metakernel.py
- Instead of searching "gap_list" each time, it only searches "subgap_list", or the list of gaps that are within the scope of the time interval it is searching. 
- Stopped converting the gap times to integers. I'm not sure why that was there in the first place, because it causes some issues later on with file contents not being exactly equal to the gaps we're searching. This makes it look like some files partially fill some gaps by fractions of a second, when they actually don't. 
- The very last change in the file I think was just simply a bug, and that would also occasionally cause an extra interval to be searched unnecessarily 

## Testing

I didn't add any testing, the output is ultimately the same but it takes less time. In theory we could add a unit test that takes the JSON structure I was testing with and then time how long it takes to run or something. 