### PR TITLE
Fix hi L1C ancillary dependency

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -214,7 +214,7 @@ ephemeris_90days, spice, best, hi, l1c, 45sensor-pset, HARD_NO_TRIGGER, DOWNSTRE
 repoint, repoint, historical, hi, l1c, 45sensor-pset, HARD_NO_TRIGGER, DOWNSTREAM
 spin, spin, historical, hi, l1c, 45sensor-pset, HARD_NO_TRIGGER, DOWNSTREAM
 hi, ancillary, 45sensor-cal-prod, hi, l1c, 45sensor-pset, HARD, DOWNSTREAM
-hi, ancillary, 45sensor-goodtimes, hi, l1c, 45sensor-pset, HARD, DOWNSTREAM
+hi, ancillary, 45sensor-backgrounds, hi, l1c, 45sensor-pset, HARD, DOWNSTREAM
 hi, l1b, 45sensor-de, hi, l1c, 45sensor-pset, HARD, DOWNSTREAM
 hi, l1b, 45sensor-goodtimes, hi, l1c, 45sensor-pset, HARD, DOWNSTREAM
 
@@ -232,7 +232,7 @@ ephemeris_90days, spice, best, hi, l1c, 90sensor-pset, HARD_NO_TRIGGER, DOWNSTRE
 repoint, repoint, historical, hi, l1c, 90sensor-pset, HARD_NO_TRIGGER, DOWNSTREAM
 spin, spin, historical, hi, l1c, 90sensor-pset, HARD_NO_TRIGGER, DOWNSTREAM
 hi, ancillary, 90sensor-cal-prod, hi, l1c, 90sensor-pset, HARD, DOWNSTREAM
-hi, ancillary, 90sensor-goodtimes, hi, l1c, 90sensor-pset, HARD, DOWNSTREAM
+hi, ancillary, 90sensor-backgrounds, hi, l1c, 90sensor-pset, HARD, DOWNSTREAM
 hi, l1b, 90sensor-de, hi, l1c, 90sensor-pset, HARD, DOWNSTREAM
 hi, l1b, 90sensor-goodtimes, hi, l1c, 90sensor-pset, HARD, DOWNSTREAM
 


### PR DESCRIPTION
# Change Summary

I goofed when I added the new ancillary dependency to Hi L1C. I named it "goodtimes" when it should have been "backgrounds". This PR fixes that.

Closes: #1233 