### PR TITLE
I-ALiRT - added api feature

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_packets_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_packets_query_api.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def lambda_handler(event, context):
+def lambda_handler(event, context):  # noqa: PLR0911, PLR0912, PLR0915
     """Entry point to the query API lambda.
 
     Parameters
@@ -28,53 +28,135 @@ def lambda_handler(event, context):
 
     Notes
     -----
-    Based on filename iois_1_packets_YYYY_DOY_HH_MM_SS.bin.
-    Allows partial time specification (YYYY, DOY[, HH[, MM[, SS]]]).
+    Based on filename iois_1_packets_YYYY_DOY_HH_MM_SS.
+
+    Two mutually exclusive query modes are supported:
+
+    UTC range mode — both use strict ISO 8601 format YYYY-MM-DDTHH:MM:SS.
+    Queries by day (year + DOY) and post-filters by exact time range.
+    time_utc_start is required; time_utc_end is optional.
+
+    Individual params mode — partial time specification
+    (year, doy[, hh[, mm[, ss]]]). Builds an S3 prefix directly.
+    At minimum, year and doy must be provided.
+
+    Example
+    -------
+    UTC range mode:
+        ?time_utc_start=2025-10-29T18:55:02
+        ?time_utc_start=2025-10-29T18:55:02&time_utc_end=2025-10-29T19:05:00
+
+    Individual params mode:
+        ?year=2025&doy=148&hh=16&mm=24
     """
     logger.info(f"Event: {event}")
     logger.info(f"Context: {context}")
 
     logger.info("Received event: " + json.dumps(event, indent=2))
 
-    query_params = event["queryStringParameters"]
+    query_params = event.get("queryStringParameters") or {}
+    time_utc_start = query_params.get("time_utc_start")
+    time_utc_end = query_params.get("time_utc_end")
     year = query_params.get("year")
     doy = query_params.get("doy")
     hh = query_params.get("hh")
     mm = query_params.get("mm")
     ss = query_params.get("ss")
 
-    if not year or not doy:
+    utc_params = {time_utc_start, time_utc_end} - {None}
+    individual_params = {year, doy, hh, mm, ss} - {None}
+
+    if utc_params and individual_params:
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},
             "body": json.dumps(
-                {"error": "At minimum, 'year' and 'doy' must be provided."}
+                {
+                    "error": "Cannot mix UTC range parameters (time_utc_start, "
+                    "time_utc_end) with individual parameters (year, doy, hh, mm, ss)."
+                }
             ),
         }
 
-    try:
-        datetime.strptime(f"{year}{doy}", "%Y%j")
-    except ValueError:
-        return {
-            "statusCode": 400,
-            "headers": {"Content-Type": "application/json"},
-            "body": json.dumps(
-                {"error": "Invalid year or day format. Use YYYY and DOY."}
-            ),
-        }
+    end_dt = None
 
-    parts = [year, doy]
-    if hh:
-        # Pad values if necessary.
-        parts.append(hh.zfill(2))
-    if mm:
-        # Pad values if necessary.
-        parts.append(mm.zfill(2))
-    if ss:
-        # Pad values if necessary.
-        parts.append(ss.zfill(2))
+    if utc_params:
+        # --- UTC range mode ---
+        if not time_utc_start:
+            return {
+                "statusCode": 400,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"error": "'time_utc_start' is required."}),
+            }
 
-    prefix = "packets/iois_1_packets_" + "_".join(parts)
+        try:
+            start_dt = datetime.fromisoformat(time_utc_start)
+        except ValueError as e:
+            return {
+                "statusCode": 400,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"error": str(e)}),
+            }
+
+        if time_utc_end:
+            try:
+                end_dt = datetime.fromisoformat(time_utc_end)
+            except ValueError as e:
+                return {
+                    "statusCode": 400,
+                    "headers": {"Content-Type": "application/json"},
+                    "body": json.dumps({"error": str(e)}),
+                }
+
+            if end_dt <= start_dt:
+                return {
+                    "statusCode": 400,
+                    "headers": {"Content-Type": "application/json"},
+                    "body": json.dumps(
+                        {"error": "'time_utc_end' must be after 'time_utc_start'."}
+                    ),
+                }
+
+        # Use year + DOY as the S3 prefix (day granularity) so the full
+        # requested range is covered, then post-filter by exact time.
+        year = str(start_dt.year)
+        doy = str(start_dt.timetuple().tm_yday)
+        prefix = f"packets/iois_1_packets_{year}_{doy}"
+
+    else:
+        if not year or not doy:
+            return {
+                "statusCode": 400,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps(
+                    {"error": "At minimum, 'year' and 'doy' must be provided."}
+                ),
+            }
+
+        try:
+            datetime.strptime(f"{year}{doy}", "%Y%j")
+        except ValueError:
+            return {
+                "statusCode": 400,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps(
+                    {"error": "Invalid year or day format. Use YYYY and DOY."}
+                ),
+            }
+
+        parts = [year, doy]
+        if hh:
+            # Pad values if necessary.
+            parts.append(hh.zfill(2))
+        if mm:
+            # Pad values if necessary.
+            parts.append(mm.zfill(2))
+        if ss:
+            # Pad values if necessary.
+            parts.append(ss.zfill(2))
+
+        prefix = "packets/iois_1_packets_" + "_".join(parts)
+        start_dt = None
 
     bucket = os.getenv("S3_BUCKET")
     region = os.getenv("REGION")
@@ -90,6 +172,13 @@ def lambda_handler(event, context):
 
     for obj in response.get("Contents", []):
         filename = obj["Key"].split("/")[-1]
+        if start_dt is not None:
+            _, _, _, year, doy, hh, mm, ss = filename.split("_")
+            file_dt = datetime.strptime(f"{year}{doy}{hh}{mm}{ss}", "%Y%j%H%M%S")
+            if file_dt < start_dt:
+                continue
+            if end_dt and file_dt > end_dt:
+                continue
         files.append(filename)
 
     response = {

--- a/tests/lambda_endpoints/test_ialirt_packets_query_api.py
+++ b/tests/lambda_endpoints/test_ialirt_packets_query_api.py
@@ -5,33 +5,143 @@ import json
 from sds_data_manager.lambda_code.IAlirtCode import ialirt_packets_query_api
 
 
-def test_packet_query_within_range(s3_client, monkeypatch):
-    """Test that the packet query API returns matching files by partial datetime."""
+def test_packet_query_start_only(s3_client, monkeypatch):
+    """Test that time_utc_start alone returns all files from that time onward."""
     s3_client.create_bucket(Bucket="test-data-bucket")
-
-    # Patch environment variables
     monkeypatch.setenv("S3_BUCKET", "test-data-bucket")
     monkeypatch.setenv("REGION", "us-west-2")
 
-    # Add files matching and not matching the prefix
+    # DOY 148 = May 28
     s3_client.put_object(
         Bucket="test-data-bucket",
-        Key="packets/iois_1_packets_2025_148_16_24_27.bin",
+        Key="packets/iois_1_packets_2025_148_16_24_27",
         Body=b"test-data",
     )
     s3_client.put_object(
         Bucket="test-data-bucket",
-        Key="packets/iois_1_packets_2025_148_16_24_28.bin",
+        Key="packets/iois_1_packets_2025_148_16_24_28",
         Body=b"test-data",
     )
     s3_client.put_object(
         Bucket="test-data-bucket",
-        Key="packets/iois_1_packets_2025_149_16_24_27.bin",  # Different DOY
+        Key="packets/iois_1_packets_2025_148_10_00_00",  # before start, excluded
+        Body=b"test-data",
+    )
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key="packets/iois_1_packets_2025_149_16_24_27",  # different DOY, excluded
+        Body=b"test-data",
+    )
+
+    event = {"queryStringParameters": {"time_utc_start": "2025-05-28T16:24:27"}}
+
+    response = ialirt_packets_query_api.lambda_handler(event=event, context=None)
+    response_data = json.loads(response["body"])
+
+    assert response["statusCode"] == 200
+    assert sorted(response_data["files"]) == [
+        "iois_1_packets_2025_148_16_24_27",
+        "iois_1_packets_2025_148_16_24_28",
+    ]
+
+
+def test_packet_query_start_and_end(s3_client, monkeypatch):
+    """Test that time_utc_start + time_utc_end returns only files within range."""
+    s3_client.create_bucket(Bucket="test-data-bucket")
+    monkeypatch.setenv("S3_BUCKET", "test-data-bucket")
+    monkeypatch.setenv("REGION", "us-west-2")
+
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key="packets/iois_1_packets_2025_148_16_00_00",  # before start
+        Body=b"test-data",
+    )
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key="packets/iois_1_packets_2025_148_16_24_27",  # within range
+        Body=b"test-data",
+    )
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key="packets/iois_1_packets_2025_148_17_00_00",  # after end
         Body=b"test-data",
     )
 
     event = {
-        "queryStringParameters": {"year": "2025", "doy": "148", "hh": "16", "mm": "24"}
+        "queryStringParameters": {
+            "time_utc_start": "2025-05-28T16:24:00",
+            "time_utc_end": "2025-05-28T16:30:00",
+        }
+    }
+
+    response = ialirt_packets_query_api.lambda_handler(event=event, context=None)
+    response_data = json.loads(response["body"])
+
+    assert response["statusCode"] == 200
+    assert response_data["files"] == ["iois_1_packets_2025_148_16_24_27"]
+
+
+def test_packet_query_no_params():
+    """Test that providing no parameters returns a 400."""
+    event = {"queryStringParameters": {}}
+
+    response = ialirt_packets_query_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 400
+    assert "year" in response["body"]
+
+
+def test_packet_query_invalid_start_format():
+    """Test that an invalid time_utc_start format returns a 400."""
+    event = {"queryStringParameters": {"time_utc_start": "28/05/2025 16:24"}}
+
+    response = ialirt_packets_query_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 400
+    assert "isoformat" in response["body"]
+
+
+def test_packet_query_end_before_start():
+    """Test that time_utc_end <= time_utc_start returns a 400."""
+    event = {
+        "queryStringParameters": {
+            "time_utc_start": "2025-05-28T17:00:00",
+            "time_utc_end": "2025-05-28T16:00:00",
+        }
+    }
+
+    response = ialirt_packets_query_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 400
+    assert "time_utc_end" in response["body"]
+
+
+def test_packet_query_individual_params(s3_client, monkeypatch):
+    """Test that individual year/doy/hh/mm params build the correct S3 prefix."""
+    s3_client.create_bucket(Bucket="test-data-bucket")
+    monkeypatch.setenv("S3_BUCKET", "test-data-bucket")
+    monkeypatch.setenv("REGION", "us-west-2")
+
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key="packets/iois_1_packets_2025_148_16_24_27",
+        Body=b"test-data",
+    )
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key="packets/iois_1_packets_2025_148_16_24_28",
+        Body=b"test-data",
+    )
+    s3_client.put_object(
+        Bucket="test-data-bucket",
+        Key="packets/iois_1_packets_2025_149_16_24_27",  # different DOY
+        Body=b"test-data",
+    )
+
+    event = {
+        "queryStringParameters": {
+            "year": "2025",
+            "doy": "148",
+            "hh": "16",
+            "mm": "24",
+        }
     }
 
     response = ialirt_packets_query_api.lambda_handler(event=event, context=None)
@@ -39,20 +149,34 @@ def test_packet_query_within_range(s3_client, monkeypatch):
 
     assert response["statusCode"] == 200
     assert sorted(response_data["files"]) == [
-        "iois_1_packets_2025_148_16_24_27.bin",
-        "iois_1_packets_2025_148_16_24_28.bin",
+        "iois_1_packets_2025_148_16_24_27",
+        "iois_1_packets_2025_148_16_24_28",
     ]
 
 
-def test_packet_query_invalid_date(s3_client):
-    """Test that an error is returned for invalid year/doy input."""
+def test_packet_query_individual_params_invalid_date():
+    """Test that invalid year/doy returns a 400 in individual params mode."""
     event = {
         "queryStringParameters": {
             "year": "abcd",
-            "doy": "999",  # also invalid
+            "doy": "999",
         }
     }
 
     response = ialirt_packets_query_api.lambda_handler(event=event, context=None)
     assert response["statusCode"] == 400
     assert "Invalid year or day format" in response["body"]
+
+
+def test_packet_query_mixed_modes_returns_400():
+    """Test that mixing UTC range and individual params returns a 400."""
+    event = {
+        "queryStringParameters": {
+            "time_utc_start": "2025-05-28T16:24:00",
+            "year": "2025",
+        }
+    }
+
+    response = ialirt_packets_query_api.lambda_handler(event=event, context=None)
+    assert response["statusCode"] == 400
+    assert "Cannot mix" in response["body"]


### PR DESCRIPTION
This pull request refactors the `ialirt_packets_query_api` Lambda handler to support two mutually exclusive query modes for packet file retrieval: a UTC range mode using strict ISO 8601 timestamps, and an individual parameters mode using year, day-of-year, and optional time components. It also introduces comprehensive error handling for invalid or mixed query modes, and adds/updates tests to cover these scenarios.

### Query API enhancements

* Added support for two mutually exclusive query modes: UTC range mode (`time_utc_start`, `time_utc_end`) and individual params mode (`year`, `doy`, `hh`, `mm`, `ss`). Each mode builds the S3 prefix differently and applies appropriate time filtering.
* Implemented error handling for mixed usage of query modes, missing required parameters, invalid date formats, and cases where the end time is before the start time. [[1]](diffhunk://#diff-55f305da74f7a1b987795dfebc06d4b74592309e742e32af32bd1a71cdbca87bL31-R126) [[2]](diffhunk://#diff-55f305da74f7a1b987795dfebc06d4b74592309e742e32af32bd1a71cdbca87bR159)

### Lambda handler improvements

* Refactored the Lambda handler to use `.get()` for query parameters, handle missing keys gracefully, and apply post-filtering of files by exact time range when using UTC mode. [[1]](diffhunk://#diff-55f305da74f7a1b987795dfebc06d4b74592309e742e32af32bd1a71cdbca87bL31-R126) [[2]](diffhunk://#diff-55f305da74f7a1b987795dfebc06d4b74592309e742e32af32bd1a71cdbca87bR175-R181)
* Updated filename parsing and filtering logic to support the new modes and ensure only the correct files are returned for each query type.

### Testing updates

* Added new tests to cover UTC range queries, individual param queries, error cases (invalid formats, missing params, mixed modes), and updated existing tests to match the new filename format.