### PR TITLE
CODICE l2 dependency typo

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -24,7 +24,7 @@ codice, l1a, hi-sectored, codice, l1b, hi-sectored, HARD, DOWNSTREAM
 # CoDICe L2 dependencies
 codice, l1a, lo-direct-events, codice, l2, lo-direct-events, HARD, DOWNSTREAM
 codice, ancillary, l2-lo-onboard-energy-table, codice, l2, lo-direct-events, HARD, DOWNSTREAM
-codice, ancillary, l2-lo-onbaord-energy-bins, codice, l2, lo-direct-events, HARD, DOWNSTREAM
+codice, ancillary, l2-lo-onboard-energy-bins, codice, l2, lo-direct-events, HARD, DOWNSTREAM
 codice, ancillary, l2-lo-onboard-mpq-cal, codice, l2, lo-direct-events, HARD, DOWNSTREAM
 
 codice, l1a, hi-direct-events, codice, l2, hi-direct-events, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview

Sean noticed that there were no l2 lo-direct-events getting processed. I discovered it was because of a typo in the dependency csv. 
