### PR TITLE
I-ALiRT - added port

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -95,6 +95,8 @@ class IalirtProcessing(Construct):
             "198.118.1.14/32": [7526],  # BlueNet (tlm relay)
             "193.174.22.3/32": [7564],  # Kiel
             "185.83.168.248/32": [7566, 7567],  # UKSA
+            "41.74.156.19/32": [7568],  # SANSA
+            "41.74.156.20/32": [7568],  # SANSA
         }
 
         for ip_range, ports in partner_access.items():


### PR DESCRIPTION
This pull request makes a minor update to the security group configuration by adding two new IP addresses for SANSA to the list of allowed partners.

- Added `"41.74.156.19/32"` and `"41.74.156.20/32"` to the `partner_access` dictionary in `create_ecs_security_group` to allow SANSA access on port 7568.