### PR TITLE
SWAPI/SWE now able to use predicted ephemeris for L3

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1070,7 +1070,8 @@ swapi, l3a, proton-sw, swe, l3, sci, HARD, DOWNSTREAM
 mag, l1d, norm-dsrf, swe, l3, sci, HARD, DOWNSTREAM
 imap_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
-ephemeris_reconstructed, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
+ephemeris_predicted, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
+ephemeris_reconstructed, spice, historical, swe, l3, sci, SOFT_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 pointing_attitude, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1014,8 +1014,8 @@ swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, proton-sw, HARD_NO_
 swapi, ancillary, efficiency-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 swapi, ancillary, helium-inflow-vector, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
-ephemeris_predicted, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swapi, l3a, proton-sw, SOFT_TRIGGER, DOWNSTREAM
+ephemeris_predicted, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1033,8 +1033,8 @@ swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, pui-he, HARD, DOWNS
 swapi, ancillary, efficiency-lut, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, helium-inflow-vector, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, pui-he, HARD, DOWNSTREAM
-ephemeris_predicted, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, SOFT_TRIGGER, DOWNSTREAM
+ephemeris_predicted, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1070,8 +1070,8 @@ swapi, l3a, proton-sw, swe, l3, sci, HARD, DOWNSTREAM
 mag, l1d, norm-dsrf, swe, l3, sci, HARD, DOWNSTREAM
 imap_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
-ephemeris_predicted, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swe, l3, sci, SOFT_NO_TRIGGER, DOWNSTREAM
+ephemeris_predicted, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 pointing_attitude, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1014,7 +1014,8 @@ swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, proton-sw, HARD_NO_
 swapi, ancillary, efficiency-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 swapi, ancillary, helium-inflow-vector, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
-ephemeris_reconstructed, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
+ephemeris_predicted, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
+ephemeris_reconstructed, spice, historical, swapi, l3a, proton-sw, SOFT_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1032,7 +1033,8 @@ swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, pui-he, HARD, DOWNS
 swapi, ancillary, efficiency-lut, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, helium-inflow-vector, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, pui-he, HARD, DOWNSTREAM
-ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
+ephemeris_predicted, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
+ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, SOFT_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview

Allow using predicted ephemeris for SWAPI L3a proton-sw/pui-he and SWE L3. Our intention for SWAPI with the HARD dependency on predicted and SOFT_TRIGGER dependency on reconstructed is that data can be initially processed using predicted, and then will later be automatically reprocessed once reconstructed is available.

We assume that any ephemeris change will trigger SWAPI to produce a new L3a proton-sw file, which will trigger SWE, so we don't need SWE to directly trigger on ephemeris.

## File changes

dependency_config.csv


## Testing

N/A