### PR TITLE
BUG: Batch starter need write scope for upload API to upload dependency file

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -942,7 +942,13 @@ def upload_dependency_file(dependency_file_path: Path, serialized_dependencies: 
         )
     # call the upload API handler directly
     signed_url = upload_api.lambda_handler(
-        {"pathParameters": {"proxy": dependency_file_path.as_posix()}}, None
+        {
+            "pathParameters": {"proxy": dependency_file_path.as_posix()},
+            "requestContext": {
+                "authorizer": {"lambda": {"scope": "write", "apiKey": "batch-starter"}}
+            },
+        },
+        None,
     )
     if signed_url["statusCode"] == 409:
         logger.info(


### PR DESCRIPTION
# Change Summary

## Overview

<!--Add a list or paragraph giving an overview of your changes-->
This fixes bug in batch starter that failed to upload dependency file because upload API now expects access scope information.

## File changes

<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
Added write scope in the input since we import and call upload API lambda directly.

## Testing

<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
