### PR TITLE
Skip daily file check for IDEX

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/__init__.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/__init__.py
@@ -1,3 +1,5 @@
 VALID_CADENCE_STRS = ["1mo", "3mo", "6mo", "1yr"]
 
 REPOINT_DEPENDENT_INSTRUMENTS = ["glows", "hi", "lo", "ultra"]
+
+NON_DAILY_INSTRUMENTS = ["idex"]

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -1228,7 +1228,6 @@ def get_upstream_dependency_inputs(
                     require_coverage
                     and dep["data_type"] not in [DataType.ANCILLARY]
                     # Verify coverage for HARD science dependencies
-                    # TODO except idex!
                     and not verify_science_coverage(
                         records, start_date, end_date, dep, repoint
                     )

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -20,7 +20,7 @@ from ..api_lambdas import spice_metakernel_api
 from ..database import database as db
 from ..database import models
 from ..database.models import AncillaryFiles
-from . import REPOINT_DEPENDENT_INSTRUMENTS, VALID_CADENCE_STRS
+from . import NON_DAILY_INSTRUMENTS, REPOINT_DEPENDENT_INSTRUMENTS, VALID_CADENCE_STRS
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -628,6 +628,12 @@ def verify_science_coverage(
     bool
         True if coverage is complete, False if gaps exist.
     """
+    if dependency["data_source"] in NON_DAILY_INSTRUMENTS:
+        logger.info(
+            f"Skipping daily coverage verification for {dependency['data_source']} "
+            f"as it is a non-daily instrument."
+        )
+        return True
     if not records:
         return False
 
@@ -1222,6 +1228,7 @@ def get_upstream_dependency_inputs(
                     require_coverage
                     and dep["data_type"] not in [DataType.ANCILLARY]
                     # Verify coverage for HARD science dependencies
+                    # TODO except idex!
                     and not verify_science_coverage(
                         records, start_date, end_date, dep, repoint
                     )

--- a/tests/lambda_endpoints/test_dependency_api.py
+++ b/tests/lambda_endpoints/test_dependency_api.py
@@ -1692,6 +1692,28 @@ class TestVerifyScienceCoverage:
 
         assert coverage_ok is False
 
+    def test_verify_science_coverage_non_daily_instrument(self, caplog):
+        """Test verify_science_coverage when start_date equals end_date."""
+        records = [
+            ScienceRecord("file1.cdf", datetime(2024, 5, 10), None),
+        ]
+
+        dependency = {
+            "data_source": "idex",
+            "data_type": "l1a",
+            "descriptor": "sci-1week",
+        }
+
+        coverage_ok = verify_science_coverage(
+            records, datetime(2024, 5, 1), datetime(2024, 5, 10), dependency
+        )
+
+        assert coverage_ok is True
+        assert (
+            "Skipping daily coverage verification for idex as it is a non-daily"
+            " instrument"
+        ) in caplog.text
+
 
 #####################################
 # REQUIRE_COVERAGE INTEGRATION TESTS


### PR DESCRIPTION
# Change Summary

## Overview

I realized that IDEX dependencies were getting checked to make sure they have daily coverage. This will never be the case because they are ~weekly. This PR just returns true for the coverage check if the instrument is IDEX. 

## File changes
- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
- Always return true for the daily coverage check if the instrument is IDEX


## Testing

Coverage test for this case. 