### PR TITLE
Update versioning Logic in Batch Starter

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -272,19 +272,19 @@ def determine_job_version(
         )
     ).scalar()
 
-    # Step 5: By default, use the max version from the science files table unless
-    # it is a spacecraft "pointing-attitude" job. If a so, then use the max version
-    # from the processing jobs table. If the job is a spacecraft pointing-attitude job,
-    # it will produce a SPICE kernel and not a science file. There is no way to
-    # determine the filename of the kernel that will be produced, so we rely on the max
-    # version from the processing jobs table.
-    if instrument == "spacecraft" and descriptor == "pointing-attitude":
-        max_version = max_version_processing
-    else:
-        max_version = max_version_sci
+    # Step 5: Generally, we use the science files table as the source
+    # of truth for the max version. However, some jobs may complete without producing a
+    # science file (e.g. spacecraft "pointing-attitude" jobs produce a SPICE kernel
+    # instead) or we may just not produce a file due to lack of relevant data. To
+    # account for this, we take the max between the science files table
+    # and the processing jobs table. For spacecraft "pointing-attitude" jobs, the
+    # science files table will always be empty, so the max version will come solely from
+    # the processing jobs table.
+    versions = [v for v in [max_version_processing, max_version_sci] if v is not None]
+    max_version = max(int(v[1:]) for v in versions) if versions else None
 
     # Bump the version number. "V001" will be returned if max_version is None.
-    return f"v{int(max_version[1:]) + 1:03d}" if max_version else "v001"
+    return f"v{max_version + 1:03d}" if max_version else "v001"
 
 
 def dependency_hash(serialized_dependencies):

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -2398,11 +2398,11 @@ def test_lambda_skip_processing_due_to_crid_check(session, caplog):
 # Add tests to verify that the correct version is calculated.
 def test_determine_job_version_science(session):
     """Tests ``determine_job_version`` for science jobs."""
-    # For science files, the job version should be determined from the science files
-    # table. Although there is a successful job with v003, the latest science file is
-    # v001, so the next version should be v002. It is possible for a job to have
-    # Status = SUCCEEDED, but no files were produced for the job, which is why we check
-    # the science files table for the version.
+    # For science files, the job version should be determined to be the max version
+    # from the science files table and the processing job table. There is a successful
+    # processing job record with v003, but latest science file is
+    # v001. The next job version should be v004 because sometimes a job may not produce
+    # a file for a few different reasons.
     records = [
         ScienceFiles(
             file_path="/path/to/imap_lo_l1a_de_20240101_v002.cdf",
@@ -2430,8 +2430,8 @@ def test_determine_job_version_science(session):
     version = determine_job_version(
         session, "lo", "l1a", "de", datetime(2024, 1, 1), "test_dependency"
     )
-    # The version should be v002
-    assert version == "v002"
+    # The version should be v004
+    assert version == "v004"
 
 
 def test_determine_job_version_spacecraft(session):


### PR DESCRIPTION
# Change Summary

closes #1244

## Overview

We only check the science files table for max version which incorrectly can submit a duplicate processing job if the job before it did not produce a file. 

For example:

processing job for lo, l1b , bgrates v001 shows it suceeded but produced no file. 

later if you want to reprocess, batch starter checks what the max version is for lo, l1b, bgrates, finds no file and tries to submit another job using version == v001. This causes a duplicate record error because that record already exists from before and shows it succeeded. 

The fix is to check BOTH the science files table and the processing job table and use the max version. This can cause version gaps if a previous run didnt produce a file but it is better than the job getting submitted.  

## File changes

- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py 
- update comment and logic 


## Testing
update test to reflect new logic changes. 
