### PR TITLE
IDEX l1b event message job

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -1172,14 +1172,14 @@ def cadence_processing_event(
         data_level = job_node["data_type"]
         descriptor = job_node["descriptor"]
         if instrument == "idex" and data_level == "l2b":
-            # IDEX l2b jobs are dependent on idex l1b evt housekeeping files. The job
+            # IDEX l2b jobs are dependent on idex l1b msg housekeeping files. The job
             # should be offset by 1 month to allow for all the event message
             # packets to be processed for the corresponding l2a files (This should only
             # be done for first version products). L2b jobs also
-            # depend on l1b evt housekeeping files that might be before the cadence job
-            # start date. To account for this, we will query for all the l1b evt files
+            # depend on l1b msg housekeeping files that might be before the cadence job
+            # start date. To account for this, we will query for all the l1b msg files
             # including those two weeks before the cadence job start date. This should
-            # ensure that all the l1b evt files are available for the l2b job.
+            # ensure that all the l1b msg files are available for the l2b job.
             if not reprocessing:
                 offset_1month = datetime.timedelta(days=CadenceDays.ONE_MONTH)
                 start_date = (
@@ -1194,7 +1194,7 @@ def cadence_processing_event(
                 else start_date
             )
             # Subtract two weeks from the start date to get all the necessary hk files.
-            l1b_evt_start_date = (start_date - datetime.timedelta(weeks=2)).strftime(
+            l1b_msg_start_date = (start_date - datetime.timedelta(weeks=2)).strftime(
                 "%Y%m%d"
             )
             start_date = start_date.strftime("%Y%m%d")
@@ -1204,14 +1204,14 @@ def cadence_processing_event(
                 descriptor=descriptor,
                 dependency_type="UPSTREAM",
                 relationship="ALL",
-                start_date=l1b_evt_start_date,
+                start_date=l1b_msg_start_date,
                 end_date=end_date,
             )
             if not upstream_extended_idex_deps:
                 continue
-            # Extract only the processing input for the idex l2b evt files
+            # Extract only the processing input for the idex l2b msg files
             additional_input = upstream_extended_idex_deps.get_processing_inputs(
-                source="idex", data_type="l1b", descriptor="evt"
+                source="idex", data_type="l1b", descriptor="msg"
             )
         else:
             additional_input = None

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -729,6 +729,8 @@ attitude_history, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 
+idex, l1a, msg, idex, l1b, msg, HARD, DOWNSTREAM
+
 idex, l1b, sci-1week, idex, l2a, sci-1week, HARD, DOWNSTREAM
 idex, ancillary, l2a-calibration-curve-yield-params, idex, l2a, sci-1week, HARD, DOWNSTREAM
 idex, ancillary, l2a-calibration-curve-t-rise, idex, l2a, sci-1week, HARD, DOWNSTREAM
@@ -736,7 +738,7 @@ idex, ancillary, l2a-calibration-curve-t-rise, idex, l2a, sci-1week, HARD, DOWNS
 idex, l2a, sci-1week, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
-idex, l1b, evt, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
+idex, l1b, msg, idex, l2b, all-1mo, HARD_NO_TRIGGER, DOWNSTREAM
 
 # <---- LO Dependencies ---->
 lo, l0, raw, lo, l1a, all, HARD, DOWNSTREAM

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1452,16 +1452,16 @@ def test_idex_l1b(session, auth_event, mock_upload_request_success, caplog):
 def test_idex_l2b(session, auth_event, mock_upload_request_success):
     """Tests ``lambda_handler` for unique idex l2b case."""
     _static_spice_files(session)
-    # Add 2 idex l1b evt files. Although the second file is out of the month range,
+    # Add 2 idex l1b msg files. Although the second file is out of the month range,
     # It should be included in the ProcessingInputCollection because IDEX l2b jobs
     # need housekeeping files that may be before the start date of the cadence job.
     session.add_all(
         [
             ScienceFiles(
-                file_path="/path/to/imap_idex_l1b_evt_20230201_v001.cdf",
+                file_path="/path/to/imap_idex_l1b_msg_20230201_v001.cdf",
                 instrument="idex",
                 data_level="l1b",
-                descriptor="evt",
+                descriptor="msg",
                 start_date=datetime(2023, 2, 1),
                 version="v001",
                 extension="cdf",
@@ -1470,10 +1470,10 @@ def test_idex_l2b(session, auth_event, mock_upload_request_success):
                 ),
             ),
             ScienceFiles(
-                file_path="/path/to/imap_idex_l1b_evt_20230101_v001.cdf",
+                file_path="/path/to/imap_idex_l1b_msg_20230101_v001.cdf",
                 instrument="idex",
                 data_level="l1b",
-                descriptor="evt",
+                descriptor="msg",
                 start_date=datetime(2023, 1, 1),
                 version="v001",
                 extension="cdf",
@@ -1507,12 +1507,12 @@ def test_idex_l2b(session, auth_event, mock_upload_request_success):
     expected_processing_input = ProcessingInputCollection(
         SPICEInput("naif0012.tls", "imap_sclk_0000.tsc"),
         ScienceInput("imap_idex_l2a_sci-1week_20230202_v001.cdf"),
-        # There will be 2 science inputs containing l1b evt dependencies.
+        # There will be 2 science inputs containing l1b msg dependencies.
         # The second input should include both l1b housekeeping files. THe IDEX
         # l2b processing code will deduplicate all of the inputs
-        ScienceInput("imap_idex_l1b_evt_20230201_v001.cdf"),
+        ScienceInput("imap_idex_l1b_msg_20230201_v001.cdf"),
         ScienceInput(
-            "imap_idex_l1b_evt_20230201_v001.cdf", "imap_idex_l1b_evt_20230101_v001.cdf"
+            "imap_idex_l1b_msg_20230201_v001.cdf", "imap_idex_l1b_msg_20230101_v001.cdf"
         ),
     )
 
@@ -1543,7 +1543,7 @@ def test_idex_l2b(session, auth_event, mock_upload_request_success):
                     "--version",
                     "v001",
                     "--dependency",
-                    "imap_idex_l2b_all-1mo-9de6e4ae_20230109_v001.json",
+                    "imap_idex_l2b_all-1mo-4976c57e_20230109_v001.json",
                     "--upload-to-sdc",
                 ]
             },
@@ -1583,7 +1583,7 @@ def test_idex_l2b(session, auth_event, mock_upload_request_success):
                     "--version",
                     "v002",
                     "--dependency",
-                    "imap_idex_l2b_all-1mo-9de6e4ae_20230109_v002.json",
+                    "imap_idex_l2b_all-1mo-4976c57e_20230109_v002.json",
                     "--upload-to-sdc",
                 ]
             },


### PR DESCRIPTION
# Change Summary

## Overview
Add a job for IDEX l1b msg that depends on IDEX l1a msg. 

See [this ticket](https://github.com/IMAP-Science-Operations-Center/imap_processing/issues/2844) for more info 

## File changes

sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
- rename descriptor 
sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
- update descriptor name and add new l1b msg job


## Testing
Fix test to use new descriptor 