### PR TITLE
fix cadence trigger start dates

### DIFF
--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -167,7 +167,7 @@ class BatchStarterLambda(Construct):
         # Note: We are defining the schedules to run at minute level intervals because
         # AWS EventBridge Scheduler does not allow for decimal values in the rate
         # expression. E.g., we cannot specify "rate(91.2 days)" for 3 months.
-        # Determine the first trigger date for each map cadence:
+        # The first trigger date for each map cadence:
         #    - 3 month maps start at FIRST_MAP_START_DATE + 3 months
         #    - 6 month maps start at FIRST_MAP_START_DATE + 6 months
         #    - 1 year maps start at FIRST_MAP_START_DATE + 1 year

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -168,9 +168,18 @@ class BatchStarterLambda(Construct):
         # Note: We are defining the schedules to run at minute level intervals because
         # AWS EventBridge Scheduler does not allow for decimal values in the rate
         # expression. E.g., we cannot specify "rate(91.2 days)" for 3 months.
-        # Determine the first map trigger date by taking the start date + 3 months.
-        first_map_jobs = FIRST_MAP_START_DATE + datetime.timedelta(
+        # Determine the first trigger date for each map cadence:
+        #    - 3 month maps start at FIRST_MAP_START_DATE + 3 months
+        #    - 6 month maps start at FIRST_MAP_START_DATE + 6 months
+        #    - 1 year maps start at FIRST_MAP_START_DATE + 1 year
+        first_3mo_map_jobs = FIRST_MAP_START_DATE + datetime.timedelta(
             days=CadenceDays.THREE_MONTHS.value
+        )
+        first_6mo_map_jobs = FIRST_MAP_START_DATE + datetime.timedelta(
+            days=CadenceDays.SIX_MONTHS.value
+        )
+        first_1yr_map_jobs = FIRST_MAP_START_DATE + datetime.timedelta(
+            days=CadenceDays.ONE_YEAR.value
         )
         # 1mo jobs are not map jobs. We want them to start earlier. E.g. IDEX l2b is
         # a 1 month cadence job and the first job should be a month after launch
@@ -178,13 +187,20 @@ class BatchStarterLambda(Construct):
         first_1mo_jobs = launch_date + datetime.timedelta(
             days=CadenceDays.ONE_MONTH.value
         )
+        # Map cadence labels to their first job start dates
+        first_job_lookup = {
+            "1mo": first_1mo_jobs,
+            "3mo": first_3mo_map_jobs,
+            "6mo": first_6mo_map_jobs,
+            "1yr": first_1yr_map_jobs,
+        }
         today = datetime.datetime.now(tz=datetime.timezone.utc)
         # loop through dictionary of cadence labels and their corresponding CadenceDays
         # enum objects
         for label, cadence_obj in CadenceDays.str_lookup().items():
             # Calculate interval in minutes
             interval_minutes = int(cadence_obj.value * 24 * 60)
-            first_job = first_1mo_jobs if label == "1mo" else first_map_jobs
+            first_job = first_job_lookup[label]
             # Calculate the next run time based on the first job date and the cadence
             next_run = calculate_next_run(first_job, today, interval_minutes)
             # Format date as yyyy-MM-ddTHH:mm:ss.SSSZ (with milliseconds)

--- a/sds_data_manager/constructs/instrument_lambdas.py
+++ b/sds_data_manager/constructs/instrument_lambdas.py
@@ -19,7 +19,6 @@ from constructs import Construct
 
 from sds_data_manager.constructs.api_gateway_construct import ApiGateway
 from sds_data_manager.constructs.database_construct import SdpDatabase
-from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import FIRST_MAP_START_DATE
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.batch_starter import (
     CadenceDays,
 )
@@ -172,35 +171,14 @@ class BatchStarterLambda(Construct):
         #    - 3 month maps start at FIRST_MAP_START_DATE + 3 months
         #    - 6 month maps start at FIRST_MAP_START_DATE + 6 months
         #    - 1 year maps start at FIRST_MAP_START_DATE + 1 year
-        first_3mo_map_jobs = FIRST_MAP_START_DATE + datetime.timedelta(
-            days=CadenceDays.THREE_MONTHS.value
-        )
-        first_6mo_map_jobs = FIRST_MAP_START_DATE + datetime.timedelta(
-            days=CadenceDays.SIX_MONTHS.value
-        )
-        first_1yr_map_jobs = FIRST_MAP_START_DATE + datetime.timedelta(
-            days=CadenceDays.ONE_YEAR.value
-        )
-        # 1mo jobs are not map jobs. We want them to start earlier. E.g. IDEX l2b is
-        # a 1 month cadence job and the first job should be a month after launch
-        launch_date = datetime.datetime(2025, 9, 24, tzinfo=datetime.timezone.utc)
-        first_1mo_jobs = launch_date + datetime.timedelta(
-            days=CadenceDays.ONE_MONTH.value
-        )
-        # Map cadence labels to their first job start dates
-        first_job_lookup = {
-            "1mo": first_1mo_jobs,
-            "3mo": first_3mo_map_jobs,
-            "6mo": first_6mo_map_jobs,
-            "1yr": first_1yr_map_jobs,
-        }
+
         today = datetime.datetime.now(tz=datetime.timezone.utc)
         # loop through dictionary of cadence labels and their corresponding CadenceDays
         # enum objects
         for label, cadence_obj in CadenceDays.str_lookup().items():
             # Calculate interval in minutes
             interval_minutes = int(cadence_obj.value * 24 * 60)
-            first_job = first_job_lookup[label]
+            first_job = cadence_obj.get_first_job_start_date()
             # Calculate the next run time based on the first job date and the cadence
             next_run = calculate_next_run(first_job, today, interval_minutes)
             # Format date as yyyy-MM-ddTHH:mm:ss.SSSZ (with milliseconds)

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/__init__.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/__init__.py
@@ -7,3 +7,5 @@ REPOINT_DEPENDENT_INSTRUMENTS = ["glows", "hi", "lo", "ultra"]
 NON_DAILY_INSTRUMENTS = ["idex"]
 
 FIRST_MAP_START_DATE = datetime.datetime(2026, 1, 17, tzinfo=datetime.timezone.utc)
+
+LAUNCH_DATE = datetime.datetime(2025, 9, 24, tzinfo=datetime.timezone.utc)

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -179,7 +179,9 @@ class CadenceDays(float, Enum):
             )
         return lookup[cadence_str]
 
-    def get_first_job_start_date(self, as_string: bool = False) -> datetime.datetime:
+    def get_first_job_start_date(
+        self, as_string: bool = False
+    ) -> datetime.datetime | str:
         """Get the first job start date for this cadence.
 
         Parameters
@@ -190,10 +192,10 @@ class CadenceDays(float, Enum):
 
         Returns
         -------
-        datetime.datetime
+        datetime.datetime | str
             The first job start date for this cadence.
         """
-        if self == CadenceDays.ONE_MONTH:
+        if self.value == CadenceDays.ONE_MONTH.value:
             # 1mo jobs are not map jobs. We want them to start earlier. E.g. IDEX l2b is
             # a 1 month cadence job and the first job should be a month after launch
             start_date = LAUNCH_DATE + datetime.timedelta(days=self.value)

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -28,6 +28,7 @@ from ..database import database as db
 from ..database import models
 from . import (
     FIRST_MAP_START_DATE,
+    LAUNCH_DATE,
     REPOINT_DEPENDENT_INSTRUMENTS,
     VALID_CADENCE_STRS,
     dependency,
@@ -177,6 +178,33 @@ class CadenceDays(float, Enum):
                 f" {cls.valid_cadence_str()}"
             )
         return lookup[cadence_str]
+
+    def get_first_job_start_date(self, as_string: bool = False) -> datetime.datetime:
+        """Get the first job start date for this cadence.
+
+        Parameters
+        ----------
+        as_string : bool
+            If True, return the date as a string in the format 'YYYYMMDD'.
+            Default is False.
+
+        Returns
+        -------
+        datetime.datetime
+            The first job start date for this cadence.
+        """
+        if self == CadenceDays.ONE_MONTH:
+            # 1mo jobs are not map jobs. We want them to start earlier. E.g. IDEX l2b is
+            # a 1 month cadence job and the first job should be a month after launch
+            start_date = LAUNCH_DATE + datetime.timedelta(days=self.value)
+        else:
+            # For map jobs, we want the first job to start at the first map start date
+            # plus the cadence. E.g.:
+            #    - 3 month maps start at FIRST_MAP_START_DATE + 3 months
+            #    - 6 month maps start at FIRST_MAP_START_DATE + 6 months
+            #    - 1 year maps start at FIRST_MAP_START_DATE + 1 year
+            start_date = FIRST_MAP_START_DATE + datetime.timedelta(days=self.value)
+        return start_date.strftime("%Y%m%d") if as_string else start_date
 
 
 def determine_job_version(

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -781,7 +781,7 @@ leapseconds, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREA
 spacecraft_clock, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, idex, l1b, sci-1week, HARD, DOWNSTREAM
+attitude_history, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, idex, l1b, sci-1week, HARD_NO_TRIGGER, DOWNSTREAM
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1669,7 +1669,7 @@ def test_cadence_to_datetime_range():
 
 
 def test_cadence_start_map_start_dates():
-    """Test that the cadence start date for map jobs is correct."""
+    """Test that the cadence start date for cadence jobs is correct."""
     # Verify each cadence obj returns the expected start date
     assert CadenceDays.ONE_MONTH.get_first_job_start_date(as_string=True) == "20251024"
     assert (
@@ -1677,6 +1677,10 @@ def test_cadence_start_map_start_dates():
     )
     assert CadenceDays.SIX_MONTHS.get_first_job_start_date(as_string=True) == "20260718"
     assert CadenceDays.ONE_YEAR.get_first_job_start_date(as_string=True) == "20270117"
+    # check that the start date is a datetime object when as_string is False
+    assert isinstance(
+        CadenceDays.ONE_MONTH.get_first_job_start_date(as_string=False), datetime
+    )
 
 
 def test_upload_dependency_file(

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1882,12 +1882,6 @@ def test_dependency_success():
             "descriptor": "historical",
             "relationship": "HARD",
         },
-        {
-            "data_source": "attitude_history",
-            "data_type": "spice",
-            "descriptor": "historical",
-            "relationship": "HARD",
-        },
     ]
 
 

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -1668,6 +1668,17 @@ def test_cadence_to_datetime_range():
         )
 
 
+def test_cadence_start_map_start_dates():
+    """Test that the cadence start date for map jobs is correct."""
+    # Verify each cadence obj returns the expected start date
+    assert CadenceDays.ONE_MONTH.get_first_job_start_date(as_string=True) == "20251024"
+    assert (
+        CadenceDays.THREE_MONTHS.get_first_job_start_date(as_string=True) == "20260418"
+    )
+    assert CadenceDays.SIX_MONTHS.get_first_job_start_date(as_string=True) == "20260718"
+    assert CadenceDays.ONE_YEAR.get_first_job_start_date(as_string=True) == "20270117"
+
+
 def test_upload_dependency_file(
     s3_client, tmp_path, dependency_file, caplog, mock_upload_request_success
 ):


### PR DESCRIPTION
# Change Summary

closes #1262

## Overview

Fix the start dates of the 6mo and 1yr cadence maps. 

## File changes

- sds_data_manager/constructs/instrument_lambdas.py
  - make sure the 6mo and 1yr maps are using the correct start date. 

