### PR TITLE
ULTRA l1c reduce reprocessing

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1387,22 +1387,22 @@ ultra, l1a, 45sensor-rates, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 45sensor-aux, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1b, 45sensor-goodtimes, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 
-ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-sc-pointing-theta, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-sc-pointing-phi, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-sc-pointing-index, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-sc-pointing-bsf, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
-ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-45sensor-imgparams-lookup, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
+ultra, ancillary, l1b-45sensor-imgparams-lookup, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-static-dead-times, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-de-product-lookup, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
-ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
+ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
+ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
-ultra, ancillary, l1b-45sensor-imgparams-lookup, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-45sensor-imgparams-lookup, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-static-dead-times, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-de-product-lookup, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 
@@ -1640,22 +1640,22 @@ ultra, l1a, 90sensor-rates, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1a, 90sensor-aux, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, l1b, 90sensor-goodtimes, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 
-ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-sc-pointing-theta, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-sc-pointing-phi, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-sc-pointing-index, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-sc-pointing-bsf, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
-ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-90sensor-imgparams-lookup, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-imgparams-lookup, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-static-dead-times, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-de-product-lookup, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
-ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
+ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
-ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-90sensor-imgparams-lookup, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-imgparams-lookup, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-static-dead-times, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-de-product-lookup, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1218,7 +1218,7 @@ ultra, ancillary, l1b-45sensor-spbtphcorr, ultra, l1b, 45sensor-de, HARD, DOWNST
 ultra, ancillary, l1b-45sensor-sptpphcorr, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
-ultra, ancillary, l1b-45sensor-de-product-lookup, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, l1b-45sensor-de-product-lookup, ultra, l1b, 45sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
 
 ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1b, 45sensor-priority-1-de, HARD, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-leftslit-lookup, ultra, l1b, 45sensor-priority-1-de, HARD, DOWNSTREAM
@@ -1394,19 +1394,19 @@ ultra, ancillary, l1c-45sensor-sc-pointing-index, ultra, l1c, 45sensor-spacecraf
 ultra, ancillary, l1c-45sensor-sc-pointing-bsf, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-imgparams-lookup, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-static-dead-times, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-45sensor-de-product-lookup, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1c-45sensor-de-product-lookup, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-imgparams-lookup, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-static-dead-times, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-45sensor-de-product-lookup, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
+ultra, ancillary, l1c-45sensor-de-product-lookup, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 
 repoint, repoint, historical, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 spacecraft_clock, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1415,7 +1415,7 @@ planetary_ephemeris, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HAR
 pointing_attitude, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 science_frames, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 spin, spin, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
@@ -1424,7 +1424,7 @@ leapseconds, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER,
 ephemeris_reconstructed, spice, historical, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1473,7 +1473,7 @@ ultra, ancillary, l1b-90sensor-spbtphcorr, ultra, l1b, 90sensor-de, HARD, DOWNST
 ultra, ancillary, l1b-90sensor-sptpphcorr, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
-ultra, ancillary, l1b-90sensor-de-product-lookup, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-de-product-lookup, ultra, l1b, 90sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
 
 ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1b, 90sensor-priority-1-de, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-leftslit-lookup, ultra, l1b, 90sensor-priority-1-de, HARD, DOWNSTREAM
@@ -1649,19 +1649,19 @@ ultra, ancillary, l1c-90sensor-sc-pointing-index, ultra, l1c, 90sensor-spacecraf
 ultra, ancillary, l1c-90sensor-sc-pointing-bsf, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-imgparams-lookup, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-static-dead-times, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-90sensor-de-product-lookup, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
+ultra, ancillary, l1c-90sensor-de-product-lookup, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
+ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-imgparams-lookup, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-static-dead-times, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1c-90sensor-de-product-lookup, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
+ultra, ancillary, l1c-90sensor-de-product-lookup, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 
 repoint, repoint, historical, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 spacecraft_clock, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1670,7 +1670,7 @@ planetary_ephemeris, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HAR
 pointing_attitude, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 science_frames, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 spin, spin, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
@@ -1679,7 +1679,7 @@ leapseconds, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER,
 ephemeris_reconstructed, spice, historical, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1301,11 +1301,11 @@ leapseconds, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNST
 ephemeris_reconstructed, spice, historical, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 45sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 45sensor-de, HARD, DOWNSTREAM
 
@@ -1314,11 +1314,11 @@ leapseconds, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD_NO_TRIG
 ephemeris_reconstructed, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 45sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 45sensor-priority-1-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 45sensor-priority-1-de, HARD, DOWNSTREAM
 
@@ -1327,11 +1327,11 @@ leapseconds, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD_NO_TRIG
 ephemeris_reconstructed, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 45sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 45sensor-priority-2-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 45sensor-priority-2-de, HARD, DOWNSTREAM
 
@@ -1340,11 +1340,11 @@ leapseconds, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD_NO_TRIG
 ephemeris_reconstructed, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 45sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 45sensor-priority-3-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 45sensor-priority-3-de, HARD, DOWNSTREAM
 
@@ -1353,11 +1353,11 @@ leapseconds, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD_NO_TRIG
 ephemeris_reconstructed, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 45sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 45sensor-priority-4-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 45sensor-priority-4-de, HARD, DOWNSTREAM
 
@@ -1365,7 +1365,7 @@ spacecraft_clock, spice, historical, ultra, l1b, 45sensor-extendedspin, HARD, DO
 leapseconds, spice, historical, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 45sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 45sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, ultra, l1b, 45sensor-extendedspin, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 45sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 45sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1410,7 +1410,7 @@ repoint, repoint, historical, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTR
 spacecraft_clock, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 spin, spin, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1426,7 +1426,7 @@ attitude_history, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRI
 imap_frames, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 spin, spin, historical, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 
 # Ultra-90 products
@@ -1554,11 +1554,11 @@ leapseconds, spice, historical, ultra, l1b, 90sensor-de, HARD_NO_TRIGGER, DOWNST
 ephemeris_reconstructed, spice, historical, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 90sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 90sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 90sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 90sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 90sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 90sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 90sensor-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 90sensor-de, HARD, DOWNSTREAM
 
@@ -1567,11 +1567,11 @@ leapseconds, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD_NO_TRIG
 ephemeris_reconstructed, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 90sensor-priority-1-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 90sensor-priority-1-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 90sensor-priority-1-de, HARD, DOWNSTREAM
 
@@ -1580,11 +1580,11 @@ leapseconds, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD_NO_TRIG
 ephemeris_reconstructed, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 90sensor-priority-2-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 90sensor-priority-2-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 90sensor-priority-2-de, HARD, DOWNSTREAM
 
@@ -1593,11 +1593,11 @@ leapseconds, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD_NO_TRIG
 ephemeris_reconstructed, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 90sensor-priority-3-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 90sensor-priority-3-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 90sensor-priority-3-de, HARD, DOWNSTREAM
 
@@ -1606,11 +1606,11 @@ leapseconds, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD_NO_TRIG
 ephemeris_reconstructed, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
-attitude_history, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD, DOWNSTREAM
+attitude_history, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 90sensor-priority-4-de, HARD_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, ultra, l1b, 90sensor-priority-4-de, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 90sensor-priority-4-de, HARD, DOWNSTREAM
 
@@ -1618,7 +1618,7 @@ spacecraft_clock, spice, historical, ultra, l1b, 90sensor-extendedspin, HARD, DO
 leapseconds, spice, historical, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
 spin, spin, historical, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
 science_frames, spice, historical, ultra, l1b, 90sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1b, 90sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_reconstructed, spice, historical, ultra, l1b, 90sensor-extendedspin, HARD, DOWNSTREAM
 ephemeris_predicted, spice, historical, ultra, l1b, 90sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
 ephemeris_90days, spice, historical, ultra, l1b, 90sensor-extendedspin, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1663,7 +1663,7 @@ repoint, repoint, historical, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTR
 spacecraft_clock, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 leapseconds, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 spin, spin, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1679,7 +1679,7 @@ attitude_history, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRI
 imap_frames, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 science_frames, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 planetary_ephemeris, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
-pointing_attitude, spice, historical, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
+pointing_attitude, spice, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 spin, spin, historical, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 
 # L2 ENA Map Names break down as:

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1392,7 +1392,6 @@ ultra, ancillary, l1c-45sensor-sc-pointing-theta, ultra, l1c, 45sensor-spacecraf
 ultra, ancillary, l1c-45sensor-sc-pointing-phi, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-sc-pointing-index, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-sc-pointing-bsf, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-spacecraftpset, HARD, DOWNSTREAM
@@ -1403,7 +1402,6 @@ ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 45sensor
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-logistic-interpolation, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
-ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-45sensor-imgparams-lookup, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-static-dead-times, ultra, l1c, 45sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-45sensor-de-product-lookup, ultra, l1c, 45sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1647,7 +1645,6 @@ ultra, ancillary, l1c-90sensor-sc-pointing-theta, ultra, l1c, 90sensor-spacecraf
 ultra, ancillary, l1c-90sensor-sc-pointing-phi, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-sc-pointing-index, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-sc-pointing-bsf, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
@@ -1655,7 +1652,6 @@ ultra, ancillary, l1b-90sensor-imgparams-lookup, ultra, l1c, 90sensor-spacecraft
 ultra, ancillary, l1c-90sensor-static-dead-times, ultra, l1c, 90sensor-spacecraftpset, HARD, DOWNSTREAM
 ultra, ancillary, l1c-90sensor-de-product-lookup, ultra, l1c, 90sensor-spacecraftpset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-scattering-calibration-data, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
-ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-sensor-gf-blades, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM
 ultra, ancillary, l1b-90sensor-logistic-interpolation, ultra, l1c, 90sensor-heliopset, HARD_NO_TRIGGER, DOWNSTREAM
 ultra, ancillary, l1b-scattering-thresholds-per-energy, ultra, l1c, 90sensor-heliopset, HARD, DOWNSTREAM


### PR DESCRIPTION
# Change Summary

## Overview

I am getting a LOT of reprocessing for ultra psets. I see versions in the 40. The main reason for this is the attitude history file getting updated and causing reprocessing. 

Another issue I saw were ancillary files used by l1b and l1c. It was triggering both and then when the l1b was done it retriggered l1c.  The solution is to let l1b get triggered, processed, and then trigger l1c. 

## File changes

- sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
 - fix dependency relationships

