### PR TITLE
IDEX l1b filename bug fix

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -511,7 +511,7 @@ def submit_all_jobs(
             # 1week, it can actually contain over a week of data, so we want to
             # add a buffer to make sure we are getting all the spice coverage we need.
             query_start_date = (
-                datetime.datetime.strptime(end_date, "%Y%m%d")
+                datetime.datetime.strptime(start_date, "%Y%m%d")
                 - datetime.timedelta(days=12)
             ).strftime("%Y%m%d")
         else:
@@ -541,7 +541,7 @@ def submit_all_jobs(
             if not upstream_deps_for_job:
                 logger.info(
                     f"Skipping job submission for {job_node} with start_date: "
-                    f"{start_date} because of a missing upstream dependency."
+                    f"{query_start_date} because of a missing upstream dependency."
                 )
                 continue
         else:

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -501,6 +501,21 @@ def submit_all_jobs(
     for filename in primary_science.filename_list:
         science_file = ScienceFilePath(filename)
         start_date, end_date = determine_date_range(session, science_file)
+        if (
+            job_node["data_source"] == "idex"
+            and job_node["descriptor"] == "sci-1week"
+            and job_node["data_type"] == "l1b"
+        ):
+            # For idex l1b sci-1week jobs, we want to use a date range of 12 days ending
+            # at the start date in the filename. Although the file is named as
+            # 1week, it can actually contain over a week of data, so we want to
+            # add a buffer to make sure we are getting all the spice coverage we need.
+            query_start_date = (
+                datetime.datetime.strptime(end_date, "%Y%m%d")
+                - datetime.timedelta(days=12)
+            ).strftime("%Y%m%d")
+        else:
+            query_start_date = start_date
 
         # Get the repointing number from the science file object
         job_repointing = science_file.repointing
@@ -516,7 +531,7 @@ def submit_all_jobs(
                 descriptor=job_node["descriptor"],
                 dependency_type="UPSTREAM",
                 relationship="ALL",
-                start_date=start_date,
+                start_date=query_start_date,
                 end_date=end_date,
                 repoint=job_repointing,
                 calculate_crids=False,
@@ -698,20 +713,6 @@ def determine_date_range(session, file_obj):
             start_date, end_date = calculate_pointing_date_range(
                 session, file_obj.repointing
             )
-        elif (
-            file_obj.instrument == "idex"
-            and "sci-1week" in file_obj.descriptor
-            and file_obj.data_level == "l1a"
-        ):
-            # For idex l1b sci-1week jobs, we want to use a date range of 12 days ending
-            # at the start date in the filename. Although the file is named as
-            # 1week, it can actually contain over a week of data, so we want to
-            # add a buffer to make sure we are getting all the spice coverage we need.
-            end_date = file_obj.start_date
-            start_date = (
-                datetime.datetime.strptime(end_date, "%Y%m%d")
-                - datetime.timedelta(days=12)
-            ).strftime("%Y%m%d")
         else:
             start_date = end_date = file_obj.start_date
     elif isinstance(file_obj, AncillaryFilePath):

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -1252,7 +1252,6 @@ def get_upstream_dependency_inputs(
                     require_coverage
                     and dep["data_type"] not in [DataType.ANCILLARY]
                     # Verify coverage for HARD science dependencies
-                    # TODO except idex!
                     and not verify_science_coverage(
                         records, start_date, end_date, dep, repoint
                     )

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency.py
@@ -1252,6 +1252,7 @@ def get_upstream_dependency_inputs(
                     require_coverage
                     and dep["data_type"] not in [DataType.ANCILLARY]
                     # Verify coverage for HARD science dependencies
+                    # TODO except idex!
                     and not verify_science_coverage(
                         records, start_date, end_date, dep, repoint
                     )

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -38,6 +38,7 @@ from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.batch_starter import 
     determine_date_range,
     determine_job_version,
     lambda_handler,
+    submit_all_jobs,
     upload_dependency_file,
 )
 
@@ -1312,6 +1313,142 @@ def test_def_cadence_map_event(
         )
 
 
+def test_idex_l1b(session, auth_event, mock_upload_request_success, caplog):
+    """Tests ``submit_all_jobs` for unique idex job with buffered query start date."""
+    _static_spice_files(session)
+    # Add idex l1a sci-1week file for 20251018 and spin file covering the date range.
+    session.add_all(
+        [
+            ScienceFiles(
+                file_path="/path/to/imap_idex_l1a_sci-1week_20251018_v001.cdf",
+                instrument="idex",
+                data_level="l1a",
+                descriptor="sci-1week",
+                start_date=datetime(2025, 10, 18),
+                version="v001",
+                extension="cdf",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),
+            # Spin file covering the buffered query window (12 days before 20251018)
+            SpinFiles(
+                file_path="imap_2025_291_2025_292_01.spin.csv",
+                start_date=datetime(2025, 10, 18),
+                end_date=datetime(2025, 10, 19),
+                version="01",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),  # Spin file covering the rest of the window
+            SpinFiles(
+                file_path="imap_2025_285_2025_291_01.spin.csv",
+                start_date=datetime(2025, 10, 6),
+                end_date=datetime(2025, 10, 18),
+                version="01",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+            ),
+            SPICEFiles(
+                file_path="path/to/imap_2000_055_2000_056_01.ah.bc",
+                file_name="imap_2000_055_2000_056_01.ah.bc",
+                ingestion_date=datetime.now(),
+                file_root="imap_2000_055_2000_056_.ah.bc",
+                kernel_type="attitude_history",
+                min_date_j2000=86400.1854936,
+                max_date_j2000=4575787269.1854936,
+                file_intervals_j2000=[[86400, 4575787269]],
+                min_date_datetime=datetime(2000, 1, 1),
+                max_date_datetime=datetime(2145, 1, 1),
+                file_intervals_datetime=[["0", "0"]],
+                min_date_sclk="",
+                max_date_sclk="",
+                file_intervals_sclk=[["0", "0"]],
+                sclk_kernel="imap_sclk_0001.tsc",
+                lsk_kernel="naif0012.tls",
+                version=1,
+            ),
+            SPICEFiles(
+                file_path="path/to/imap_recon_20240101_20240101_v01.bsp",
+                file_name="imap_recon_20240101_20240101_v01.bsp",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+                file_root="imap_recon_20240101_20240101_.bsp",
+                kernel_type="ephemeris_reconstructed",
+                min_date_j2000=0,
+                max_date_j2000=4575787269.183866,
+                file_intervals_j2000=[[0, 4575787269.183866]],
+                min_date_datetime=datetime.strptime(
+                    "2000-01-01 12:00:00+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+                max_date_datetime=datetime.strptime(
+                    "2145-01-01 00:00:00+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+                file_intervals_datetime="[[2000-01-01T00:00:00, 2145-01-01T00:00:00]]",
+                min_date_sclk="1/0000000000:00000",
+                max_date_sclk="1/4285909749:39444",
+                file_intervals_sclk="[[1/00000000000:00000, 1/4285909749:39444]]",
+                sclk_kernel="/mnt/data/imap/spice/sclk/imap_sclk_0001.tsc",
+                lsk_kernel="/mnt/data/imap/spice/lsk/naif0012.tls",
+                version=1,
+            ),
+            # Add ephemeris predicted file
+            SPICEFiles(
+                file_path="path/to/imap_pred_20240101_20240101_v01.bsp",
+                file_name="imap_pred_20240101_20240101_v01.bsp",
+                ingestion_date=datetime.strptime(
+                    "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+                file_root="imap_pred_20240101_20240101_.bsp",
+                kernel_type="ephemeris_predicted",
+                min_date_j2000=0,
+                max_date_j2000=4575787269.183866,
+                file_intervals_j2000=[[0, 4575787269.183866]],
+                min_date_datetime=datetime.strptime(
+                    "2000-01-01 12:00:00+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+                max_date_datetime=datetime.strptime(
+                    "2145-01-01 00:00:00+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+                file_intervals_datetime="[[2000-01-01T00:00:00, 2145-01-01T00:00:00]]",
+                min_date_sclk="1/0000000000:00000",
+                max_date_sclk="1/4285909749:39444",
+                file_intervals_sclk="[[1/00000000000:00000, 1/4285909749:39444]]",
+                sclk_kernel="/mnt/data/imap/spice/sclk/imap_sclk_0001.tsc",
+                lsk_kernel="/mnt/data/imap/spice/lsk/naif0012.tls",
+                version=1,
+            ),
+        ]
+    )
+
+    session.commit()
+    job_node = {
+        "data_source": "idex",
+        "data_type": "l1b",
+        "descriptor": "sci-1week",
+    }
+    with (
+        patch.object(batch_starter, "try_to_submit_job") as mock_submit,
+    ):
+        submit_all_jobs(
+            session,
+            job_node,
+            "20251018",
+            "20251018",
+            repoint=None,
+            calculate_crids=False,
+        )
+
+        # Verify that try_to_submit_job was called with the correct start date
+        assert mock_submit.call_count == 1
+        call_args = mock_submit.call_args
+        assert call_args[0][2] == "20251018", (
+            f"Expected start_date 20251018, got {call_args[0][2]}"
+        )
+
+
 def test_idex_l2b(session, auth_event, mock_upload_request_success):
     """Tests ``lambda_handler` for unique idex l2b case."""
     _static_spice_files(session)
@@ -2006,32 +2143,6 @@ def test_repoint_date_range(
             },
             retryStrategy=batch_starter.BATCH_JOB_RETRY_STRATEGY,
         )
-
-
-def test_idex_l1a_date_range(session):
-    """Test that the date range for IDEX l1a files is correct."""
-    _static_spice_files(session)
-    session.add(
-        ScienceFiles(
-            file_path="/path/to/imap_idex_l1a_sci-1week_20251020_v001.cdf",
-            instrument="idex",
-            data_level="l1a",
-            descriptor="sci-1week",
-            start_date=datetime(2025, 10, 20),
-            version="v001",
-            extension="cdf",
-            ingestion_date=datetime.strptime(
-                "2024-01-25 23:35:26+00:00", "%Y-%m-%d %H:%M:%S%z"
-            ),
-        )
-    )
-    session.commit()
-
-    filename = "imap_idex_l1a_sci-1week_20251020_v001.cdf"
-    file_obj = imap_data_access.ScienceFilePath(filename)
-    date_range = determine_date_range(session, file_obj)
-    # Idex l1b jobs should have a date range of start date - 12 days - start date
-    assert date_range == ("20251008", "20251020")
 
 
 def test_lambda_skip_processing_due_to_crid_check(session, caplog):

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1314,7 +1314,7 @@ def test_def_cadence_map_event(
 
 
 def test_idex_l1b(session, auth_event, mock_upload_request_success, caplog):
-    """Tests ``submit_all_jobs` for unique idex job with buffered query start date."""
+    """Tests ``submit_all_jobs`` for unique idex job with buffered query start date."""
     _static_spice_files(session)
     # Add idex l1a sci-1week file for 20251018 and spin file covering the date range.
     session.add_all(


### PR DESCRIPTION
# Change Summary

## Overview

I added a buffer to the idex l1b job start date but the buffer should have ONLY been added to the dependency query start date and not the start date that is used in the job file name. This caused the resulting l1b filename to have the incorrect start-date. 

## File changes

- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
- fix the special case handling for idex l1b jobs. The start date should stay the same (keep the same date as the l1a file) but the query should collect spice files from earlier than the start date. The IDEX filenames are incorrect anyway I will be fixed in the future but this is a temporary fix to get the IDEX team data. 


## Testing

Add a test to ensure we are submitting the job with the correct filename start date. 
