### PR TITLE
I-ALiRT Metadata and Database Update

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -263,7 +263,9 @@ def parse_packets(filenames: list, bucket: str, download_dir: Path, apid=478):
     return combined
 
 
-def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
+def process_algorithms(  # noqa: PLR0915
+    combined: xr.Dataset, data_table, kernel_set_key, kernel_set_key_ttj2000ns
+):
     """Process the algorithms and insert data, as needed.
 
     Parameters
@@ -272,8 +274,10 @@ def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
         L0 parsed data.
     data_table : dynamodb.Table
         The DynamoDB table to insert or update the data.
-    kernel_set_key : str, optional
+    kernel_set_key : str
         The kernel set identifier.
+    kernel_set_key_ttj2000ns : int
+        The kernel set identifier in ttj2000ns.
     """
     processors = [
         ("mag", process_packet),
@@ -286,6 +290,7 @@ def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
 
     # Collect any errors during processing to raise at the end
     processing_errors = []
+    all_ancillary_files = {}
 
     for instrument, process_func in processors:
         try:
@@ -293,16 +298,21 @@ def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
                 logger.info("Processing SWE.")
                 download_path = get_ancillary(instrument, "l1b-in-flight-cal")
                 logger.info("swe l1b-in-flight-cal: %s", download_path)
+                ancillary_files = {"swe_l1b-in-flight-cal": download_path.name}
                 result = process_func(combined, [download_path])
             elif instrument == "mag":
                 logger.info("Processing MAG.")
-                download_path = get_ancillary(instrument, "ialirt-calibration")
-                ialirt_calibration_data = load_cdf(download_path)
+                ialirt_cal_path = get_ancillary(instrument, "ialirt-calibration")
+                ialirt_calibration_data = load_cdf(ialirt_cal_path)
 
-                logger.info("mag ialirt-calibration: %s", download_path)
-                download_path = get_ancillary(instrument, "l1b-calibration")
-                logger.info("mag l1b-calibration: %s", download_path)
-                l1b_calibration_data = load_cdf(download_path)
+                logger.info("mag ialirt-calibration: %s", ialirt_cal_path)
+                l1b_cal_path = get_ancillary(instrument, "l1b-calibration")
+                logger.info("mag l1b-calibration: %s", l1b_cal_path)
+                l1b_calibration_data = load_cdf(l1b_cal_path)
+                ancillary_files = {
+                    "mag_ialirt-calibration": ialirt_cal_path.name,
+                    "mag_l1b-calibration": l1b_cal_path.name,
+                }
                 result = process_func(
                     combined,
                     l1b_calibration_data,
@@ -320,6 +330,11 @@ def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
                 logger.info("codice l1a-sci-lut: %s", l1a_download_path)
                 logger.info("codice l2-lo-efficiency: %s", l2_efficiency_download_path)
                 logger.info("codice l2-lo-gfactor: %s", l2_geometric_download_path)
+                ancillary_files = {
+                    "codice_l1a-sci-lut": l1a_download_path.name,
+                    "codice_l2-lo-efficiency": l2_efficiency_download_path.name,
+                    "codice_l2-lo-gfactor": l2_geometric_download_path.name,
+                }
                 result, _ = process_func(
                     combined,
                     l1a_download_path,
@@ -338,6 +353,10 @@ def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
                 logger.info(
                     "codice l2-hi-ialirt-efficiency: %s", l2_efficiency_download_path
                 )
+                ancillary_files = {
+                    "codice_l1a-sci-lut": l1a_download_path.name,
+                    "codice_l2-hi-ialirt-efficiency": l2_efficiency_download_path.name,
+                }
                 # I-ALiRT Hi does not use a geometric factor.
                 _, result = process_func(
                     combined,
@@ -349,13 +368,16 @@ def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
                 logger.info("Processing SWAPI.")
                 download_path = get_ancillary(instrument, "esa-unit-conversion")
                 logger.info("swapi esa-unit-conversion: %s", download_path)
+                ancillary_files = {"swapi_esa-unit-conversion": download_path.name}
                 calibration_data = pd.read_csv(download_path)
                 result = process_func(combined, calibration_data)
             else:
                 logger.info("Processing HIT.")
+                ancillary_files = {}
                 result = process_func(combined)
 
             logger.info("[%s] results populated for [%s]", len(result), instrument)
+            all_ancillary_files.update(ancillary_files)
 
             if any(result) and all(result):
                 insert_formatted_data(result, data_table, instrument, kernel_set_key)
@@ -365,6 +387,16 @@ def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
             logger.error(error_msg, exc_info=True)
             processing_errors.append((instrument, e))
             # Continue to next instrument
+
+    # Insert a single ancillary record keyed to the same time_utc as the SPICE kernels.
+    if all_ancillary_files:
+        ancillary_item = {
+            "instrument": "ancillary",
+            "time_utc": kernel_set_key,
+            "ancillary_files": all_ancillary_files,
+            "ttj2000ns": kernel_set_key_ttj2000ns,
+        }
+        data_table.put_item(Item=ancillary_item)
 
 
 def reformat_data(data):
@@ -480,6 +512,8 @@ def insert_kernels(dependency_inputs, data_table):
     -------
     kernel_set_key : str
         The kernel set identifier.
+    kernet_set_key_ttj2000ns : int
+        The kernel set key for TTJ2000 ns.
     """
     last_modified = datetime.now(timezone.utc)
     last_modified_for_spice = last_modified.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -503,7 +537,7 @@ def insert_kernels(dependency_inputs, data_table):
         f"Stored SPICE kernel mapping in "
         f"DynamoDB: {json.dumps(spice_kernels, indent=2)}"
     )
-    return kernel_set_key
+    return kernel_set_key, int(met_to_ttj2000ns(met))
 
 
 def lambda_handler(event, context):
@@ -556,9 +590,13 @@ def lambda_handler(event, context):
         combined = parse_packets(filenames, bucket, Path("/tmp"))  # noqa: S108
         logger.info("Packets parsed. Processing algorithms.")
         # Insert kernel metadata every minute.
-        kernel_set_key = insert_kernels(dependency_inputs, data_table)
+        kernel_set_key, kernel_set_key_ttj2000ns = insert_kernels(
+            dependency_inputs, data_table
+        )
         # Process algorithms and insert new data.
-        process_algorithms(combined, data_table, kernel_set_key)
+        process_algorithms(
+            combined, data_table, kernel_set_key, kernel_set_key_ttj2000ns
+        )
 
         logger.info("Successfully wrote all new items to DynamoDB")
     else:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -263,19 +263,15 @@ def parse_packets(filenames: list, bucket: str, download_dir: Path, apid=478):
     return combined
 
 
-def process_algorithms(
-    combined: xr.Dataset, algorithm_table, table_name, kernel_set_key
-):
+def process_algorithms(combined: xr.Dataset, data_table, kernel_set_key):
     """Process the algorithms and insert data, as needed.
 
     Parameters
     ----------
     combined : xr.Dataset
         L0 parsed data.
-    algorithm_table : dynamodb.Table
+    data_table : dynamodb.Table
         The DynamoDB table to insert or update the data.
-    table_name : str
-        Name of the DynamoDB table
     kernel_set_key : str, optional
         The kernel set identifier.
     """
@@ -362,9 +358,7 @@ def process_algorithms(
             logger.info("[%s] results populated for [%s]", len(result), instrument)
 
             if any(result) and all(result):
-                insert_formatted_data(
-                    result, algorithm_table, instrument, kernel_set_key
-                )
+                insert_formatted_data(result, data_table, instrument, kernel_set_key)
 
         except Exception as e:
             error_msg = f"Error processing {instrument}: {e!s}"
@@ -564,7 +558,7 @@ def lambda_handler(event, context):
         # Insert kernel metadata every minute.
         kernel_set_key = insert_kernels(dependency_inputs, data_table)
         # Process algorithms and insert new data.
-        process_algorithms(combined, data_table, data_table_name, kernel_set_key)
+        process_algorithms(combined, data_table, kernel_set_key)
 
         logger.info("Successfully wrote all new items to DynamoDB")
     else:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -15,7 +15,6 @@ import pandas as pd
 import requests
 import spiceypy
 import xarray as xr
-from boto3.dynamodb.conditions import Key
 from imap_data_access.processing_input import (
     ProcessingInputCollection,
     SPICEInput,
@@ -36,10 +35,8 @@ from imap_processing.spice.geometry import (
 from imap_processing.spice.time import (
     et_to_met,
     et_to_ttj2000ns,
-    met_to_sclkticks,
     met_to_ttj2000ns,
     met_to_utc,
-    sct_to_et,
     str_to_et,
 )
 from imap_processing.utils import packet_file_to_datasets
@@ -266,7 +263,7 @@ def parse_packets(filenames: list, bucket: str, download_dir: Path, apid=478):
     return combined
 
 
-def process_algorithms(  # noqa: PLR0915
+def process_algorithms(
     combined: xr.Dataset, algorithm_table, table_name, kernel_set_key
 ):
     """Process the algorithms and insert data, as needed.
@@ -365,121 +362,15 @@ def process_algorithms(  # noqa: PLR0915
             logger.info("[%s] results populated for [%s]", len(result), instrument)
 
             if any(result) and all(result):
-                if table_name == "ialirt-algorithm-table":
-                    insert_data(result, algorithm_table, instrument, kernel_set_key)
-                else:
-                    insert_formatted_data(
-                        result, algorithm_table, instrument, kernel_set_key
-                    )
+                insert_formatted_data(
+                    result, algorithm_table, instrument, kernel_set_key
+                )
 
         except Exception as e:
             error_msg = f"Error processing {instrument}: {e!s}"
             logger.error(error_msg, exc_info=True)
             processing_errors.append((instrument, e))
             # Continue to next instrument
-
-
-def insert_data(
-    data: list[dict], algorithm_table, instrument: str, kernel_set_key: str
-):
-    """Insert or update database row, depending on content of item.
-
-    Parameters
-    ----------
-    data : list[dict]
-        Data product produced from processing respectively instrument.
-    algorithm_table : dynamodb.Table
-        The DynamoDB table to insert or update the data.
-    instrument : str
-        The prefix for the product name.
-    kernel_set_key : str
-        The kernel set identifier.
-    """
-    apid = data[0]["apid"]
-    mets = [item["met"] for item in data]
-    min_met = min(mets)
-    max_met = max(mets)
-    logger.info(f"Processing mets {min_met} to {max_met}.")
-    logger.info(f"Processing utc {met_to_utc(min_met)} to {met_to_utc(max_met)}.")
-
-    # Query existing items.
-    response = algorithm_table.query(
-        KeyConditionExpression=Key("apid").eq(apid)
-        & Key("met").between(min_met, max_met)
-    )
-
-    existing_items = {item["met"]: item for item in response.get("Items", [])}
-
-    # Insert or update as needed
-    for raw in data:
-        met = raw["met"]
-        key = {"apid": apid, "met": met}
-        existing = existing_items.get(met)
-        raw["last_modified"] = datetime.now(timezone.utc).isoformat()
-        raw["kernel_set_key"] = kernel_set_key
-
-        # Calculate the spacecraft position and velocity in GSM coordinates.
-        et = sct_to_et(met_to_sclkticks(met))
-        gsm_state = imap_state(
-            [et], ref_frame=SpiceFrame.IMAP_GSM, observer=SpiceBody.EARTH
-        )
-        gse_state = imap_state(
-            [et], ref_frame=SpiceFrame.IMAP_GSE, observer=SpiceBody.EARTH
-        )
-
-        raw["sc_position_GSM"] = [Decimal(str(val)) for val in gsm_state[0, :3]]
-        raw["sc_velocity_GSM"] = [Decimal(str(val)) for val in gsm_state[0, 3:]]
-        raw["sc_position_GSE"] = [Decimal(str(val)) for val in gse_state[0, :3]]
-        raw["sc_velocity_GSE"] = [Decimal(str(val)) for val in gse_state[0, 3:]]
-
-        if existing:
-            if any(key.startswith(instrument) for key in existing.keys()):
-                continue
-
-            update_expr = "SET " + ", ".join(
-                f"{field} = :{field}"
-                for field in raw
-                if field
-                not in {
-                    "apid",
-                    "met",
-                    "met_in_utc",
-                    "ttj2000ns",
-                    "sc_position_GSM",
-                    "sc_velocity_GSM",
-                    "sc_position_GSE",
-                    "sc_velocity_GSE",
-                    "instrument",
-                    "kernel_set_key",
-                }
-            )
-
-            expression_values = {
-                f":{field}": value
-                for field, value in raw.items()
-                if field
-                not in {
-                    "apid",
-                    "met",
-                    "met_in_utc",
-                    "ttj2000ns",
-                    "sc_position_GSM",
-                    "sc_velocity_GSM",
-                    "sc_position_GSE",
-                    "sc_velocity_GSE",
-                    "instrument",
-                    "kernel_set_key",
-                }
-            }
-
-            algorithm_table.update_item(
-                Key=key,
-                UpdateExpression=update_expr,
-                ExpressionAttributeValues=expression_values,
-            )
-        else:
-            algorithm_table.put_item(Item=raw)
-        logger.info(f"Inserted {instrument.upper()}.")
 
 
 def reformat_data(data):
@@ -581,14 +472,14 @@ def insert_formatted_data(
     data_table.put_item(Item=spacecraft)
 
 
-def insert_kernels(dependency_inputs, algorithm_table):
+def insert_kernels(dependency_inputs, data_table):
     """Insert SPICE kernel metadata into the database.
 
     Parameters
     ----------
     dependency_inputs : ProcessingInputCollection
         SPICE kernel dependencies.
-    algorithm_table : dynamodb.Table
+    data_table : dynamodb.Table
         The DynamoDB table to insert or update the data.
 
     Returns
@@ -599,32 +490,20 @@ def insert_kernels(dependency_inputs, algorithm_table):
     last_modified = datetime.now(timezone.utc)
     last_modified_for_spice = last_modified.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     met = et_to_met(str_to_et(last_modified_for_spice))
-    last_modified_utc = last_modified.isoformat()
     spice_input = dependency_inputs.processing_input[0]
     spice_kernels = dict(zip(spice_input.source, spice_input.filename_list))
 
     # Will return the same kernel_set_key for the same set of kernels.
     kernel_set_key = met_to_utc(met).split(".")[0]
 
-    if algorithm_table.table_name == "ialirt-algorithm-table":
-        kernel_item = {
-            "apid": 478,
-            "met": int(met),
-            "met_in_utc": met_to_utc(met).split(".")[0],
-            "ttj2000ns": int(met_to_ttj2000ns(met)),
-            "instrument": "spice",
-            "last_modified": last_modified_utc,
-            "spice_kernels": spice_kernels,
-        }
-    else:
-        kernel_item = {
-            "instrument": "spice",
-            "time_utc": met_to_utc(met).split(".")[0],
-            "spice_kernels": spice_kernels,
-            "ttj2000ns": int(met_to_ttj2000ns(met)),
-        }
+    kernel_item = {
+        "instrument": "spice",
+        "time_utc": met_to_utc(met).split(".")[0],
+        "spice_kernels": spice_kernels,
+        "ttj2000ns": int(met_to_ttj2000ns(met)),
+    }
 
-    algorithm_table.put_item(Item=kernel_item)
+    data_table.put_item(Item=kernel_item)
 
     logger.info(
         f"Stored SPICE kernel mapping in "
@@ -652,10 +531,8 @@ def lambda_handler(event, context):
     """
     logger.info("Received event: %s", json.dumps(event))
 
-    algorithm_table_name = os.environ.get("ALGORITHM_TABLE")
     data_table_name = os.environ.get("DATA_TABLE")
     dynamodb = boto3.resource("dynamodb")
-    algorithm_table = dynamodb.Table(algorithm_table_name)
     data_table = dynamodb.Table(data_table_name)
     url = os.environ.get("IMAP_DATA_ACCESS_URL")
 
@@ -685,13 +562,8 @@ def lambda_handler(event, context):
         combined = parse_packets(filenames, bucket, Path("/tmp"))  # noqa: S108
         logger.info("Packets parsed. Processing algorithms.")
         # Insert kernel metadata every minute.
-        kernel_set_key = insert_kernels(dependency_inputs, algorithm_table)
-        # Process algorithms and insert new data.
-        process_algorithms(
-            combined, algorithm_table, algorithm_table_name, kernel_set_key
-        )
-
         kernel_set_key = insert_kernels(dependency_inputs, data_table)
+        # Process algorithms and insert new data.
         process_algorithms(combined, data_table, data_table_name, kernel_set_key)
 
         logger.info("Successfully wrote all new items to DynamoDB")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,57 +8,6 @@ from moto import mock_dynamodb
 
 
 @pytest.fixture
-def setup_dynamodb():
-    """Initialize DynamoDB resource and create table."""
-    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
-    os.environ["INGEST_TABLE"] = "imap-ingest-table"
-    os.environ["ALGORITHM_TABLE"] = "ialirt-algorithm-table"
-
-    with mock_dynamodb():
-        # Initialize DynamoDB resource
-        dynamodb = boto3.resource("dynamodb", region_name="us-west-2")
-
-        algorithm_table = dynamodb.create_table(
-            TableName=os.environ["ALGORITHM_TABLE"],
-            KeySchema=[
-                # Partition key
-                {"AttributeName": "apid", "KeyType": "HASH"},
-                # Sort key
-                {"AttributeName": "met", "KeyType": "RANGE"},
-            ],
-            AttributeDefinitions=[
-                {"AttributeName": "apid", "AttributeType": "N"},
-                {"AttributeName": "met", "AttributeType": "N"},
-                {"AttributeName": "met_in_utc", "AttributeType": "S"},
-                {"AttributeName": "last_modified", "AttributeType": "S"},
-            ],
-            GlobalSecondaryIndexes=[
-                {
-                    "IndexName": "met_in_utc",  # Unique index name
-                    "KeySchema": [
-                        {"AttributeName": "apid", "KeyType": "HASH"},
-                        {"AttributeName": "met_in_utc", "KeyType": "RANGE"},
-                    ],
-                    "Projection": {"ProjectionType": "ALL"},
-                },
-                {
-                    "IndexName": "last_modified",  # Unique index name
-                    "KeySchema": [
-                        {"AttributeName": "apid", "KeyType": "HASH"},
-                        {"AttributeName": "last_modified", "KeyType": "RANGE"},
-                    ],
-                    "Projection": {"ProjectionType": "ALL"},
-                },
-            ],
-            BillingMode="PAY_PER_REQUEST",
-        )
-
-        yield {
-            "algorithm_table": algorithm_table,
-        }
-
-
-@pytest.fixture
 def setup_data_table():
     """Initialize DynamoDB resource and create table."""
     os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,57 @@ from moto import mock_dynamodb
 
 
 @pytest.fixture
+def setup_dynamodb():
+    """Initialize DynamoDB resource and create table."""
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
+    os.environ["INGEST_TABLE"] = "imap-ingest-table"
+    os.environ["ALGORITHM_TABLE"] = "ialirt-algorithm-table"
+
+    with mock_dynamodb():
+        # Initialize DynamoDB resource
+        dynamodb = boto3.resource("dynamodb", region_name="us-west-2")
+
+        algorithm_table = dynamodb.create_table(
+            TableName=os.environ["ALGORITHM_TABLE"],
+            KeySchema=[
+                # Partition key
+                {"AttributeName": "apid", "KeyType": "HASH"},
+                # Sort key
+                {"AttributeName": "met", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "apid", "AttributeType": "N"},
+                {"AttributeName": "met", "AttributeType": "N"},
+                {"AttributeName": "met_in_utc", "AttributeType": "S"},
+                {"AttributeName": "last_modified", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "met_in_utc",  # Unique index name
+                    "KeySchema": [
+                        {"AttributeName": "apid", "KeyType": "HASH"},
+                        {"AttributeName": "met_in_utc", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": "last_modified",  # Unique index name
+                    "KeySchema": [
+                        {"AttributeName": "apid", "KeyType": "HASH"},
+                        {"AttributeName": "last_modified", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        yield {
+            "algorithm_table": algorithm_table,
+        }
+
+
+@pytest.fixture
 def setup_data_table():
     """Initialize DynamoDB resource and create table."""
     os.environ["AWS_DEFAULT_REGION"] = "us-west-2"

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -20,7 +20,6 @@ from sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest import (
     download_spice_file,
     get_ancillary,
     get_latest_spice_kernels,
-    insert_data,
     insert_formatted_data,
     insert_kernels,
     lambda_handler,
@@ -172,80 +171,6 @@ def test_query_filenames_crossing_hour_boundary(s3_client):
     result = query_filenames(bucket, region, now)
 
     assert sorted(result) == sorted([first_prefix_key, second_prefix_key])
-
-
-@patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.imap_state",
-    return_value=np.array([[1, 2, 3, 4, 5, 6]]),
-)
-@patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.sct_to_et",
-    return_value=12345.0,
-)
-@patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.met_to_utc",
-    side_effect=lambda met: "2025-05-21T00:00:00",
-)
-def test_insert_data(
-    mock_met_to_utc,
-    mock_sct_to_et,
-    mock_imap_state,
-    setup_dynamodb,
-):
-    """Test insert_data function."""
-    algorithm_table = setup_dynamodb["algorithm_table"]
-
-    # Existing item with 'hit' keys
-    algorithm_table.put_item(
-        Item={"apid": 478, "met": 123456, "hit_e_a_side_low_en": Decimal("0.0")}
-    )
-
-    # Existing item with no 'hit' keys
-    algorithm_table.put_item(Item={"apid": 478, "met": 123457, "other_data": 42})
-
-    # Create data for all three cases
-    test_data = [
-        # Will skip.
-        {
-            "apid": 478,
-            "met": 123456,
-            "met_in_utc": "2025-05-21T14:00:00",
-            "ttj2000ns": 759175836184000000,
-            "hit_e_a_side_med_en": Decimal("2.0"),
-        },
-        # Will update.
-        {
-            "apid": 478,
-            "met": 123457,
-            "met_in_utc": "2025-05-21T14:00:01",
-            "ttj2000ns": 759175836184000001,
-            "hit_e_a_side_low_en": Decimal("3.0"),
-        },
-        # Will insert.
-        {
-            "apid": 478,
-            "met": 123458,
-            "met_in_utc": "2025-05-21T14:00:02",
-            "ttj2000ns": 759175836184000002,
-            "hit_e_a_side_low_en": Decimal("5.0"),
-        },
-    ]
-
-    insert_data(test_data, algorithm_table, "hit", "test-kernel-set-id")
-
-    item1 = algorithm_table.get_item(Key={"apid": 478, "met": 123456})["Item"]
-    item2 = algorithm_table.get_item(Key={"apid": 478, "met": 123457})["Item"]
-    item3 = algorithm_table.get_item(Key={"apid": 478, "met": 123458})["Item"]
-
-    # Not updated
-    assert item1["hit_e_a_side_low_en"] == Decimal("0.0")
-
-    # Existing item with no 'hit' data should be updated
-    assert item2["hit_e_a_side_low_en"] == Decimal("3.0")
-    assert item2["other_data"] == 42  # Original data still there
-
-    # New item should be inserted
-    assert item3["hit_e_a_side_low_en"] == Decimal("5.0")
 
 
 def test_reformat_data():
@@ -624,10 +549,10 @@ def test_insert_kernels(
     mock_et_to_met,
     mock_met_to_utc,
     mock_met_to_ttj2000ns,
-    setup_dynamodb,
+    setup_data_table,
 ):
     "Test insert_kernels function."
-    algorithm_table = setup_dynamodb["algorithm_table"]
+    data_table = setup_data_table["data_table"]
 
     spice_input = MagicMock()
     spice_input.source = ["leapseconds", "planetary_constants", "imap_frames"]
@@ -636,16 +561,15 @@ def test_insert_kernels(
     dependency_inputs = MagicMock()
     dependency_inputs.processing_input = [spice_input]
 
-    insert_kernels(dependency_inputs, algorithm_table)
+    insert_kernels(dependency_inputs, data_table)
 
-    response = algorithm_table.query(
-        KeyConditionExpression="apid = :a", ExpressionAttributeValues={":a": 478}
+    response = data_table.query(
+        KeyConditionExpression=Key("instrument").eq("spice"),
     )
     items = response["Items"]
 
-    assert items[0]["apid"] == 478
-    assert items[0]["met"] == 498089058
-    assert items[0]["met_in_utc"] == "2025-10-13T22:04:15"
+    assert items[0]["instrument"] == "spice"
+    assert items[0]["time_utc"] == "2025-10-13T22:04:15"
     assert int(items[0]["ttj2000ns"]) == 813665124895612928
     assert items[0]["spice_kernels"] == {
         "leapseconds": "naif0012.tls",

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -47,11 +47,11 @@ def s3_test_packet(s3_client):
 @patch("spiceypy.furnsh")
 @patch("imap_data_access.processing_input.ProcessingInputCollection.download_all_files")
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")
-def test_lambda_handler(mock_get, mock_download, mock_furnsh, setup_dynamodb):
+def test_lambda_handler(mock_get, mock_download, mock_furnsh, setup_data_table):
     """Test the lambda_handler function."""
     # Mock event data
-    algorithm_table = setup_dynamodb["algorithm_table"]
-    os.environ["DATA_TABLE"] = algorithm_table.name
+    data_table = setup_data_table["data_table"]
+    os.environ["DATA_TABLE"] = data_table.name
 
     mock_response = MagicMock()
     mock_response.json.return_value = [
@@ -73,15 +73,9 @@ def test_lambda_handler(mock_get, mock_download, mock_furnsh, setup_dynamodb):
 
     lambda_handler(event, {})
 
-    response = algorithm_table.get_item(
-        Key={
-            "apid": 478,
-            "met": 123,
-        }
-    )
-    item = response.get("Item")
-
-    assert item is None
+    response = data_table.scan()
+    items = response.get("Items", [])
+    assert len(items) == 0
 
 
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.packet_file_to_datasets")
@@ -359,16 +353,12 @@ def test_insert_formatted_data(
     return_value=np.array([[1, 2, 3, 4, 5, 6]]),
 )
 @patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.sct_to_et",
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.et_to_ttj2000ns",
     return_value=12345.0,
 )
 @patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.met_to_sclkticks",
-    return_value=67890.0,
-)
-@patch(
-    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.met_to_utc",
-    side_effect=lambda met: "2025-05-21T00:00:00",
+    "sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.str_to_et",
+    return_value=12345.0,
 )
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.load_cdf")
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.pd.read_csv")
@@ -385,67 +375,91 @@ def test_process_algorithms(
     mock_packet,
     mock_hit,
     mock_get_ancillary,
-    mock_load_cdf,
     mock_read_csv,
-    mock_met_to_sclkticks,
-    mock_sct_to_et,
-    mock_met_to_utc,
+    mock_load_cdf,
+    mock_str_to_et,
+    mock_et_to_ttj2000ns,
     mock_imap_state,
-    setup_dynamodb,
+    setup_data_table,
 ):
-    """Tests process_algorithms function."""
-    algorithm_table = setup_dynamodb["algorithm_table"]
+    """Test process_algorithms function."""
+    data_table = setup_data_table["data_table"]
 
-    # Mock calibration + lookup
     mock_load_cdf.return_value = {"mock": "calibration data"}
     mock_read_csv.return_value = pd.DataFrame({"mock": [1.23]})
     mock_get_ancillary.return_value = Path(
         "/mock/imap_mag_l1b-calibration_20250101_v002.cdf"
     )
 
-    # Mock algorithm outputs
     mock_hit.return_value = [
-        {"apid": 478, "met": 111, "hit_e_a_side_low_en": Decimal("1.0")}
+        {
+            "instrument": "hit",
+            "met_in_utc": "2025-05-21T00:00:01",
+            "apid": 478,
+            "met": 111,
+            "hit_e_a_side_low_en": Decimal("1.0"),
+        }
     ]
-
     mock_swe.return_value = [
         {
+            "instrument": "swe",
+            "met_in_utc": "2025-05-21T00:00:02",
             "apid": 478,
             "met": 222,
             "swe_normalized_counts_quarter_1_esa_0": Decimal("0.123"),
         }
     ]
-
     mock_packet.return_value = [
-        {"apid": 478, "met": 333, "mag_phi_4s_b_gsm": Decimal("0.456")}
+        {
+            "instrument": "mag",
+            "met_in_utc": "2025-05-21T00:00:03",
+            "apid": 478,
+            "met": 333,
+            "mag_phi_4s_b_gsm": Decimal("0.456"),
+        }
     ]
-
     mock_codice.return_value = (
         [],
-        [{"apid": 478, "met": 444, "codice": Decimal("0.111")}],  # codice_hi_data
+        [
+            {
+                "instrument": "codice_hi",
+                "met_in_utc": "2025-05-21T00:00:04",
+                "apid": 478,
+                "met": 444,
+                "codice": Decimal("0.111"),
+            }
+        ],
     )
+    mock_swapi.return_value = [
+        {
+            "instrument": "swapi",
+            "met_in_utc": "2025-05-21T00:00:05",
+            "apid": 478,
+            "met": 555,
+            "swapi": Decimal("0.123"),
+        }
+    ]
 
-    mock_swapi.return_value = [{"apid": 478, "met": 555, "swapi": Decimal("0.123")}]
-
-    # --- Call function ---
     process_algorithms(
         combined=None,
-        algorithm_table=algorithm_table,
-        table_name="ialirt-algorithm-table",
-        kernel_set_key="test-kernel-set-id",
+        data_table=data_table,
+        kernel_set_key="2025-05-21T00:00:00",
+        kernel_set_key_ttj2000ns=12345,
     )
 
-    # --- Verify DynamoDB inserts ---
-    items = algorithm_table.query(KeyConditionExpression=Key("apid").eq(478))["Items"]
-
-    assert any(item["met"] == 111 and "hit_e_a_side_low_en" in item for item in items)
-    assert any(
-        item["met"] == 222 and "swe_normalized_counts_quarter_1_esa_0" in item
-        for item in items
-    )
-    assert any(item["met"] == 333 and "mag_phi_4s_b_gsm" in item for item in items)
-    assert any(item["met"] == 444 and "codice" in item for item in items)
-    assert any(item["met"] == 555 and "swapi" in item for item in items)
+    # Query by instrument since that's the partition key
+    for instrument, _met, _field in [
+        ("hit", 111, "hit_e_a_side_low_en"),
+        ("swe", 222, "swe_normalized_counts_quarter_1_esa_0"),
+        ("mag", 333, "mag_phi_4s_b_gsm"),
+        ("codice_hi", 444, "codice"),
+        ("swapi", 555, "swapi"),
+    ]:
+        response = data_table.query(
+            KeyConditionExpression=Key("instrument").eq(instrument)
+        )
+        items = response["Items"]
+        assert items[0]["instrument"] == instrument
 
 
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_ingest.requests.get")


### PR DESCRIPTION
# Change Summary

## Overview

ialirt_ingest.py
  - Remove algorithm table ingestion: All writes to the I-ALiRT algorithm table have been removed. The lambda now writes exclusively to the data table.                                       
  - Add ancillary file tracking: Each instrument's calibration/lookup files are now recorded in DynamoDB
