### PR TITLE
Add spice dependencies for GLOWS L2

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -132,6 +132,9 @@ glows, l1b, hist, glows, l2, hist, HARD, DOWNSTREAM
 glows, ancillary, pipeline-settings, glows, l2, hist, HARD, DOWNSTREAM
 leapseconds, spice, historical, glows, l2, hist, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, glows, l2, hist, HARD_NO_TRIGGER, DOWNSTREAM
+imap_frames, spice, historical, glows, l2, hist, HARD_NO_TRIGGER, DOWNSTREAM
+science_frames, spice, historical, glows, l2, hist, HARD_NO_TRIGGER, DOWNSTREAM
+pointing_attitude, spice, historical, glows, l2, hist, HARD_NO_TRIGGER, DOWNSTREAM
 
 glows, l2, hist, glows, l3a, hist, HARD, DOWNSTREAM
 glows, ancillary, calibration-data, glows, l3a, hist, HARD, DOWNSTREAM


### PR DESCRIPTION
This pull request adds new dependencies to the `dependency_config.csv` file for the GLOWS L2 pipeline. Specifically, it introduces three additional SPICE dependencies required for processing.

**Dependency config updates:**

* Added `imap_frames`, `science_frames`, and `pointing_attitude` SPICE dependencies for the `glows, l2, hist` pipeline, all marked as `HARD_NO_TRIGGER` and `DOWNSTREAM`.
