### PR TITLE
I-ALiRT - add spacecraft status

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_data_query_api.py
@@ -184,7 +184,7 @@ def filter_items_by_scope(items: list[dict], scope: str) -> list[dict]:
     return filtered_items
 
 
-def lambda_handler(event, context):
+def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     """Create metadata and add it to the database.
 
     This function is an event handler for s3 ingest bucket.
@@ -235,6 +235,11 @@ def lambda_handler(event, context):
             return _error(403, "Unauthorized for HK access.")
         meta_instrument = params["instrument"]
         meta_type = "hk"
+    elif params["instrument"] == "spacecraft_status":
+        if scope not in FULL_SCOPES:
+            return _error(403, "Unauthorized for spacecraft_status access.")
+        meta_instrument = params["instrument"]
+        meta_type = "spacecraft_status"
     elif params["instrument"] == "spacecraft":
         meta_instrument = params["instrument"]
         meta_type = "spacecraft"

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -25,6 +25,7 @@ from imap_processing.cdf.utils import load_cdf
 from imap_processing.ialirt.l0.parse_mag import process_packet
 from imap_processing.ialirt.l0.process_codice import process_codice
 from imap_processing.ialirt.l0.process_hit import process_hit
+from imap_processing.ialirt.l0.process_status import process_status
 from imap_processing.ialirt.l0.process_swapi import process_swapi_ialirt
 from imap_processing.ialirt.l0.process_swe import process_swe
 from imap_processing.spice.geometry import (
@@ -286,6 +287,7 @@ def process_algorithms(  # noqa: PLR0915
         ("codice_lo", process_codice),
         ("codice_hi", process_codice),
         ("swapi", process_swapi_ialirt),
+        ("spacecraft_status", process_status),
     ]
 
     # Collect any errors during processing to raise at the end
@@ -371,8 +373,12 @@ def process_algorithms(  # noqa: PLR0915
                 ancillary_files = {"swapi_esa-unit-conversion": download_path.name}
                 calibration_data = pd.read_csv(download_path)
                 result = process_func(combined, calibration_data)
-            else:
+            elif instrument == "hit":
                 logger.info("Processing HIT.")
+                ancillary_files = {}
+                result = process_func(combined)
+            else:
+                logger.info("Processing Spacecraft Status.")
                 ancillary_files = {}
                 result = process_func(combined)
 


### PR DESCRIPTION
This pull request expands support for the `spacecraft_status` instrument in the ingestion and query APIs. It introduces the necessary import and processing logic for `spacecraft_status` data, ensures proper authorization, and updates the ingestion pipeline to handle this new instrument type.

**Support for `spacecraft_status` instrument:**

* Added import for `process_status` and included it in the instrument processing pipeline in `ialirt_ingest.py`, allowing the system to handle `spacecraft_status` data. [[1]](diffhunk://#diff-7e034b4dee5a4574c3d70d46b7516a63d46a1c9402a5945c2fe053255e9e0184R28) [[2]](diffhunk://#diff-7e034b4dee5a4574c3d70d46b7516a63d46a1c9402a5945c2fe053255e9e0184R290)
* Updated the processing logic in `process_algorithms` to correctly handle `spacecraft_status` as a new case, including logging and ancillary file handling.

**API and authorization updates:**

* Modified the `lambda_handler` in `ialirt_data_query_api.py` to add authorization checks and metadata handling for the `spacecraft_status` instrument, ensuring only authorized scopes can access this data.
* Added linter suppression comments to `lambda_handler` for code style warnings.