### PR TITLE
I-ALiRT - UKSA Architecture 2

### DIFF
--- a/sds_data_manager/constructs/ialirt_coverage_construct.py
+++ b/sds_data_manager/constructs/ialirt_coverage_construct.py
@@ -103,11 +103,11 @@ class IalirtCoverageConstruct(Construct):
     def create_event_rule(
         self, ialirt_coverage_lambda: lambda_.DockerImageFunction
     ) -> None:
-        """Create the event rule to trigger Lambda once per day."""
-        # Scheduled rule - daily at 00:00 UTC
+        """Create the event rule to trigger Lambda twice per day."""
+        # Scheduled rule - 01:00 and 13:00 UTC (one hour after schedule fetch)
         rule = events.Rule(
             self,
-            "IalirtDailyCoverageRule",
-            schedule=events.Schedule.cron(minute="0", hour="0"),
+            "IalirtCoverageRule",
+            schedule=events.Schedule.cron(minute="0", hour="1,13"),
         )
         rule.add_target(targets.LambdaFunction(ialirt_coverage_lambda))

--- a/sds_data_manager/constructs/ialirt_schedule_fetch_construct.py
+++ b/sds_data_manager/constructs/ialirt_schedule_fetch_construct.py
@@ -122,10 +122,10 @@ class IalirtScheduleFetchConstruct(Construct):
     def create_event_rule(
         self, ialirt_schedule_fetch_lambda: lambda_.DockerImageFunction
     ) -> None:
-        """Create the event rule to trigger Lambda once per hour."""
+        """Create the event rule to trigger Lambda twice per day."""
         rule = events.Rule(
             self,
-            "IalirtHourlyScheduleFetchRule",
-            schedule=events.Schedule.rate(Duration.hours(1)),
+            "IalirtScheduleFetchRule",
+            schedule=events.Schedule.cron(minute="0", hour="0,12"),
         )
         rule.add_target(targets.LambdaFunction(ialirt_schedule_fetch_lambda))

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -109,7 +109,8 @@ def parse_uksa_schedule_xml(xml_content: str) -> list[tuple[str, str]]:
     Returns
     -------
     list[tuple[str, str]]
-        List of (beginningOfTrack, endOfTrack) tuples for all scheduled activities,
+        List of (start, end) tuples derived from each activity's
+        ``beginningOfActivity`` (+30 min) and ``endOfActivity`` (-15 min),
         converted from DOY format (YYYY-DOYThh:mm:ss.sssZ) to ISO 8601 calendar format.
 
     Notes
@@ -151,19 +152,26 @@ def get_uksa(bucket: str, region: str) -> list[tuple[str, str]]:
     Returns
     -------
     list[tuple[str, str]]
-        List of (beginningOfTrack, endOfTrack) tuples from the UKSA schedule.
+        List of (start, end) tuples from the UKSA schedule, with offsets applied
+        per ``parse_uksa_schedule_xml``.
     """
     s3_client = boto3.client("s3", region_name=region)
     prefix = "ground_station_schedules/uksa/"
 
-    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
-    objects = response.get("Contents", [])
+    paginator = s3_client.get_paginator("list_objects_v2")
+    latest_obj = None
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if not obj["Key"].endswith(".xml"):
+                continue
+            if latest_obj is None or obj["LastModified"] > latest_obj["LastModified"]:
+                latest_obj = obj
 
-    if not objects:
+    if latest_obj is None:
         logger.info("No UKSA schedule files found in S3. Returning empty list.")
         return []
 
-    latest_key = sorted(objects, key=lambda x: x["Key"])[-1]["Key"]
+    latest_key = latest_obj["Key"]
     logger.info(f"Reading UKSA schedule from s3://{bucket}/{latest_key}")
 
     obj = s3_client.get_object(Bucket=bucket, Key=latest_key)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -18,7 +19,6 @@ from imap_data_access.processing_input import (
 from imap_processing.ialirt.generate_coverage import (
     format_coverage_summary,
     generate_coverage,
-    parse_uksa_schedule_xlsx,
 )
 
 logger = logging.getLogger(__name__)
@@ -98,38 +98,74 @@ def get_dsn(download_dir: Path):
     return download_path, dsn_dict
 
 
-def get_uksa(download_dir: Path) -> list[tuple[str, str]]:
-    """Query and download UKSA contact schedule data.
+def parse_uksa_schedule_xml(xml_content: str) -> list[tuple[str, str]]:
+    """Parse UKSA contact schedule XML and return track timestamps.
 
     Parameters
     ----------
-    download_dir : Path
-        The directory where the file will be downloaded.
+    xml_content : str
+        Raw XML string from the UKSA schedule file.
 
     Returns
     -------
     list[tuple[str, str]]
-        List of (start, end) contact windows from the UKSA schedule.
-    """
-    imap_data_access.config["DATA_DIR"] = download_dir
-    uksa_files = imap_data_access.query(
-        table="ancillary",
-        instrument="ialirt",
-        descriptor="uksa-contact-schedule",
-        version="latest",
-    )
+        List of (beginningOfTrack, endOfTrack) tuples for all scheduled activities,
+        converted from DOY format (YYYY-DOYThh:mm:ss.sssZ) to ISO 8601 calendar format.
 
-    if not uksa_files:
-        logger.info("No UKSA files found for IALiRT. Returning empty list.")
+    Notes
+    -----
+    Input timestamp format: 2025-177T12:40:00.000Z (year + day-of-year)
+    Output timestamp format: 2025-06-26T12:40:00Z
+    """
+    root = ET.fromstring(xml_content)  # noqa: S314
+    contacts = []
+    for activity in root.iter("scheduledActivity"):
+        start = activity.get("beginningOfTrack")
+        end = activity.get("endOfTrack")
+        if start and end:
+            start_dt = datetime.strptime(start, "%Y-%jT%H:%M:%S.%fZ")
+            end_dt = datetime.strptime(end, "%Y-%jT%H:%M:%S.%fZ")
+            contacts.append(
+                (
+                    start_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    end_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                )
+            )
+    return contacts
+
+
+def get_uksa(bucket: str, region: str) -> list[tuple[str, str]]:
+    """Read and parse the latest UKSA contact schedule XML from S3.
+
+    Parameters
+    ----------
+    bucket : str
+        The name of the S3 bucket.
+    region : str
+        The AWS region.
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        List of (beginningOfTrack, endOfTrack) tuples from the UKSA schedule.
+    """
+    s3_client = boto3.client("s3", region_name=region)
+    prefix = "ground_station_schedules/uksa/"
+
+    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    objects = response.get("Contents", [])
+
+    if not objects:
+        logger.info("No UKSA schedule files found in S3. Returning empty list.")
         return []
 
-    latest = sorted(
-        uksa_files, key=lambda x: (x["start_date"], x["version"]), reverse=True
-    )[0]
-    download_path = imap_data_access.download(latest["file_path"])
-    logger.info(f"Downloading UKSA schedule to {download_path}.")
+    latest_key = sorted(objects, key=lambda x: x["Key"])[-1]["Key"]
+    logger.info(f"Reading UKSA schedule from s3://{bucket}/{latest_key}")
 
-    return parse_uksa_schedule_xlsx(download_path)
+    obj = s3_client.get_object(Bucket=bucket, Key=latest_key)
+    xml_content = obj["Body"].read().decode("utf-8")
+
+    return parse_uksa_schedule_xml(xml_content)
 
 
 def get_latest_spice_kernels(kernels: list[str], url: str) -> ProcessingInputCollection:
@@ -341,7 +377,7 @@ def lambda_handler(event, context):
     _, dsn = get_dsn(Path("/tmp"))  # noqa: S108
 
     # Get UKSA schedule
-    uksa = get_uksa(Path("/tmp"))  # noqa: S108
+    uksa = get_uksa(bucket, region)
 
     # Download latest SPICE kernels
     dependency_inputs = get_latest_spice_kernels(

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -120,11 +120,15 @@ def parse_uksa_schedule_xml(xml_content: str) -> list[tuple[str, str]]:
     root = ET.fromstring(xml_content)  # noqa: S314
     contacts = []
     for activity in root.iter("scheduledActivity"):
-        start = activity.get("beginningOfTrack")
-        end = activity.get("endOfTrack")
+        start = activity.get("beginningOfActivity")
+        end = activity.get("endOfActivity")
         if start and end:
-            start_dt = datetime.strptime(start, "%Y-%jT%H:%M:%S.%fZ")
-            end_dt = datetime.strptime(end, "%Y-%jT%H:%M:%S.%fZ")
+            start_dt = datetime.strptime(start, "%Y-%jT%H:%M:%S.%fZ") + timedelta(
+                minutes=30
+            )
+            end_dt = datetime.strptime(end, "%Y-%jT%H:%M:%S.%fZ") - timedelta(
+                minutes=15
+            )
             contacts.append(
                 (
                     start_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_schedule_fetch.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_schedule_fetch.py
@@ -84,10 +84,11 @@ def lambda_handler(event, context):
     key_secret_name = os.environ.get("KEY_SECRET_NAME")
     region = os.environ.get("AWS_REGION")
 
-    if not url or not cert_secret_name or not key_secret_name:
+    bucket = os.environ.get("S3_BUCKET")
+    if not url or not cert_secret_name or not key_secret_name or not bucket:
         logger.info(
-            "SCHEDULE_ENDPOINT_URL, CERT_SECRET_NAME, "
-            "and KEY_SECRET_NAME are required. "
+            "SCHEDULE_ENDPOINT_URL, CERT_SECRET_NAME, KEY_SECRET_NAME, "
+            "and S3_BUCKET are required. "
             "Skipping schedule fetch."
         )
         return
@@ -97,8 +98,12 @@ def lambda_handler(event, context):
 
     xml_content = fetch_schedule_xml(url, cert_path, key_path)
 
-    bucket = os.environ.get("S3_BUCKET")
     date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
     s3_key = f"ground_station_schedules/uksa/imap_ialirt_uksa-schedule_{date_str}.xml"
-    boto3.client("s3").put_object(Bucket=bucket, Key=s3_key, Body=xml_content)
+    boto3.client("s3", region_name=region).put_object(
+        Bucket=bucket,
+        Key=s3_key,
+        Body=xml_content.encode("utf-8"),
+        ContentType="application/xml",
+    )
     logger.info(f"Saved schedule to s3://{bucket}/{s3_key}")

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_schedule_fetch.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_schedule_fetch.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 import boto3
@@ -95,4 +96,9 @@ def lambda_handler(event, context):
     key_path = write_temp_file(get_secret(key_secret_name, region), "client.key")
 
     xml_content = fetch_schedule_xml(url, cert_path, key_path)
-    logger.info(f"XML content:\n{xml_content}")
+
+    bucket = os.environ.get("S3_BUCKET")
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+    s3_key = f"ground_station_schedules/uksa/imap_ialirt_uksa-schedule_{date_str}.xml"
+    boto3.client("s3").put_object(Bucket=bucket, Key=s3_key, Body=xml_content)
+    logger.info(f"Saved schedule to s3://{bucket}/{s3_key}")

--- a/tests/infrastructure/test_ialirt_coverage_construct.py
+++ b/tests/infrastructure/test_ialirt_coverage_construct.py
@@ -40,7 +40,7 @@ def test_creates_lambda_and_rule(template):
     template.resource_count_is("AWS::Events::Rule", 1)
 
     template.has_resource_properties(
-        "AWS::Events::Rule", {"ScheduleExpression": "cron(0 0 * * ? *)"}
+        "AWS::Events::Rule", {"ScheduleExpression": "cron(0 1,13 * * ? *)"}
     )
 
 

--- a/tests/lambda_endpoints/test_ialirt_coverage.py
+++ b/tests/lambda_endpoints/test_ialirt_coverage.py
@@ -302,12 +302,17 @@ SAMPLE_UKSA_XML = """\
 
 
 def test_parse_uksa_schedule_xml():
-    """Test that parse_uksa_schedule_xml extracts and converts track timestamps."""
+    """Test that parse_uksa_schedule_xml extracts activity timestamps with offsets.
+
+    beginningOfActivity + 30 min, endOfActivity - 15 min.
+    Input:  BOA=2025-177T11:40:00Z, EOA=2025-177T14:25:00Z -> 12:10, 14:10
+            BOA=2025-177T16:00:00Z, EOA=2025-177T18:15:00Z -> 16:30, 18:00
+    """
     contacts = parse_uksa_schedule_xml(SAMPLE_UKSA_XML)
 
     assert contacts == [
-        ("2025-06-26T12:40:00Z", "2025-06-26T14:10:00Z"),
-        ("2025-06-26T16:00:00Z", "2025-06-26T18:15:00Z"),
+        ("2025-06-26T12:10:00Z", "2025-06-26T14:10:00Z"),
+        ("2025-06-26T16:30:00Z", "2025-06-26T18:00:00Z"),
     ]
 
 
@@ -335,6 +340,6 @@ def test_get_uksa(s3_client):
     result = get_uksa(bucket, region)
 
     assert result == [
-        ("2025-06-26T12:40:00Z", "2025-06-26T14:10:00Z"),
-        ("2025-06-26T16:00:00Z", "2025-06-26T18:15:00Z"),
+        ("2025-06-26T12:10:00Z", "2025-06-26T14:10:00Z"),
+        ("2025-06-26T16:30:00Z", "2025-06-26T18:00:00Z"),
     ]

--- a/tests/lambda_endpoints/test_ialirt_coverage.py
+++ b/tests/lambda_endpoints/test_ialirt_coverage.py
@@ -15,8 +15,10 @@ from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import (
     get_dsn,
     get_latest_outage_file,
     get_latest_spice_kernels,
+    get_uksa,
     lambda_handler,
     parse_outage_file,
+    parse_uksa_schedule_xml,
     setup_spice_file,
 )
 
@@ -28,9 +30,11 @@ from sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage import (
 @patch("spiceypy.furnsh")
 @patch("imap_data_access.processing_input.ProcessingInputCollection.download_all_files")
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.requests.get")
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.get_uksa")
 @patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_coverage.get_dsn")
 def test_lambda_handler(
     mock_get_dsn,
+    mock_get_uksa,
     mock_requests_get,
     mock_download,
     mock_furnsh,
@@ -63,6 +67,7 @@ def test_lambda_handler(
         Path("/imap_ialirt_contact-schedule_20260922_v001.tsv"),
         {},
     )
+    mock_get_uksa.return_value = []
     mock_generate_coverage.return_value = (
         {"DSS-55": ["some coverage"]},
         {"Kiel": ["some outage"]},
@@ -260,3 +265,76 @@ def test_get_dsn(mock_query, mock_ancillaryfilepath, mock_download, tmp_path):
         "DSS-56": [("2025-07-22T21:40:00Z", "2025-07-23T01:40:00Z")],
         "DSS-55": [("2025-07-23T22:00:00Z", "2025-07-24T01:10:00Z")],
     }
+
+
+SAMPLE_UKSA_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<simpleSchedule>
+  <simpleScheduleHeader originatingOrganization="GES"
+    generationTime="2025-177T12:25:28.379Z" version="1"
+    startTime="2025-177T12:25:28.379Z" endTime="2025-365T15:51:31.000Z"
+    status="OPERATIONAL" inclusionType="OVERLAP_INCLUSION"/>
+  <scheduledPackage user="IMAP" comment=""
+    scheduledPackageId="EVENT-2025.126.08.13.26.491418-1029794">
+    <scheduledActivity scheduledActivityId="EVENT-2025.126.08.13.26.491418-1029794"
+      siteRef="GHY6" apertureRef="GHY6"
+      beginningOfActivity="2025-177T11:40:00.000Z"
+      endOfActivity="2025-177T14:25:00.000Z"
+      beginningOfTrack="2025-177T12:40:00.000Z"
+      endOfTrack="2025-177T14:10:00.000Z"
+      activityStatus="COMMITTED">
+      <serviceInfo serviceType="TELEMETRY" frequencyBand="N/A"/>
+    </scheduledActivity>
+  </scheduledPackage>
+  <scheduledPackage user="PROVIDER-CSSS" comment=""
+    scheduledPackageId="GHY6-REQ-3674">
+    <scheduledActivity scheduledActivityId="GHY6-REQ-3674"
+      siteRef="GHY6" apertureRef="GHY6"
+      beginningOfActivity="2025-177T16:00:00.000Z"
+      endOfActivity="2025-177T18:15:00.000Z"
+      beginningOfTrack="2025-177T16:00:00.000Z"
+      endOfTrack="2025-177T18:15:00.000Z"
+      activityStatus="TENTATIVE">
+      <serviceInfo serviceType="TBD" frequencyBand="N/A"/>
+    </scheduledActivity>
+  </scheduledPackage>
+</simpleSchedule>"""
+
+
+def test_parse_uksa_schedule_xml():
+    """Test that parse_uksa_schedule_xml extracts and converts track timestamps."""
+    contacts = parse_uksa_schedule_xml(SAMPLE_UKSA_XML)
+
+    assert contacts == [
+        ("2025-06-26T12:40:00Z", "2025-06-26T14:10:00Z"),
+        ("2025-06-26T16:00:00Z", "2025-06-26T18:15:00Z"),
+    ]
+
+
+def test_get_uksa_no_files(s3_client):
+    """Test get_uksa returns empty list when no files exist in S3."""
+    bucket = "test-data-bucket"
+    region = "us-west-2"
+
+    result = get_uksa(bucket, region)
+
+    assert result == []
+
+
+def test_get_uksa(s3_client):
+    """Test get_uksa reads and parses the latest XML from S3."""
+    bucket = "test-data-bucket"
+    region = "us-west-2"
+
+    s3_client.put_object(
+        Bucket=bucket,
+        Key="ground_station_schedules/uksa/imap_ialirt_uksa-schedule_20250626.xml",
+        Body=SAMPLE_UKSA_XML.encode("utf-8"),
+    )
+
+    result = get_uksa(bucket, region)
+
+    assert result == [
+        ("2025-06-26T12:40:00Z", "2025-06-26T14:10:00Z"),
+        ("2025-06-26T16:00:00Z", "2025-06-26T18:15:00Z"),
+    ]


### PR DESCRIPTION
This pull request refactors how UKSA contact schedule data is handled for the IALiRT coverage workflow, moving from XLSX-based, local file access to a cloud-native, XML-based approach using S3. It also updates the scheduling of the relevant AWS Lambda functions to better align with data availability. Comprehensive tests have been added to ensure the correctness of the new XML parsing and S3 integration.

**UKSA schedule data handling improvements:**

* Replaced the previous XLSX-based `get_uksa` function with a new implementation that reads the latest UKSA contact schedule XML file directly from S3, parses it, and extracts contact windows with specified time offsets. (`sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py`, [[1]](diffhunk://#diff-0dab9e442295d2656764d12c44625d3dceb7b26ce995450e99d2a0a712432e6aL101-R172) [[2]](diffhunk://#diff-0dab9e442295d2656764d12c44625d3dceb7b26ce995450e99d2a0a712432e6aL344-R384)
* Added a new function `parse_uksa_schedule_xml` to parse the XML format and convert timestamps from DOY to ISO 8601, applying the required offsets. (`sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py`, [sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.pyL101-R172](diffhunk://#diff-0dab9e442295d2656764d12c44625d3dceb7b26ce995450e99d2a0a712432e6aL101-R172))
* Updated the schedule fetch Lambda to save the fetched XML schedule file to S3, ensuring the coverage Lambda can access the latest data. (`sds_data_manager/lambda_code/IAlirtCode/ialirt_schedule_fetch.py`, [sds_data_manager/lambda_code/IAlirtCode/ialirt_schedule_fetch.pyL98-R104](diffhunk://#diff-f62255e7117aaed5a9a7cb7a74c4efd2c912cc2fe2fcaa391165525e434702b2L98-R104))

**Lambda scheduling changes:**

* Changed the schedule fetch Lambda to run twice per day (at 00:00 and 12:00 UTC) instead of hourly, and the coverage Lambda to run twice per day (at 01:00 and 13:00 UTC) instead of daily, to better align with data freshness. (`sds_data_manager/constructs/ialirt_schedule_fetch_construct.py`, [[1]](diffhunk://#diff-c95110a6500a7a5e876043cd6fa458e315e7273ff8f20324e6a9d4c50c7f8507L125-R129); `sds_data_manager/constructs/ialirt_coverage_construct.py`, [[2]](diffhunk://#diff-8bf0c240e454873f734a2bd80659bede542f014fe913ec999ef9adf53fdfab15L106-R111)

**Testing improvements:**

* Added unit tests for the new XML parsing logic and S3 integration, including edge cases where no files are present. (`tests/lambda_endpoints/test_ialirt_coverage.py`, [tests/lambda_endpoints/test_ialirt_coverage.pyR268-R345](diffhunk://#diff-4c57378e8e4c4951a07969b6d5a42eee46065a5e22346b72d15c57e9f4cf5e2cR268-R345))
* Updated mocks and test setups to accommodate the new `get_uksa` and `parse_uksa_schedule_xml` functions. (`tests/lambda_endpoints/test_ialirt_coverage.py`, [[1]](diffhunk://#diff-4c57378e8e4c4951a07969b6d5a42eee46065a5e22346b72d15c57e9f4cf5e2cR18-R21) [[2]](diffhunk://#diff-4c57378e8e4c4951a07969b6d5a42eee46065a5e22346b72d15c57e9f4cf5e2cR33-R37) [[3]](diffhunk://#diff-4c57378e8e4c4951a07969b6d5a42eee46065a5e22346b72d15c57e9f4cf5e2cR70)

These changes modernize and streamline the data flow for UKSA schedules, improve reliability, and ensure the system is well-tested for the new workflow.
