### PR TITLE
Add planetary_constants to SWAPI L3a SPICE dependencies

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -1091,6 +1091,7 @@ swapi, ancillary, passband-fit-coefficients, swapi, l3a, alpha-sw, HARD, DOWNSTR
 ephemeris_reconstructed, spice, historical, swapi, l3a, alpha-sw, SOFT_NO_TRIGGER, DOWNSTREAM
 ephemeris_predicted, spice, historical, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
+planetary_constants, spice, historical, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, alpha-sw, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, swapi, l3a, alpha-sw, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1114,6 +1115,7 @@ swapi, ancillary, passband-fit-coefficients, swapi, l3a, proton-sw, HARD, DOWNST
 ephemeris_reconstructed, spice, historical, swapi, l3a, proton-sw, SOFT_NO_TRIGGER, DOWNSTREAM
 ephemeris_predicted, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
+planetary_constants, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, proton-sw, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, swapi, l3a, proton-sw, HARD_NO_TRIGGER, DOWNSTREAM
@@ -1137,6 +1139,7 @@ swapi, ancillary, passband-fit-coefficients, swapi, l3a, pui-he, HARD, DOWNSTREA
 ephemeris_reconstructed, spice, historical, swapi, l3a, pui-he, SOFT_NO_TRIGGER, DOWNSTREAM
 ephemeris_predicted, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
 planetary_ephemeris, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
+planetary_constants, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 attitude_history, spice, historical, swapi, l3a, pui-he, HARD, DOWNSTREAM
 leapseconds, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM
 imap_frames, spice, historical, swapi, l3a, pui-he, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_swapi_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_swapi_dependencies.yaml
@@ -27,6 +27,10 @@ l3a_spice_common: &l3a_spice_common
     upstream_data_type: spice
     upstream_descriptor: historical
     kickoff_job: false
+  - upstream_source: planetary_constants
+    upstream_data_type: spice
+    upstream_descriptor: historical
+    kickoff_job: false
   - upstream_source: attitude_history
     upstream_data_type: spice
     upstream_descriptor: historical


### PR DESCRIPTION
# Change Summary

## Overview

We realized that the new SWAPI L3a algorithms need the planetary constants SPICE kernel.

## File changes

Add planetary_constants to SWAPI L3a dependencies in both csv and yaml configuration.