### PR TITLE
HIT: custom data dependency updates

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -712,6 +712,11 @@ hit, l0, raw, hit, l1b, hk, HARD, DOWNSTREAM
 leapseconds, spice, historical, hit, l1b, hk, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, hit, l1b, hk, HARD_NO_TRIGGER, DOWNSTREAM
 
+# Custom L0 data delivered by HIT
+hit, l0, pha-telemetry-corrected, hit, l1a, pha-telemetry-corrected, HARD, DOWNSTREAM
+leapseconds, spice, historical, hit, l1a, pha-telemetry-corrected, HARD_NO_TRIGGER, DOWNSTREAM
+spacecraft_clock, spice, historical, hit, l1a, pha-telemetry-corrected, HARD_NO_TRIGGER, DOWNSTREAM
+
 hit, l1a, counts-standard, hit, l1b, standard-rates, HARD, DOWNSTREAM
 hit, l1a, counts-standard, hit, l1b, summed-rates, HARD, DOWNSTREAM
 hit, l1a, counts-sectored, hit, l1b, sectored-rates, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_hit_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_hit_dependencies.yaml
@@ -28,6 +28,10 @@ l0_data: &l0_data
   - *spice_basics
   - *l0_data
 
+(l1a, pha-telemetry-corrected):
+  - upstream_source: hit
+    upstream_data_type: l0
+    upstream_descriptor: pha-telemetry-corrected
 
 (l1b, sectored-rates):
   - upstream_source: hit


### PR DESCRIPTION
# Change Summary
closes #1330 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Way to trigger HIT pipeline when HIT team delivers us custom L0 data. These L0 data are not from POC or spacecraft.

I don't know how long we need to support it. If it's once, then we push this to prod and ingest HIT L0 file and let it process through and undo this change afterwards. I am excluding HIT L1B HK processing for this work since that's less critical. If we need it, then we can revisit but excluding from this PR to keep this moving fast.

## File changes

<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->


## Testing

<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
