### PR TITLE
Increase query limit to 500

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/batch_job_query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/batch_job_query_api.py
@@ -62,7 +62,7 @@ def lambda_handler(event, context):
             select(processing_table)
             .where(and_(*filters))
             .order_by(ProcessingJob.id.desc())
-            .limit(100)
+            .limit(500)
         )
         result = session.scalars(query).all()
         logger.info(f"Query result: {result}")


### PR DESCRIPTION
This pull request increases the maximum number of results returned by the batch job query API from 100 to 500. This change allows clients to retrieve more records in a single request. This is helpful when running reprocessing for a large date range and need to see processing jobs for that time.

Closes #1240 
