### PR TITLE
imap_processing version bump v1.0.30

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1113,32 +1113,32 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "imap-processing"
-version = "1.0.28"
+version = "1.0.30"
 description = "IMAP Science Operations Center Processing"
 optional = false
-python-versions = "<4,>=3.10"
+python-versions = "<3.13,>=3.10"
 groups = ["layer-processing"]
 files = [
-    {file = "imap_processing-1.0.28-py3-none-any.whl", hash = "sha256:5c98698d539757dbacb4772d4bf8dc0d55fca9e00765774e37a74e5731ff375f"},
-    {file = "imap_processing-1.0.28.tar.gz", hash = "sha256:0c645767feead29608e378d079208d037dc5c59383492309b9256b424ce586ac"},
+    {file = "imap_processing-1.0.30-py3-none-any.whl", hash = "sha256:96df525780c1de8a25f4199943ac2b994fd7a1d85844d2680f6e040e073f766a"},
+    {file = "imap_processing-1.0.30.tar.gz", hash = "sha256:14432c16a37a9fb4956b24c3fd618cd4ce88e2ba241d489171f0919db99677b7"},
 ]
 
 [package.dependencies]
 astropy-healpix = ">=1.0"
-cdflib = ">=1.3.6,<2.0.0"
+cdflib = ">=1.3.6"
 imap-data-access = ">=0.37.0"
-numpy = "<=3"
-sammi-cdf = ">=1.0,<2.0"
-scipy = ">=1.13,<2.0"
+numpy = ">=2,<3"
+sammi-cdf = ">=1.0,<2"
+scipy = ">=1.13,<2"
 space_packet_parser = ">=6.0.0"
 spiceypy = ">=6.0.0"
-xarray = ">=2024.10.0"
+xarray = ">=2024.10.0,<2026"
 
 [package.extras]
-dev = ["mypy (==1.10.1)", "pre-commit (>=3.3.3,<4.0.0)", "ruff (==0.2.1)"]
-doc = ["numpydoc (>=1.5.0,<2.0.0)", "pydata-sphinx-theme", "sphinx", "sphinxcontrib-openapi (>=0.8.3,<0.9.0)"]
-map-visualization = ["healpy (>=1.18.0,<2.0.0)"]
-test = ["netcdf4 (>=1.7.2,<2.0.0)", "openpyxl (>=3.0.7)", "pytest (>=6.2.5)", "pytest-cov (>=4.0.0,<5.0.0)", "pytest-xdist (>=3.2,<4.0)", "requests (>=2.32.3,<3.0.0)"]
+dev = ["mypy (==1.10.1)", "pre-commit (>=3.3.3,<4)", "ruff (==0.15.2)"]
+doc = ["numpydoc (>=1.5.0,<2)", "pydata-sphinx-theme", "sphinx", "sphinxcontrib-openapi (>=0.8.3,<0.9)"]
+map-visualization = ["healpy (>=1.18.0,<2)"]
+test = ["netcdf4 (>=1.7.2,<2)", "openpyxl (>=3.0.7)", "pytest (>=6.2.5)", "pytest-cov (>=4.0.0,<5)", "pytest-xdist (>=3.2,<4)", "requests (>=2.32.3,<3)"]
 tools = ["openpyxl (>=3.0.7)", "pandas (>=2.0.0)"]
 
 [[package]]
@@ -3191,7 +3191,6 @@ description = "N-D labeled arrays and datasets in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["layer-processing"]
-markers = "python_version == \"3.10\""
 files = [
     {file = "xarray-2025.6.1-py3-none-any.whl", hash = "sha256:8b988b47f67a383bdc3b04c5db475cd165e580134c1f1943d52aee4a9c97651b"},
     {file = "xarray-2025.6.1.tar.gz", hash = "sha256:a84f3f07544634a130d7dc615ae44175419f4c77957a7255161ed99c69c7c8b0"},
@@ -3210,33 +3209,6 @@ io = ["cftime", "fsspec", "h5netcdf", "netCDF4", "pooch", "pydap ; python_versio
 parallel = ["dask[complete]"]
 types = ["pandas-stubs", "scipy-stubs", "types-PyYAML", "types-Pygments", "types-colorama", "types-decorator", "types-defusedxml", "types-docutils", "types-networkx", "types-openpyxl", "types-pexpect", "types-psutil", "types-pycurl", "types-python-dateutil", "types-pytz", "types-setuptools"]
 viz = ["cartopy", "matplotlib", "nc-time-axis", "seaborn"]
-
-[[package]]
-name = "xarray"
-version = "2026.4.0"
-description = "N-D labeled arrays and datasets in Python"
-optional = false
-python-versions = ">=3.11"
-groups = ["layer-processing"]
-markers = "python_version >= \"3.11\""
-files = [
-    {file = "xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08"},
-    {file = "xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b"},
-]
-
-[package.dependencies]
-numpy = ">=1.26"
-packaging = ">=24.2"
-pandas = ">=2.2"
-
-[package.extras]
-accel = ["bottleneck", "flox (>=0.10)", "numba (>=0.62)", "numbagg (>=0.9)", "opt_einsum", "scipy (>=1.15)"]
-complete = ["xarray[accel,etc,io,parallel,viz]"]
-etc = ["sparse (>=0.15)"]
-io = ["cftime", "fsspec", "h5netcdf[h5py] (>=1.5.0)", "netCDF4 (>=1.6.0)", "pooch", "pydap", "scipy (>=1.15)", "zarr (>=3.0)"]
-parallel = ["dask[complete]"]
-types = ["pandas-stubs", "scipy-stubs", "types-PyYAML", "types-Pygments", "types-colorama", "types-decorator", "types-defusedxml", "types-docutils", "types-networkx", "types-openpyxl", "types-pexpect", "types-psutil", "types-pycurl", "types-python-dateutil", "types-pytz", "types-requests", "types-setuptools", "types-xlrd"]
-viz = ["cartopy (>=0.24)", "matplotlib (>=3.10)", "nc-time-axis", "seaborn"]
 
 [[package]]
 name = "xmltodict"
@@ -3262,4 +3234,4 @@ test = ["moto", "pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "6e83e5b1d09d9f3426a5bc1b9bd426b8c991fcae60584604693112f13d600221"
+content-hash = "aa95fba5a59fac3a034453594ef54d48409f1ef4364971faabbbeffaa936e44c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requests = "^2.28.2"
 spiceypy = "^6.0.0"
 
 [tool.poetry.group.layer-processing.dependencies]
-imap-processing = "1.0.28"
+imap-processing = "1.0.30"
 
 [project.urls]
 homepage = "https://github.com/IMAP-Science-Operations-Center"

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -271,9 +271,9 @@ idna==3.13 ; python_version >= "3.10" and python_version < "3.13" \
 imap-data-access==0.38.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:42a1e9cd3cefd14df5a78c45fad1110e2377294eb884c73e2b5a8a49674b3e7d \
     --hash=sha256:743076cd791a02a061732d409f289b4a976798188f4262b3ae65b5483694fd87
-imap-processing==1.0.28 ; python_version >= "3.10" and python_version < "3.13" \
-    --hash=sha256:0c645767feead29608e378d079208d037dc5c59383492309b9256b424ce586ac \
-    --hash=sha256:5c98698d539757dbacb4772d4bf8dc0d55fca9e00765774e37a74e5731ff375f
+imap-processing==1.0.30 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:14432c16a37a9fb4956b24c3fd618cd4ce88e2ba241d489171f0919db99677b7 \
+    --hash=sha256:96df525780c1de8a25f4199943ac2b994fd7a1d85844d2680f6e040e073f766a
 jmespath==1.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64
@@ -956,9 +956,6 @@ tzdata==2026.2 ; python_version >= "3.10" and python_version < "3.13" and (sys_p
 urllib3==2.6.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
     --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
-xarray==2025.6.1 ; python_version == "3.10" \
+xarray==2025.6.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8b988b47f67a383bdc3b04c5db475cd165e580134c1f1943d52aee4a9c97651b \
     --hash=sha256:a84f3f07544634a130d7dc615ae44175419f4c77957a7255161ed99c69c7c8b0
-xarray==2026.4.0 ; python_version >= "3.11" and python_version < "3.13" \
-    --hash=sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b \
-    --hash=sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08


### PR DESCRIPTION
This pull request updates Python package dependencies to ensure compatibility and incorporate the latest features and fixes. The most important changes are dependency version bumps and a minor requirements file adjustment.

Dependency updates:

* Upgraded the `imap-processing` package from version `1.0.28` to `1.0.30` in both `pyproject.toml` and `requirements.txt` to pull in the latest improvements and bug fixes. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L78-R78) [[2]](diffhunk://#diff-cc8a15ab762756551934f3e9553c78546a09ffc638b7d179341292aed7c83c89L274-R276)

Requirements file cleanup:

* Updated the `xarray` dependency in `requirements.txt` to use a consistent version specifier (`python_version >= "3.10" and python_version < "3.13"`), and removed a redundant entry for Python 3.11+, simplifying version management.
