### PR TITLE
I-ALiRT bugfix

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_ingest.py
@@ -526,7 +526,11 @@ def insert_kernels(dependency_inputs, data_table):
     met = et_to_met(str_to_et(last_modified_for_spice))
     spice_input = dependency_inputs.processing_input[0]
     spice_kernels = dict(
-        zip(spice_input.source, spice_input.filename_list, strict=True)
+        zip(
+            [path.spice_metadata["type"] for path in spice_input.imap_file_paths],
+            spice_input.filename_list,
+            strict=True,
+        )
     )
 
     # Will return the same kernel_set_key for the same set of kernels.

--- a/tests/lambda_endpoints/test_ialirt_ingest.py
+++ b/tests/lambda_endpoints/test_ialirt_ingest.py
@@ -571,6 +571,12 @@ def test_insert_kernels(
     spice_input = MagicMock()
     spice_input.source = ["leapseconds", "planetary_constants", "imap_frames"]
     spice_input.filename_list = ["naif0012.tls", "pck00011.tpc", "imap_100.tf"]
+    mock_paths = []
+    for kernel_type in spice_input.source:
+        mock_path = MagicMock()
+        mock_path.spice_metadata = {"type": kernel_type}
+        mock_paths.append(mock_path)
+    spice_input.imap_file_paths = mock_paths
 
     dependency_inputs = MagicMock()
     dependency_inputs.processing_input = [spice_input]


### PR DESCRIPTION
This pull request updates the way `spice_kernels` is constructed in the `insert_kernels` function to improve accuracy and robustness. Instead of using the `source` attribute, the code now derives kernel types from the `spice_metadata["type"]` field of each path in `imap_file_paths`, ensuring the keys accurately reflect the kernel types.

**Kernel mapping improvements:**

* Changed the construction of the `spice_kernels` dictionary to use kernel types from `spice_metadata["type"]` in `imap_file_paths` as keys instead of the previous `source` attribute, improving the accuracy of kernel identification.