### PR TITLE
Swapi remove proton ephemeris dependency

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1030,7 +1030,7 @@ swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, pui-he, HARD, DOWNS
 swapi, ancillary, efficiency-lut, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, helium-inflow-vector, swapi, l3a, pui-he, HARD, DOWNSTREAM
 swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, pui-he, HARD, DOWNSTREAM
-ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, SOFT_TRIGGER, DOWNSTREAM
+ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, SOFT_NO_TRIGGER, DOWNSTREAM
 ephemeris_predicted, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1013,8 +1013,6 @@ swapi, ancillary, density-of-neutral-helium-lut, swapi, l3a, proton-sw, HARD_NO_
 swapi, ancillary, efficiency-lut, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 swapi, ancillary, helium-inflow-vector, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 swapi, ancillary, hydrogen-inflow-vector, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
-ephemeris_reconstructed, spice, historical, swapi, l3a, proton-sw, SOFT_TRIGGER, DOWNSTREAM
-ephemeris_predicted, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1070,7 +1068,7 @@ mag, l1d, norm-dsrf, swe, l3, sci, HARD, DOWNSTREAM
 imap_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, swe, l3, sci, SOFT_NO_TRIGGER, DOWNSTREAM
-ephemeris_predicted, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
+ephemeris_predicted, spice, historical, swe, l3, sci, HARD, DOWNSTREAM
 leapseconds, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM
 pointing_attitude, spice, historical, swe, l3, sci, HARD_NO_TRIGGER, DOWNSTREAM


### PR DESCRIPTION
# Change Summary
- Remove SWAPI l3a proton-sw dependency on ephemeris SPICE kernels
- Make SWE trigger off predicted ephemeris
- Do not trigger SWAPI pui-he on reconstructed ephemeris

## Overview
We discovered SWAPI l3a proton does not require ephemeris data.

Previously SWE did not have to be triggered by ephemeris, because we knew it was available if SWAPI proton-sw was available. Since proton-sw no longer depends on ephemeris, it is important for SWE to directly trigger off ephemeris in case predicted ephemeris is the last SWE dependency to become available.

Predicted ephemeris should be sufficient for the pickup ion computation, so we made the SOFT_TRIGGER dependency on reconstructed ephemeris a SOFT_NO_TRIGGER to prevent excess versions of the file being produced.

## File changes
- dependency_config.csv