### PR TITLE
I-ALiRT - add alarm for missing instrument data

### DIFF
--- a/sds_data_manager/constructs/ialirt_alarm_construct.py
+++ b/sds_data_manager/constructs/ialirt_alarm_construct.py
@@ -3,6 +3,7 @@
 from aws_cdk import (
     Duration,
     RemovalPolicy,
+    aws_dynamodb,
     aws_s3,
 )
 from aws_cdk import (
@@ -38,6 +39,7 @@ class IalirtAlarmConstruct(Construct):
         construct_id: str,
         code: lambda_.Code,
         ialirt_bucket: aws_s3.Bucket,
+        data_table: aws_dynamodb.Table,
         **kwargs,
     ) -> None:
         """Create ialirt alarms and rsync failure notifications.
@@ -52,6 +54,8 @@ class IalirtAlarmConstruct(Construct):
             Lambda code bundle.
         ialirt_bucket : aws_s3.Bucket
             The data bucket to monitor.
+        data_table : aws_dynamodb.Table
+            The ialirt-data-table to monitor for instrument freshness.
         kwargs : dict
             Keyword arguments.
 
@@ -66,24 +70,16 @@ class IalirtAlarmConstruct(Construct):
         ialirt_alarm_email = ssm.StringParameter.value_for_string_parameter(
             self, "/imap/ialirt/alarm_email"
         )
-        # Phone number to text in the case of no packets.
-        ialirt_ssm = ssm.StringParameter.value_for_string_parameter(
-            self, "/imap/ialirt/alarm_ssm_number"
-        )
-        no_packets_topic = sns.Topic(
+        operation_topic = sns.Topic(
             self,
             "IalirtAlarmTopics",
-            display_name="I-ALiRT No Packet Alarm Notifications",
+            display_name="I-ALiRT Operations Alarm Notifications",
         )
         if ialirt_alarm_email:
-            no_packets_topic.add_subscription(
-                subs.EmailSubscription(ialirt_alarm_email)
-            )
-        if ialirt_ssm:
-            no_packets_topic.add_subscription(subs.SmsSubscription(ialirt_ssm))
+            operation_topic.add_subscription(subs.EmailSubscription(ialirt_alarm_email))
 
         # Create CloudWatch monitoring for 'no packets arrived' condition.
-        self.setup_monitoring(ialirt_bucket, no_packets_topic)
+        self.setup_monitoring(ialirt_bucket, operation_topic)
 
         # Setup a notification for rsync failures.
         ops_alarm_email = ssm.StringParameter.value_for_string_parameter(
@@ -97,6 +93,9 @@ class IalirtAlarmConstruct(Construct):
 
         # Create rsync Lambda + event trigger
         self.create_rsync_lambda(ialirt_bucket, code, rsync_topic)
+
+        # Create instrument freshness alarm Lambda + daily schedule
+        self.create_instrument_alarm_lambda(code, data_table, operation_topic)
 
     def create_rsync_lambda(
         self,
@@ -200,3 +199,74 @@ class IalirtAlarmConstruct(Construct):
         alarm.add_alarm_action(cloudwatch_actions.SnsAction(alarm_topic))
 
         return alarm
+
+    def create_instrument_alarm_lambda(
+        self,
+        code: lambda_.Code,
+        data_table: aws_dynamodb.Table,
+        alarm_topic: sns.Topic,
+    ) -> lambda_.Function:
+        """Create a scheduled Lambda that alerts when an instrument has no recent data.
+
+        Parameters
+        ----------
+        code : lambda_.Code
+            Lambda code bundle.
+        data_table : aws_dynamodb.Table
+            The ialirt-data-table to query for instrument freshness.
+        alarm_topic : sns.Topic
+            SNS topic to publish alerts to.
+
+        Returns
+        -------
+        lambda_.Function
+            The created Lambda function.
+
+        """
+        lambda_role = iam.Role(
+            self,
+            "IalirtInstrumentAlarmRole",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AWSLambdaBasicExecutionRole"
+                ),
+            ],
+        )
+
+        lambda_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["sns:Publish"],
+                resources=[alarm_topic.topic_arn],
+            )
+        )
+
+        data_table.grant_read_data(lambda_role)
+
+        instrument_alarm_lambda = lambda_.Function(
+            self,
+            id="IalirtInstrumentAlarmLambda",
+            function_name="ialirt-instrument-alarm",
+            code=code,
+            handler="IAlirtCode.ialirt_instrument_alarm.lambda_handler",
+            runtime=lambda_.Runtime.PYTHON_3_12,
+            timeout=Duration.minutes(1),
+            memory_size=256,
+            role=lambda_role,
+            environment={
+                "DATA_TABLE": data_table.table_name,
+                "SNS_TOPIC_ARN": alarm_topic.topic_arn,
+            },
+        )
+
+        instrument_alarm_lambda.apply_removal_policy(RemovalPolicy.DESTROY)
+
+        daily_rule = events.Rule(
+            self,
+            "IalirtInstrumentAlarmSchedule",
+            rule_name="ialirt-instrument-alarm-schedule",
+            schedule=events.Schedule.rate(Duration.hours(8)),
+        )
+        daily_rule.add_target(targets.LambdaFunction(instrument_alarm_lambda))
+
+        return instrument_alarm_lambda

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_instrument_alarm.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_instrument_alarm.py
@@ -1,0 +1,102 @@
+"""IALiRT instrument data freshness alarm lambda."""
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+INSTRUMENTS = ["hit", "mag", "codice_hi", "codice_lo", "swe", "swapi"]
+
+
+def check_instrument(table, instrument: str, cutoff: str) -> bool:
+    """Return True if the instrument has data within the last 8 hours.
+
+    Parameters
+    ----------
+    table : boto3 DynamoDB Table resource
+        Table resource used to query.
+    instrument : str
+        Instrument partition key value.
+    cutoff : str
+        ISO 8601 timestamp; items with time_utc >= this value are considered fresh.
+
+    Returns
+    -------
+    bool
+        True if at least one item exists within the cutoff window.
+
+    """
+    response = table.query(
+        KeyConditionExpression=Key("instrument").eq(instrument)
+        & Key("time_utc").gte(cutoff),
+        Limit=1,
+    )
+    return response["Count"] > 0
+
+
+def notify_missing(sns_client, topic_arn: str, missing: list) -> None:
+    """Publish an SNS alert for instruments with no recent data.
+
+    Parameters
+    ----------
+    sns_client : boto3 SNS client
+        Client used to publish the notification.
+    topic_arn : str
+        ARN of the SNS topic.
+    missing : list
+        Instrument names that have not reported data.
+
+    """
+    instruments_str = ", ".join(missing)
+    message = (
+        f"The following instruments have not reported data in the last 8 hours: "
+        f"{instruments_str}"
+    )
+    sns_client.publish(
+        TopicArn=topic_arn,
+        Subject="I-ALiRT Instrument Data Missing",
+        Message=message,
+    )
+    logger.info("Published SNS alert for missing instruments: %s", instruments_str)
+
+
+def lambda_handler(event, context):
+    """Check each instrument for data within the last 8 hours.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process.
+    context : LambdaContext
+        This object provides methods and properties that provide
+        information about the invocation, function,
+        and runtime environment.
+
+    """
+    logger.info("Received event: %s", json.dumps(event))
+
+    table_name = os.environ["DATA_TABLE"]
+    topic_arn = os.environ["SNS_TOPIC_ARN"]
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=8)).isoformat()
+
+    table = boto3.resource("dynamodb").Table(table_name)
+    sns_client = boto3.client("sns")
+
+    missing = [
+        instrument
+        for instrument in INSTRUMENTS
+        if not check_instrument(table, instrument, cutoff)
+    ]
+
+    if missing:
+        notify_missing(sns_client, topic_arn, missing)
+
+    return {"missing_instruments": missing}

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -417,6 +417,7 @@ def build_sds(
         construct_id="IalirtAlarm",
         code=lambda_.Code.from_asset(str(Path(__file__).parent.parent / "lambda_code")),
         ialirt_bucket=ialirt_bucket.ialirt_bucket,
+        data_table=ingest.data_table,
     )
 
     ialirt_monitoring = monitoring_construct.MonitoringConstruct(

--- a/tests/lambda_endpoints/test_ialirt_instrument_alarm.py
+++ b/tests/lambda_endpoints/test_ialirt_instrument_alarm.py
@@ -1,10 +1,13 @@
 """Test the I-ALiRT instrument data freshness alarm lambda."""
 
+import os
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from sds_data_manager.lambda_code.IAlirtCode.ialirt_instrument_alarm import (
+    INSTRUMENTS,
     check_instrument,
+    lambda_handler,
     notify_missing,
 )
 
@@ -37,3 +40,14 @@ def test_notify_missing_publishes_correct_message(mock_boto3_client):
             "hit, mag"
         ),
     )
+
+
+@patch("sds_data_manager.lambda_code.IAlirtCode.ialirt_instrument_alarm.notify_missing")
+def test_lambda_handler_returns_missing_instruments(mock_notify, setup_data_table):
+    """lambda_handler returns all instruments as missing when table is empty."""
+    os.environ["SNS_TOPIC_ARN"] = TOPIC_ARN
+
+    result = lambda_handler({}, None)
+
+    assert result["missing_instruments"] == INSTRUMENTS
+    mock_notify.assert_called_once()

--- a/tests/lambda_endpoints/test_ialirt_instrument_alarm.py
+++ b/tests/lambda_endpoints/test_ialirt_instrument_alarm.py
@@ -1,0 +1,39 @@
+"""Test the I-ALiRT instrument data freshness alarm lambda."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from sds_data_manager.lambda_code.IAlirtCode.ialirt_instrument_alarm import (
+    check_instrument,
+    notify_missing,
+)
+
+TOPIC_ARN = "arn:aws:sns:us-east-1:123456789012:TestTopic"
+
+
+def test_check_instrument_returns_true_when_recent_data(setup_data_table):
+    """check_instrument returns True when a recent item exists."""
+    table = setup_data_table["data_table"]
+    table.put_item(
+        Item={
+            "instrument": "hit",
+            "time_utc": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+        }
+    )
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=8)).isoformat()
+    assert check_instrument(table, "hit", cutoff) is True
+
+
+@patch("boto3.client")
+def test_notify_missing_publishes_correct_message(mock_boto3_client):
+    """notify_missing publishes the expected SNS message."""
+    mock_sns = mock_boto3_client.return_value
+    notify_missing(mock_sns, TOPIC_ARN, ["hit", "mag"])
+    mock_sns.publish.assert_called_once_with(
+        TopicArn=TOPIC_ARN,
+        Subject="I-ALiRT Instrument Data Missing",
+        Message=(
+            "The following instruments have not reported data in the last 8 hours: "
+            "hit, mag"
+        ),
+    )


### PR DESCRIPTION
This pull request introduces a new scheduled Lambda function to monitor the freshness of instrument data in the I-ALiRT system, sending alerts if any instrument has not reported data within the last 8 hours. It updates the `ialirt_alarm_construct` to support this feature, adds the Lambda implementation, and includes tests for the new logic.

**Instrument Data Freshness Monitoring**

* Added a new Lambda function (`ialirt_instrument_alarm`) that checks DynamoDB for recent data from each instrument and sends an SNS alert if any are missing. The Lambda is scheduled to run every 8 hours and is integrated into the `ialirt_alarm_construct`. [[1]](diffhunk://#diff-98bc3e20a79e4254a5b8ca59394ad4f6e185f40920b7cfbc0aa1487e32fc9249R97-R99) [[2]](diffhunk://#diff-98bc3e20a79e4254a5b8ca59394ad4f6e185f40920b7cfbc0aa1487e32fc9249R202-R272) [[3]](diffhunk://#diff-af59d44b3ac9a33bdfd437773ebbd192e99fa121430986a00e886ef6f21e2b1bR1-R102)
* Updated the `ialirt_alarm_construct` to accept a `data_table` parameter (DynamoDB table) and pass it to the new Lambda, including updates to documentation and constructor signature. [[1]](diffhunk://#diff-98bc3e20a79e4254a5b8ca59394ad4f6e185f40920b7cfbc0aa1487e32fc9249R6) [[2]](diffhunk://#diff-98bc3e20a79e4254a5b8ca59394ad4f6e185f40920b7cfbc0aa1487e32fc9249R42) [[3]](diffhunk://#diff-98bc3e20a79e4254a5b8ca59394ad4f6e185f40920b7cfbc0aa1487e32fc9249R57-R58) [[4]](diffhunk://#diff-1fd5f2574e77f4c3b009083385c0626699731348110f7543441a12b09195e6f3R420)

**Alarm Notification Improvements**

* Refactored SNS topic creation for operation alarms, consolidating email and SMS subscriptions into a single topic and updating naming for clarity.

**Testing**

* Added unit tests for the new Lambda's core functions, ensuring correct detection of missing instruments and proper SNS notification behavior.