### PR TITLE
I-ALiRT - update ecs ami

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -990,13 +990,13 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "imap-processing"
-version = "1.0.20"
+version = "1.0.19"
 description = "IMAP Science Operations Center Processing"
 optional = false
 python-versions = "<4,>=3.10"
 files = [
-    {file = "imap_processing-1.0.20-py3-none-any.whl", hash = "sha256:db1da4e0b924da21a5897579e05a0979821574e783a6d3e62090f84f35e5312e"},
-    {file = "imap_processing-1.0.20.tar.gz", hash = "sha256:18060444cfd1bdd605b47a09bc4509fec667ae5c379674aca53d74659908bc2e"},
+    {file = "imap_processing-1.0.19-py3-none-any.whl", hash = "sha256:819274d52cfc44a74aff626640dc3a100e3360676fc1400e1b0e823cb9adbbe5"},
+    {file = "imap_processing-1.0.19.tar.gz", hash = "sha256:3970871ed678916f5f4f84b6bc342977f51601a3b12a68f0fd319dab36dab601"},
 ]
 
 [package.dependencies]
@@ -2744,4 +2744,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "908420a0ceb54fa82d5ca39434bb8207485024f08ccc45f4b796cf41187c6bc7"
+content-hash = "7a2c4a3432ab9c7d8fc4a7e73492476460a94705dc7ee6f172d9c1dfecf47556"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ requests = "^2.28.2"
 spiceypy = "^6.0.0"
 
 [tool.poetry.group.layer-processing.dependencies]
-imap-processing = "1.0.20"
+imap-processing = "1.0.19"
 
 [tool.poetry.extras]
 doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -290,7 +290,7 @@ class IalirtProcessing(Construct):
             instance_type=ec2.InstanceType.of(
                 ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.LARGE
             ),
-            machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
+            machine_image=ecs.EcsOptimizedImage.amazon_linux2023(),
             vpc=self.vpc,
             desired_capacity=1,
             min_capacity=1,

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -179,9 +179,9 @@ idna==3.11 ; python_version >= "3.10" and python_version < "4" \
 imap-data-access==0.37.1 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:25743a180993f740cfcfc6805275feba9590324dd3fd6b88ab9cdb8d0731d13c \
     --hash=sha256:aebd68f8f20e85535ae651a7145468596e975dd194e661b1b1dc212326cbb88e
-imap-processing==1.0.20 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:18060444cfd1bdd605b47a09bc4509fec667ae5c379674aca53d74659908bc2e \
-    --hash=sha256:db1da4e0b924da21a5897579e05a0979821574e783a6d3e62090f84f35e5312e
+imap-processing==1.0.19 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:3970871ed678916f5f4f84b6bc342977f51601a3b12a68f0fd319dab36dab601 \
+    --hash=sha256:819274d52cfc44a74aff626640dc3a100e3360676fc1400e1b0e823cb9adbbe5
 lxml==6.0.2 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:058027e261afed589eddcfe530fcc6f3402d7fd7e89bfd0532df82ebc1563dba \
     --hash=sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8 \


### PR DESCRIPTION
# Change Summary

## Overview

The current ECS AMI is being deprecated so we need an update.

## File changes

ialirt_processing_construct.py


## Testing

Testing in dev.

**Old**
44.246.157.218
ami-02cdaf0146c5a47f1
amzn2-ami-ecs-hvm-2.0.20250909-x86_64-ebs

IalirtStack-IalirtProcessingAutoScalingGroupASG503538FE-FJz8ekAktdam
i-0900e233a708467a7
IalirtStack-IalirtProcessingAutoScalingGroupInstanc-ulQ2fDFb2O4q

Terminated at 12:09pm.
Back at 12:11pm.

**New**
44.246.157.218
ami-0b6ac29f4b0dc9bf1
al2023-ami-ecs-hvm-2023.0.20260210-kernel-6.1-x86_64

IalirtStack-IalirtProcessingAutoScalingGroupASG503538FE-FJz8ekAktdam
i-00621c20940e0a103
IalirtStack-IalirtProcessingAutoScalingGroupInstanc-ulQ2fDFb2O4q

**From the terminal:**
((.venv) ) Lauras-MacBook-Pro:sds-data-manager laurasandoval$ nc -vz 44.246.157.218 7526
Connection to 44.246.157.218 port 7526 [tcp/*] succeeded!
((.venv) ) Lauras-MacBook-Pro:sds-data-manager laurasandoval$ nc -vz 44.246.157.218 7564
Connection to 44.246.157.218 port 7564 [tcp/*] succeeded!
((.venv) ) Lauras-MacBook-Pro:sds-data-manager laurasandoval$ nc -vz 44.246.157.218 7566
Connection to 44.246.157.218 port 7566 [tcp/vsi-omega] succeeded!
((.venv) ) Lauras-MacBook-Pro:sds-data-manager laurasandoval$ 