### PR TITLE
CoDICE 3d distribution products use L2 lookup tables

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -75,34 +75,33 @@ codice, l3a, lo-direct-events, codice, l3a, lo-hplus-3d-distribution, HARD, DOWN
 codice, l1a, lo-sw-priority, codice, l3a, lo-hplus-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, l1a, lo-nsw-priority, codice, l3a, lo-hplus-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-geometric-factors, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, l2-lo-gfactor, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-energy-per-charge, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-hplus-efficiency, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, l2-lo-efficiency, codice, l3a, lo-hplus-3d-distribution, HARD, DOWNSTREAM
 
 codice, l3a, lo-direct-events, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 codice, l1a, lo-sw-priority, codice, l3a, lo-heplus2-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, l1a, lo-nsw-priority, codice, l3a, lo-heplus2-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-geometric-factors, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, l2-lo-gfactor, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-energy-per-charge, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-heplus2-efficiency, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
-
+codice, ancillary, l2-lo-efficiency, codice, l3a, lo-heplus2-3d-distribution, HARD, DOWNSTREAM
 
 codice, l3a, lo-direct-events, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 codice, l1a, lo-sw-priority, codice, l3a, lo-oplus6-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, l1a, lo-nsw-priority, codice, l3a, lo-oplus6-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-geometric-factors, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, l2-lo-gfactor, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-energy-per-charge, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-oplus6-efficiency, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, l2-lo-efficiency, codice, l3a, lo-oplus6-3d-distribution, HARD, DOWNSTREAM
 
 codice, l3a, lo-direct-events, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 codice, l1a, lo-sw-priority, codice, l3a, lo-heplus-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, l1a, lo-nsw-priority, codice, l3a, lo-heplus-3d-distribution, HARD_NO_TRIGGER, DOWNSTREAM
 codice, ancillary, lo-mass-species-bin-lookup, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-geometric-factors, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, l2-lo-gfactor, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 codice, ancillary, lo-energy-per-charge, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
-codice, ancillary, lo-heplus-efficiency, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
+codice, ancillary, l2-lo-efficiency, codice, l3a, lo-heplus-3d-distribution, HARD, DOWNSTREAM
 
 # <---- `GLOWS` Dependencies ---->
 glows, l0, raw, glows, l1a, all, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview

Updated CoDICE Lo L3 distribution dependencies to use shared L2 geometric factor and efficiency ancillary files.

## File changes

dependency_config.csv
