### PR TITLE
I-ALiRT - update version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -990,13 +990,13 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "imap-processing"
-version = "1.0.27"
+version = "1.0.28"
 description = "IMAP Science Operations Center Processing"
 optional = false
 python-versions = "<4,>=3.10"
 files = [
-    {file = "imap_processing-1.0.27-py3-none-any.whl", hash = "sha256:def9322eb14dd842d48c202941c31255d2e555cbd5f80c713419999eddbfabf9"},
-    {file = "imap_processing-1.0.27.tar.gz", hash = "sha256:6e126b3102b9ce19af75a6f9c23cb145b77c896fa4063b861e153d6cae1bc91c"},
+    {file = "imap_processing-1.0.28-py3-none-any.whl", hash = "sha256:5c98698d539757dbacb4772d4bf8dc0d55fca9e00765774e37a74e5731ff375f"},
+    {file = "imap_processing-1.0.28.tar.gz", hash = "sha256:0c645767feead29608e378d079208d037dc5c59383492309b9256b424ce586ac"},
 ]
 
 [package.dependencies]
@@ -2744,4 +2744,4 @@ doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "294aefb131014112481d3c0a958c67d82dfb4a99db8d2e2674bd1f8fd72903e3"
+content-hash = "892627281e3f71d17e457e8394e2e76322cfad417cb86e800f5bc9ad9914d5ae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ requests = "^2.28.2"
 spiceypy = "^6.0.0"
 
 [tool.poetry.group.layer-processing.dependencies]
-imap-processing = "1.0.27"
+imap-processing = "1.0.28"
 
 [tool.poetry.extras]
 doc = ["myst-parser", "pydata-sphinx-theme", "sphinx"]

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -179,9 +179,9 @@ idna==3.11 ; python_version >= "3.10" and python_version < "4" \
 imap-data-access==0.37.3 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:1cec14883a08e49de26c3c4ee20f54f9746da53584c5d1eae22bd52d1c4b9457 \
     --hash=sha256:26450684ef4e79f3e9ca45c29857e593487be75599db2cac5dc4a715e1eaf218
-imap-processing==1.0.27 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:6e126b3102b9ce19af75a6f9c23cb145b77c896fa4063b861e153d6cae1bc91c \
-    --hash=sha256:def9322eb14dd842d48c202941c31255d2e555cbd5f80c713419999eddbfabf9
+imap-processing==1.0.28 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:0c645767feead29608e378d079208d037dc5c59383492309b9256b424ce586ac \
+    --hash=sha256:5c98698d539757dbacb4772d4bf8dc0d55fca9e00765774e37a74e5731ff375f
 lxml==6.0.2 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:058027e261afed589eddcfe530fcc6f3402d7fd7e89bfd0532df82ebc1563dba \
     --hash=sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8 \


### PR DESCRIPTION
This pull request updates the version of the `imap-processing` dependency from `1.0.27` to `1.0.28` in both the Poetry and pip requirements files to ensure consistency across the project.

Dependency updates:

* Bumped the `imap-processing` package version from `1.0.27` to `1.0.28` in `pyproject.toml` to use the latest release.
* Updated the `imap-processing` package version and its associated hashes in `sds_data_manager/lambda_code/processing/requirements.txt` to match the new version.