### PR TITLE
imap_processing version bump

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -990,13 +990,13 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "imap-processing"
-version = "1.0.26"
+version = "1.0.27"
 description = "IMAP Science Operations Center Processing"
 optional = false
 python-versions = "<4,>=3.10"
 files = [
-    {file = "imap_processing-1.0.26-py3-none-any.whl", hash = "sha256:44d8c128d4c6b8d71024bdacd9d149f2d8f8237e035b185da0b69740cc111696"},
-    {file = "imap_processing-1.0.26.tar.gz", hash = "sha256:3b9df9a1c5d41b3cc501a9e36920e3e91508888fa955f450d58896fa827bc3a3"},
+    {file = "imap_processing-1.0.27-py3-none-any.whl", hash = "sha256:def9322eb14dd842d48c202941c31255d2e555cbd5f80c713419999eddbfabf9"},
+    {file = "imap_processing-1.0.27.tar.gz", hash = "sha256:6e126b3102b9ce19af75a6f9c23cb145b77c896fa4063b861e153d6cae1bc91c"},
 ]
 
 [package.dependencies]
@@ -2744,4 +2744,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "6aa16d3fa85b7894d4489d28cfeb9a1130d4d0e2f347044f853f29fcc34961ea"
+content-hash = "294aefb131014112481d3c0a958c67d82dfb4a99db8d2e2674bd1f8fd72903e3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ requests = "^2.28.2"
 spiceypy = "^6.0.0"
 
 [tool.poetry.group.layer-processing.dependencies]
-imap-processing = "1.0.26"
+imap-processing = "1.0.27"
 
 [tool.poetry.extras]
 doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -283,7 +283,7 @@ def process_algorithms(  # noqa: PLR0915
         ("mag", process_packet),
         ("hit", process_hit),
         ("swe", process_swe),
-        # ("codice_lo", process_codice), Removed until FSW is fixed.
+        ("codice_lo", process_codice),
         ("codice_hi", process_codice),
         ("swapi", process_swapi_ialirt),
     ]

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -179,9 +179,9 @@ idna==3.11 ; python_version >= "3.10" and python_version < "4" \
 imap-data-access==0.37.3 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:1cec14883a08e49de26c3c4ee20f54f9746da53584c5d1eae22bd52d1c4b9457 \
     --hash=sha256:26450684ef4e79f3e9ca45c29857e593487be75599db2cac5dc4a715e1eaf218
-imap-processing==1.0.26 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:3b9df9a1c5d41b3cc501a9e36920e3e91508888fa955f450d58896fa827bc3a3 \
-    --hash=sha256:44d8c128d4c6b8d71024bdacd9d149f2d8f8237e035b185da0b69740cc111696
+imap-processing==1.0.27 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:6e126b3102b9ce19af75a6f9c23cb145b77c896fa4063b861e153d6cae1bc91c \
+    --hash=sha256:def9322eb14dd842d48c202941c31255d2e555cbd5f80c713419999eddbfabf9
 lxml==6.0.2 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:058027e261afed589eddcfe530fcc6f3402d7fd7e89bfd0532df82ebc1563dba \
     --hash=sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8 \


### PR DESCRIPTION
This pull request updates dependencies and re-enables processing for a previously disabled algorithm. The most important changes are:

Dependency updates:

* Upgraded the `imap-processing` package from version `1.0.26` to `1.0.27` in both `pyproject.toml` and `requirements.txt` to ensure the latest features and bug fixes are included. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L85-R85) [[2]](diffhunk://#diff-cc8a15ab762756551934f3e9553c78546a09ffc638b7d179341292aed7c83c89L182-R184)

Feature re-enablement:

* Re-enabled the processing of the `codice_lo` algorithm by uncommenting its entry in the `process_algorithms` list in `ialirt_ingest.py`, now that the relevant FSW issue has been resolved.