### PR TITLE
I-ALiRT - Archive query api

### DIFF
--- a/sds_data_manager/constructs/ialirt_api_manager_construct.py
+++ b/sds_data_manager/constructs/ialirt_api_manager_construct.py
@@ -201,6 +201,33 @@ class IalirtApiManager(Construct):
             auth_route_prefixes,
         )
 
+        # archive query API lambda
+        archive_query_api_lambda = lambda_.Function(
+            self,
+            id="IAlirtCodeArchiveQueryAPILambda",
+            function_name="ialirt-archive-query-api-handler",
+            code=code,
+            handler="IAlirtCode.ialirt_archive_query_api.lambda_handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            timeout=cdk.Duration.minutes(1),
+            memory_size=1000,
+            allow_public_subnet=True,
+            vpc=vpc,
+            environment={
+                "S3_BUCKET": data_bucket.bucket_name,
+                "REGION": env.region,
+            },
+            layers=layers,
+        )
+
+        archive_query_api_lambda.add_to_role_policy(s3_read_policy)
+
+        api.add_route(
+            route="/ialirt-archive-query",
+            http_method="GET",
+            lambda_function=archive_query_api_lambda,
+        )
+
         # catalog API lambda
         catalog_api = lambda_.Function(
             self,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive_query_api.py
@@ -1,0 +1,111 @@
+"""Define lambda to support the download API."""
+
+import json
+import logging
+import os
+
+import boto3
+import botocore
+
+# Logger setup
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event, context):
+    """Entry point to the archive query API lambda.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process
+    context : LambdaContext
+        This object provides methods and properties that provide
+        information about the invocation, function,
+        and runtime environment.
+
+    Notes
+    -----
+    Based on filename imap_ialirt_l1_realtime_<yyyymmdd>_v001.cdf.
+    All parameters are optional. Defaults to listing all version 1 files.
+
+    Example
+    -------
+    Below is an event example:
+    {
+        "queryStringParameters": {
+            "year": "2024",
+            "month": "05",
+            "day": "21",
+            "version": "1"
+        }
+    }
+    """
+    logger.info(f"Event: {event}")
+    logger.info(f"Context: {context}")
+
+    logger.info("Received event: " + json.dumps(event, indent=2))
+
+    query_params = event.get("queryStringParameters") or {}
+    year = query_params.get("year")
+    month = query_params.get("month")
+    day = query_params.get("day")
+    version = query_params.get("version", "1")
+
+    if day and not month:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"error": "Cannot specify 'day' without 'month'."}),
+        }
+    if month and not year:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"error": "Cannot specify 'month' without 'year'."}),
+        }
+
+    try:
+        version_str = f"v{int(version):03d}"
+    except ValueError:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(
+                {"error": "Invalid version format. Must be an integer."}
+            ),
+        }
+
+    date_prefix = ""
+    if year:
+        date_prefix += year.zfill(4)
+    if month:
+        date_prefix += month.zfill(2)
+    if day:
+        date_prefix += day.zfill(2)
+
+    prefix = f"archive/imap_ialirt_l1_realtime_{date_prefix}"
+
+    bucket = os.getenv("S3_BUCKET")
+    region = os.getenv("REGION")
+
+    s3_client = boto3.client(
+        "s3",
+        region_name=region,
+        config=botocore.client.Config(signature_version="s3v4"),
+    )
+
+    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    files = []
+
+    for obj in response.get("Contents", []):
+        filename = obj["Key"].split("/")[-1]
+        if version_str in filename:
+            files.append(filename)
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"files": files}),
+    }

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive_query_api.py
@@ -92,13 +92,16 @@ def lambda_handler(event, context):
         config=botocore.client.Config(signature_version="s3v4"),
     )
 
-    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    paginator = s3_client.get_paginator("list_objects_v2")
     files = []
 
-    for obj in response.get("Contents", []):
-        filename = obj["Key"].split("/")[-1]
-        if version_str in filename:
-            files.append(filename)
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            filename = obj["Key"].split("/")[-1]
+            if version_str in filename:
+                files.append(filename)
+
+    files.sort()
 
     return {
         "statusCode": 200,

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive_query_api.py
@@ -53,17 +53,13 @@ def lambda_handler(event, context):
     day = query_params.get("day")
     version = query_params.get("version", "1")
 
-    if day and not month:
+    if (day and not month) or (month and not year):
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({"error": "Cannot specify 'day' without 'month'."}),
-        }
-    if month and not year:
-        return {
-            "statusCode": 400,
-            "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({"error": "Cannot specify 'month' without 'year'."}),
+            "body": json.dumps(
+                {"error": "Date parts must be specified in order: year, month, day."}
+            ),
         }
 
     try:

--- a/tests/lambda_endpoints/test_ialirt_archive_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_archive_query_api.py
@@ -1,0 +1,136 @@
+"""Tests for the I-ALiRT Archive Query API."""
+
+import json
+
+import pytest
+
+from sds_data_manager.lambda_code.IAlirtCode import ialirt_archive_query_api
+
+BUCKET = "test-data-bucket"
+
+ARCHIVE_FILES = [
+    "archive/imap_ialirt_l1_realtime_20240521_v001.cdf",
+    "archive/imap_ialirt_l1_realtime_20240522_v001.cdf",
+    "archive/imap_ialirt_l1_realtime_20240601_v001.cdf",
+    "archive/imap_ialirt_l1_realtime_20240521_v002.cdf",
+]
+
+
+@pytest.fixture
+def populated_bucket(s3_client):
+    """Upload archive test files to the mocked S3 bucket."""
+    for key in ARCHIVE_FILES:
+        s3_client.put_object(Bucket=BUCKET, Key=key, Body=b"test-data")
+    return s3_client
+
+
+def test_archive_query_no_params(populated_bucket, monkeypatch):
+    """No params returns all v001 files."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+    files = json.loads(response["body"])["files"]
+
+    assert response["statusCode"] == 200
+    assert sorted(files) == [
+        "imap_ialirt_l1_realtime_20240521_v001.cdf",
+        "imap_ialirt_l1_realtime_20240522_v001.cdf",
+        "imap_ialirt_l1_realtime_20240601_v001.cdf",
+    ]
+
+
+def test_archive_query_by_year(populated_bucket, monkeypatch):
+    """Filtering by year returns all v001 files for that year."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"year": "2024"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+    files = json.loads(response["body"])["files"]
+
+    assert response["statusCode"] == 200
+    assert sorted(files) == [
+        "imap_ialirt_l1_realtime_20240521_v001.cdf",
+        "imap_ialirt_l1_realtime_20240522_v001.cdf",
+        "imap_ialirt_l1_realtime_20240601_v001.cdf",
+    ]
+
+
+def test_archive_query_by_year_month(populated_bucket, monkeypatch):
+    """Filtering by year and month narrows results to that month."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"year": "2024", "month": "05"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+    files = json.loads(response["body"])["files"]
+
+    assert response["statusCode"] == 200
+    assert sorted(files) == [
+        "imap_ialirt_l1_realtime_20240521_v001.cdf",
+        "imap_ialirt_l1_realtime_20240522_v001.cdf",
+    ]
+
+
+def test_archive_query_by_full_date(populated_bucket, monkeypatch):
+    """Filtering by year, month, and day returns only that day's file."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"year": "2024", "month": "05", "day": "21"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+    files = json.loads(response["body"])["files"]
+
+    assert response["statusCode"] == 200
+    assert files == ["imap_ialirt_l1_realtime_20240521_v001.cdf"]
+
+
+def test_archive_query_by_version(populated_bucket, monkeypatch):
+    """Filtering by version returns only files with that version."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"year": "2024", "month": "05", "version": "2"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+    files = json.loads(response["body"])["files"]
+
+    assert response["statusCode"] == 200
+    assert files == ["imap_ialirt_l1_realtime_20240521_v002.cdf"]
+
+
+def test_archive_query_day_without_month(monkeypatch):
+    """Specifying day without month returns a 400 error."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"year": "2024", "day": "21"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+
+    assert response["statusCode"] == 400
+    assert "order" in response["body"]
+
+
+def test_archive_query_month_without_year(monkeypatch):
+    """Specifying month without year returns a 400 error."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"month": "05"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+
+    assert response["statusCode"] == 400
+    assert "order" in response["body"]
+
+
+def test_archive_query_invalid_version(monkeypatch):
+    """A non-integer version returns a 400 error."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"version": "abc"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+
+    assert response["statusCode"] == 400
+    assert "version" in response["body"].lower()

--- a/tests/lambda_endpoints/test_ialirt_archive_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_archive_query_api.py
@@ -34,7 +34,7 @@ def test_archive_query_no_params(populated_bucket, monkeypatch):
     files = json.loads(response["body"])["files"]
 
     assert response["statusCode"] == 200
-    assert sorted(files) == [
+    assert files == [
         "imap_ialirt_l1_realtime_20240521_v001.cdf",
         "imap_ialirt_l1_realtime_20240522_v001.cdf",
         "imap_ialirt_l1_realtime_20240601_v001.cdf",
@@ -51,7 +51,7 @@ def test_archive_query_by_year(populated_bucket, monkeypatch):
     files = json.loads(response["body"])["files"]
 
     assert response["statusCode"] == 200
-    assert sorted(files) == [
+    assert files == [
         "imap_ialirt_l1_realtime_20240521_v001.cdf",
         "imap_ialirt_l1_realtime_20240522_v001.cdf",
         "imap_ialirt_l1_realtime_20240601_v001.cdf",
@@ -68,7 +68,7 @@ def test_archive_query_by_year_month(populated_bucket, monkeypatch):
     files = json.loads(response["body"])["files"]
 
     assert response["statusCode"] == 200
-    assert sorted(files) == [
+    assert files == [
         "imap_ialirt_l1_realtime_20240521_v001.cdf",
         "imap_ialirt_l1_realtime_20240522_v001.cdf",
     ]


### PR DESCRIPTION
This pull request introduces a new Lambda-based Archive Query API for the I-ALiRT system, enabling users to query available archive files in S3 by date and version. The API is fully integrated into the infrastructure and is accompanied by comprehensive unit tests to ensure correct filtering and error handling.

**Key changes:**

**Archive Query API Implementation:**
- Added a new Lambda function (`ialirt_archive_query_api.py`) that handles GET requests to query available I-ALiRT archive files in S3, supporting optional filtering by year, month, day, and version. The Lambda validates input parameters, constructs the appropriate S3 prefix, and returns matching filenames as JSON.

**Infrastructure Integration:**
- Registered the new Archive Query API Lambda in the CDK construct (`ialirt_api_manager_construct.py`), including role permissions and an API route (`/ialirt-archive-query`) for GET requests.

**Testing:**
- Added a suite of unit tests (`test_ialirt_archive_query_api.py`) covering various query scenarios, including filtering by date and version, as well as error cases for invalid or incomplete parameters.# Change Summary