### PR TITLE
I-ALiRT - add since parameter to archive API

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_archive_query_api.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from datetime import datetime
 
 import boto3
 import botocore
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def lambda_handler(event, context):
+def lambda_handler(event, context):  # noqa: PLR0912
     """Entry point to the archive query API lambda.
 
     Parameters
@@ -32,12 +33,20 @@ def lambda_handler(event, context):
 
     Example
     -------
-    Below is an event example:
+    Below is an event example using year/month/day:
     {
         "queryStringParameters": {
             "year": "2024",
             "month": "05",
             "day": "21",
+            "version": "1"
+        }
+    }
+
+    Or using since to get all files on or after a date:
+    {
+        "queryStringParameters": {
+            "since": "20240521",
             "version": "1"
         }
     }
@@ -52,8 +61,18 @@ def lambda_handler(event, context):
     month = query_params.get("month")
     day = query_params.get("day")
     version = query_params.get("version", "1")
+    since = query_params.get("since")
 
-    if (day and not month) or (month and not year):
+    if since and (year or month or day):
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(
+                {"error": "since cannot be combined with year, month, or day."}
+            ),
+        }
+
+    if not since and ((day and not month) or (month and not year)):
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},
@@ -73,13 +92,31 @@ def lambda_handler(event, context):
             ),
         }
 
+    since_date = None
+    if since:
+        try:
+            since_date = datetime.strptime(since, "%Y%m%d").date()
+        except ValueError:
+            return {
+                "statusCode": 400,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps(
+                    {
+                        "error": (
+                            "Invalid since format. Must be YYYYMMDD (e.g. 20240521)."
+                        )
+                    }
+                ),
+            }
+
     date_prefix = ""
-    if year:
-        date_prefix += year.zfill(4)
-    if month:
-        date_prefix += month.zfill(2)
-    if day:
-        date_prefix += day.zfill(2)
+    if not since:
+        if year:
+            date_prefix += year.zfill(4)
+        if month:
+            date_prefix += month.zfill(2)
+        if day:
+            date_prefix += day.zfill(2)
 
     prefix = f"archive/imap_ialirt_l1_realtime_{date_prefix}"
 
@@ -98,8 +135,14 @@ def lambda_handler(event, context):
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         for obj in page.get("Contents", []):
             filename = obj["Key"].split("/")[-1]
-            if version_str in filename:
-                files.append(filename)
+            if version_str not in filename:
+                continue
+            if since_date is not None:
+                file_date_str = filename.split("_realtime_")[1][:8]
+                file_date = datetime.strptime(file_date_str, "%Y%m%d").date()
+                if file_date < since_date:
+                    continue
+            files.append(filename)
 
     files.sort()
 

--- a/tests/lambda_endpoints/test_ialirt_archive_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_archive_query_api.py
@@ -134,3 +134,43 @@ def test_archive_query_invalid_version(monkeypatch):
 
     assert response["statusCode"] == 400
     assert "version" in response["body"].lower()
+
+
+def test_archive_query_since(populated_bucket, monkeypatch):
+    """Since returns all v001 files with a date on or after the given date."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"since": "20240522"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+    files = json.loads(response["body"])["files"]
+
+    assert response["statusCode"] == 200
+    assert files == [
+        "imap_ialirt_l1_realtime_20240522_v001.cdf",
+        "imap_ialirt_l1_realtime_20240601_v001.cdf",
+    ]
+
+
+def test_archive_query_since_invalid_format(monkeypatch):
+    """A malformed since value returns a 400 error."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"since": "2024-05-21"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+
+    assert response["statusCode"] == 400
+    assert "since" in response["body"].lower()
+
+
+def test_archive_query_since_with_year_returns_400(monkeypatch):
+    """Combining since with year/month/day returns a 400 error."""
+    monkeypatch.setenv("S3_BUCKET", BUCKET)
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    event = {"queryStringParameters": {"since": "20240521", "year": "2024"}}
+    response = ialirt_archive_query_api.lambda_handler(event=event, context=None)
+
+    assert response["statusCode"] == 400
+    assert "since" in response["body"].lower()


### PR DESCRIPTION
This pull request adds support for querying archived files using a new `since` parameter, allowing users to retrieve all files on or after a specified date. It also enforces validation to prevent combining `since` with other date parameters and improves error handling for invalid inputs. Comprehensive tests have been added to cover the new functionality and edge cases.

### API enhancements

* Added support for a `since` query parameter to return all files on or after a given date, with validation to prevent combining it with `year`, `month`, or `day`. [[1]](diffhunk://#diff-52803065f9dd05b542e9cfb0380b2b513786802a064b92abcc8797b9f12b7fe4R45-R52) [[2]](diffhunk://#diff-52803065f9dd05b542e9cfb0380b2b513786802a064b92abcc8797b9f12b7fe4R64-R75)
* Implemented strict format checking for the `since` parameter, returning a 400 error for malformed dates.

### Query logic changes

* Updated file filtering logic to select files by date when `since` is provided, ensuring only files matching the version and date criteria are returned.

### Testing improvements

* Added tests for the new `since` parameter, including valid queries, invalid date formats, and error cases when combined with other date parameters.

### Documentation

* Updated the API docstring to describe usage of the new `since` parameter and provide example events. [[1]](diffhunk://#diff-52803065f9dd05b542e9cfb0380b2b513786802a064b92abcc8797b9f12b7fe4L35-R36) [[2]](diffhunk://#diff-52803065f9dd05b542e9cfb0380b2b513786802a064b92abcc8797b9f12b7fe4R45-R52)# Change Summary