### PR TITLE
I-ALiRT - vpn tunnel

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -107,6 +107,10 @@ class IalirtProcessing(Construct):
                 "params": ["kiel"],
                 "ports": [7564],
             },
+            "noaa": {
+                "params": ["noaa"],
+                "ports": [7565],
+            },
             "uksa": {
                 "params": ["uksa"],
                 "ports": [7566, 7567],

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -29,8 +29,9 @@ class IalirtVpnConstruct(Construct):
             The Virtual Private Gateway to attach the VPN connections to.
         psk : str
             Pre-shared key for IKE authentication. Pass a CDK token from
-            ``secret_value_from_json(...).to_string()`` so the value is resolved
-            by CloudFormation at deploy time and never appears in the template.
+            ``secret_value_from_json(...).unsafe_unwrap()`` so the value is
+            resolved by CloudFormation at deploy time and never appears in
+            the template.
         wash_ip : str
             NOAA border router public IP at McLean, VA (WASH), retrieved from SSM.
         denv_ip : str

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -11,7 +11,7 @@ class IalirtVpnConstruct(Construct):
         self,
         scope: Construct,
         construct_id: str,
-        vpn_gateway: ec2.CfnVPNGateway,
+        transit_gateway_id: str,
         psk: str,
         wash_ip: str,
         denv_ip: str,
@@ -25,8 +25,13 @@ class IalirtVpnConstruct(Construct):
             Parent construct.
         construct_id : str
             A unique string identifier for this construct.
-        vpn_gateway : ec2.CfnVPNGateway
-            The Virtual Private Gateway to attach the VPN connections to.
+        transit_gateway_id : str
+            The Transit Gateway to attach the VPN connections to. A Transit
+            Gateway is used (rather than a Virtual Private Gateway) because a
+            VGW cannot route decrypted VPN traffic to a NAT Gateway, and a NAT
+            Gateway is required so NOAA's traffic reaches I-ALiRT via its
+            stable Elastic IP instead of an EC2 private IP that changes
+            whenever the Auto Scaling Group replaces the instance.
         psk : str
             Pre-shared key for IKE authentication. Pass a CDK token from
             ``secret_value_from_json(...).unsafe_unwrap()`` so the value is
@@ -106,9 +111,13 @@ class IalirtVpnConstruct(Construct):
         # Every AWS Site-to-Site VPN connection automatically provisions
         # two auto-assigned tunnel IPs.
         # These LASP IKE Gateways must be given to NOAA.
+        self.vpn_connections: dict[str, ec2.CfnVPNConnection] = {}
         for site, ip in {"WASH": wash_ip, "DENV": denv_ip}.items():
             # AWS needs to know the router's public IP and ASN to establish the tunnel.
-            # bgp_asn=64583 is NOAA's ASN per the ICD.
+            # bgp_asn=64583 is NOAA's ASN per the ICD. This must match the ASN
+            # configured on NOAA's actual router — AWS silently rejects the BGP
+            # session (not the tunnel itself) if the peer AS doesn't match what's
+            # registered here.
             cgw = ec2.CfnCustomerGateway(
                 self,
                 f"NoaaCustomerGateway{site}",
@@ -117,17 +126,18 @@ class IalirtVpnConstruct(Construct):
                 type="ipsec.1",
             )
 
-            # Create the VPN connection between our Virtual Private Gateway (VGW)
-            # and NOAA's customer gateway. Each connection gets two tunnels by default
-            # (AWS requirement for redundancy) — both use the same crypto settings.
-            # BGP is used (static_routes_only=False) so that if one site (WASH or DENV)
-            # goes down, BGP automatically reroutes traffic through the other.
-            # Data flows one way: NOAA sends to us. We do not send to NOAA.
-            ec2.CfnVPNConnection(
+            # Create the VPN connection between our Transit Gateway (TGW) and
+            # NOAA's customer gateway. Each connection gets two tunnels by
+            # default (AWS requirement for redundancy) — both use the same
+            # crypto settings. BGP is used (static_routes_only=False) so that
+            # if one site (WASH or DENV) goes down, BGP automatically reroutes
+            # traffic through the other. Data flows one way: NOAA sends to us.
+            # We do not send to NOAA.
+            self.vpn_connections[site] = ec2.CfnVPNConnection(
                 self,
                 f"NoaaVpnConnection{site}",
                 customer_gateway_id=cgw.ref,
-                vpn_gateway_id=vpn_gateway.ref,
+                transit_gateway_id=transit_gateway_id,
                 type="ipsec.1",
                 static_routes_only=False,
                 vpn_tunnel_options_specifications=[tunnel, tunnel],

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -28,7 +28,9 @@ class IalirtVpnConstruct(Construct):
         vpn_gateway : ec2.CfnVPNGateway
             The Virtual Private Gateway to attach the VPN connections to.
         psk : str
-            Pre-shared key for IKE authentication, retrieved from Secrets Manager.
+            Pre-shared key for IKE authentication. Pass a CDK token from
+            ``secret_value_from_json(...).to_string()`` so the value is resolved
+            by CloudFormation at deploy time and never appears in the template.
         wash_ip : str
             NOAA border router public IP at McLean, VA (WASH), retrieved from SSM.
         denv_ip : str
@@ -42,7 +44,8 @@ class IalirtVpnConstruct(Construct):
         # in the N-Wave ICD (NOAA0550).
         #
         # Phase 1 (IKE) — the handshake phase where both sides authenticate each other
-        # and agree on encryption keys. Uses pre-shared key (PSK) from Secrets Manager.
+        # and agree on encryption keys. Uses pre-shared key (PSK)
+        # resolved at deploy time.
         #   - IKEv2 only (NOAA requirement)
         #   - AES-256 encryption
         #   - SHA2-256 integrity

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -11,7 +11,7 @@ class IalirtVpnConstruct(Construct):
         self,
         scope: Construct,
         construct_id: str,
-        vpn_gateway: ec2.CfnVpnGateway,
+        vpn_gateway: ec2.CfnVPNGateway,
         psk: str,
         wash_ip: str,
         denv_ip: str,
@@ -25,7 +25,7 @@ class IalirtVpnConstruct(Construct):
             Parent construct.
         construct_id : str
             A unique string identifier for this construct.
-        vpn_gateway : ec2.CfnVpnGateway
+        vpn_gateway : ec2.CfnVPNGateway
             The Virtual Private Gateway to attach the VPN connections to.
         psk : str
             Pre-shared key for IKE authentication, retrieved from Secrets Manager.
@@ -116,7 +116,8 @@ class IalirtVpnConstruct(Construct):
             # Create the VPN connection between our Virtual Private Gateway (VGW)
             # and NOAA's customer gateway. Each connection gets two tunnels by default
             # (AWS requirement for redundancy) — both use the same crypto settings.
-            # static_routes_only=True because NOAA uses static routing, not BGP.
+            # BGP is used (static_routes_only=False) so that if one site (WASH or DENV)
+            # goes down, BGP automatically reroutes traffic through the other.
             # Data flows one way: NOAA sends to us. We do not send to NOAA.
             ec2.CfnVpnConnection(
                 self,
@@ -124,6 +125,6 @@ class IalirtVpnConstruct(Construct):
                 customer_gateway_id=cgw.ref,
                 vpn_gateway_id=vpn_gateway.ref,
                 type="ipsec.1",
-                static_routes_only=True,
+                static_routes_only=False,
                 vpn_tunnel_options_specifications=[tunnel, tunnel],
             )

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -1,0 +1,129 @@
+"""Configure the I-ALiRT VPN connections to NOAA N-Wave."""
+
+from aws_cdk import aws_ec2 as ec2
+from constructs import Construct
+
+
+class IalirtVpnConstruct(Construct):
+    """NOAA N-Wave customer gateways and VPN connections for I-ALiRT."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        vpn_gateway: ec2.CfnVpnGateway,
+        psk: str,
+        wash_ip: str,
+        denv_ip: str,
+        **kwargs,
+    ) -> None:
+        """Create NOAA N-Wave customer gateways and VPN connections.
+
+        Parameters
+        ----------
+        scope : Construct
+            Parent construct.
+        construct_id : str
+            A unique string identifier for this construct.
+        vpn_gateway : ec2.CfnVpnGateway
+            The Virtual Private Gateway to attach the VPN connections to.
+        psk : str
+            Pre-shared key for IKE authentication, retrieved from Secrets Manager.
+        wash_ip : str
+            NOAA border router public IP at McLean, VA (WASH), retrieved from SSM.
+        denv_ip : str
+            NOAA border router public IP at Denver, CO (DENV), retrieved from SSM.
+        kwargs : dict
+            Keyword arguments.
+        """
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Define the crypto settings for the IPSec tunnel, as specified
+        # in the N-Wave ICD (NOAA0550).
+        #
+        # Phase 1 (IKE) — the handshake phase where both sides authenticate each other
+        # and agree on encryption keys. Uses pre-shared key (PSK) from Secrets Manager.
+        #   - IKEv2 only (NOAA requirement)
+        #   - AES-256 encryption
+        #   - SHA2-256 integrity
+        #   - DH group 14 for key exchange
+        #   - 28800s (8 hour) lifetime
+        #
+        # Phase 2 (ESP) — the data phase where actual traffic is encrypted.
+        #   - AES-128 or AES-256 encryption
+        #   - HMAC-SHA2-256-128 integrity
+        #   - DH group 14 (PFS — Perfect Forward Secrecy)
+        #   - 3600s (1 hour) lifetime
+        tunnel = ec2.CfnVpnConnection.VpnTunnelOptionsSpecificationProperty(
+            pre_shared_key=psk,
+            ike_versions=[
+                ec2.CfnVpnConnection.IKEVersionsRequestListValueProperty(value="ikev2")
+            ],
+            phase1_encryption_algorithms=[
+                ec2.CfnVpnConnection.Phase1EncryptionAlgorithmsRequestListValueProperty(
+                    value="AES256"
+                )
+            ],
+            phase1_integrity_algorithms=[
+                ec2.CfnVpnConnection.Phase1IntegrityAlgorithmsRequestListValueProperty(
+                    value="SHA2-256"
+                )
+            ],
+            phase1_dh_group_numbers=[
+                ec2.CfnVpnConnection.Phase1DHGroupNumbersRequestListValueProperty(
+                    value=14
+                )
+            ],
+            phase1_lifetime_seconds=28800,
+            phase2_encryption_algorithms=[
+                ec2.CfnVpnConnection.Phase2EncryptionAlgorithmsRequestListValueProperty(
+                    value="AES128"
+                ),
+                ec2.CfnVpnConnection.Phase2EncryptionAlgorithmsRequestListValueProperty(
+                    value="AES256"
+                ),
+            ],
+            phase2_integrity_algorithms=[
+                ec2.CfnVpnConnection.Phase2IntegrityAlgorithmsRequestListValueProperty(
+                    value="HMAC-SHA2-256-128"
+                )
+            ],
+            phase2_dh_group_numbers=[
+                ec2.CfnVpnConnection.Phase2DHGroupNumbersRequestListValueProperty(
+                    value=14
+                )
+            ],
+            phase2_lifetime_seconds=3600,
+        )
+
+        # Customer Gateway - AWS's record of NOAA's router so that AWS can recognize
+        # and accept the incoming encrypted packets.
+
+        # Every AWS Site-to-Site VPN connection automatically provisions
+        # two auto-assigned tunnel IPs.
+        # These LASP IKE Gateways must be given to NOAA.
+        for site, ip in {"WASH": wash_ip, "DENV": denv_ip}.items():
+            # AWS needs to know the router's public IP and ASN to establish the tunnel.
+            # bgp_asn=64583 is NOAA's ASN per the ICD.
+            cgw = ec2.CfnCustomerGateway(
+                self,
+                f"NoaaCustomerGateway{site}",
+                bgp_asn=64583,
+                ip_address=ip,
+                type="ipsec.1",
+            )
+
+            # Create the VPN connection between our Virtual Private Gateway (VGW)
+            # and NOAA's customer gateway. Each connection gets two tunnels by default
+            # (AWS requirement for redundancy) — both use the same crypto settings.
+            # static_routes_only=True because NOAA uses static routing, not BGP.
+            # Data flows one way: NOAA sends to us. We do not send to NOAA.
+            ec2.CfnVpnConnection(
+                self,
+                f"NoaaVpnConnection{site}",
+                customer_gateway_id=cgw.ref,
+                vpn_gateway_id=vpn_gateway.ref,
+                type="ipsec.1",
+                static_routes_only=True,
+                vpn_tunnel_options_specifications=[tunnel, tunnel],
+            )

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -54,42 +54,42 @@ class IalirtVpnConstruct(Construct):
         #   - HMAC-SHA2-256-128 integrity
         #   - DH group 14 (PFS — Perfect Forward Secrecy)
         #   - 3600s (1 hour) lifetime
-        tunnel = ec2.CfnVpnConnection.VpnTunnelOptionsSpecificationProperty(
+        tunnel = ec2.CfnVPNConnection.VpnTunnelOptionsSpecificationProperty(
             pre_shared_key=psk,
             ike_versions=[
-                ec2.CfnVpnConnection.IKEVersionsRequestListValueProperty(value="ikev2")
+                ec2.CfnVPNConnection.IKEVersionsRequestListValueProperty(value="ikev2")
             ],
             phase1_encryption_algorithms=[
-                ec2.CfnVpnConnection.Phase1EncryptionAlgorithmsRequestListValueProperty(
+                ec2.CfnVPNConnection.Phase1EncryptionAlgorithmsRequestListValueProperty(
                     value="AES256"
                 )
             ],
             phase1_integrity_algorithms=[
-                ec2.CfnVpnConnection.Phase1IntegrityAlgorithmsRequestListValueProperty(
+                ec2.CfnVPNConnection.Phase1IntegrityAlgorithmsRequestListValueProperty(
                     value="SHA2-256"
                 )
             ],
             phase1_dh_group_numbers=[
-                ec2.CfnVpnConnection.Phase1DHGroupNumbersRequestListValueProperty(
+                ec2.CfnVPNConnection.Phase1DHGroupNumbersRequestListValueProperty(
                     value=14
                 )
             ],
             phase1_lifetime_seconds=28800,
             phase2_encryption_algorithms=[
-                ec2.CfnVpnConnection.Phase2EncryptionAlgorithmsRequestListValueProperty(
+                ec2.CfnVPNConnection.Phase2EncryptionAlgorithmsRequestListValueProperty(
                     value="AES128"
                 ),
-                ec2.CfnVpnConnection.Phase2EncryptionAlgorithmsRequestListValueProperty(
+                ec2.CfnVPNConnection.Phase2EncryptionAlgorithmsRequestListValueProperty(
                     value="AES256"
                 ),
             ],
             phase2_integrity_algorithms=[
-                ec2.CfnVpnConnection.Phase2IntegrityAlgorithmsRequestListValueProperty(
+                ec2.CfnVPNConnection.Phase2IntegrityAlgorithmsRequestListValueProperty(
                     value="HMAC-SHA2-256-128"
                 )
             ],
             phase2_dh_group_numbers=[
-                ec2.CfnVpnConnection.Phase2DHGroupNumbersRequestListValueProperty(
+                ec2.CfnVPNConnection.Phase2DHGroupNumbersRequestListValueProperty(
                     value=14
                 )
             ],
@@ -119,7 +119,7 @@ class IalirtVpnConstruct(Construct):
             # BGP is used (static_routes_only=False) so that if one site (WASH or DENV)
             # goes down, BGP automatically reroutes traffic through the other.
             # Data flows one way: NOAA sends to us. We do not send to NOAA.
-            ec2.CfnVpnConnection(
+            ec2.CfnVPNConnection(
                 self,
                 f"NoaaVpnConnection{site}",
                 customer_gateway_id=cgw.ref,

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -85,7 +85,7 @@ class IalirtVpnConstruct(Construct):
             ],
             phase2_integrity_algorithms=[
                 ec2.CfnVPNConnection.Phase2IntegrityAlgorithmsRequestListValueProperty(
-                    value="HMAC-SHA2-256-128"
+                    value="SHA2-256"
                 )
             ],
             phase2_dh_group_numbers=[

--- a/sds_data_manager/constructs/networking_construct.py
+++ b/sds_data_manager/constructs/networking_construct.py
@@ -1,5 +1,6 @@
 """Configure the networking components."""
 
+import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
 from constructs import Construct
 
@@ -52,3 +53,38 @@ class NetworkingConstruct(Construct):
                 ),
             ],
         )
+
+        # Create the Virtual Private Gateway (VGW).
+        # The VGW decrypts incoming IPSec packets from NOAA and hands them into the VPC.
+        self.vpn_gateway = self._create_vpn_gateway()
+
+    def _create_vpn_gateway(self) -> ec2.CfnVpnGateway:
+        """Create a Virtual Private Gateway and attach it to the VPC."""
+        # Create the Virtual Private Gateway (VGW).
+        vpn_gateway = ec2.CfnVpnGateway(
+            self,
+            "VpnGateway",
+            # IPSec version 1 is the standard protocol for encrypted VPN tunnels.
+            type="ipsec.1",
+            tags=[cdk.CfnTag(key="Name", value="ialirt-vpn-gateway")],
+        )
+
+        # Attach the VGW to the VPC so decrypted traffic can enter the VPC.
+        ec2.CfnVPCGatewayAttachment(
+            self,
+            "VpnGatewayAttachment",
+            vpc_id=self.vpc.vpc_id,
+            vpn_gateway_id=vpn_gateway.ref,
+        )
+
+        # Adds VPN route propagation to each public subnet so that regardless of
+        # which AZ the I-ALiRT EC2 lands in, it can receive traffic from the VPN.
+        for i, subnet in enumerate(self.vpc.public_subnets):
+            ec2.CfnVPNGatewayRoutePropagation(
+                self,
+                f"RoutePropagate{i}",
+                route_table_ids=[subnet.route_table.route_table_id],
+                vpn_gateway_id=vpn_gateway.ref,
+            )
+
+        return vpn_gateway

--- a/sds_data_manager/constructs/networking_construct.py
+++ b/sds_data_manager/constructs/networking_construct.py
@@ -1,6 +1,5 @@
 """Configure the networking components."""
 
-import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
 from constructs import Construct
 
@@ -53,40 +52,3 @@ class NetworkingConstruct(Construct):
                 ),
             ],
         )
-
-        # Create the Virtual Private Gateway (VGW).
-        # The VGW decrypts incoming IPSec packets from NOAA and hands them into the VPC.
-        self.vpn_gateway = self._create_vpn_gateway()
-
-    def _create_vpn_gateway(self) -> ec2.CfnVPNGateway:
-        """Create a Virtual Private Gateway and attach it to the VPC."""
-        # Create the Virtual Private Gateway (VGW).
-        vpn_gateway = ec2.CfnVPNGateway(
-            self,
-            "VpnGateway",
-            # IPSec version 1 is the standard protocol for encrypted VPN tunnels.
-            type="ipsec.1",
-            tags=[cdk.CfnTag(key="Name", value="ialirt-vpn-gateway")],
-        )
-
-        # Attach the VGW to the VPC so decrypted traffic can enter the VPC.
-        attachment = ec2.CfnVPCGatewayAttachment(
-            self,
-            "VpnGatewayAttachment",
-            vpc_id=self.vpc.vpc_id,
-            vpn_gateway_id=vpn_gateway.ref,
-        )
-
-        # Adds VPN route propagation to each public subnet so that regardless of
-        # which AZ the I-ALiRT EC2 lands in, it can receive traffic from the VPN.
-        # Must depend on the attachment being complete first.
-        for i, subnet in enumerate(self.vpc.public_subnets):
-            propagation = ec2.CfnVPNGatewayRoutePropagation(
-                self,
-                f"RoutePropagate{i}",
-                route_table_ids=[subnet.route_table.route_table_id],
-                vpn_gateway_id=vpn_gateway.ref,
-            )
-            propagation.node.add_dependency(attachment)
-
-        return vpn_gateway

--- a/sds_data_manager/constructs/networking_construct.py
+++ b/sds_data_manager/constructs/networking_construct.py
@@ -70,7 +70,7 @@ class NetworkingConstruct(Construct):
         )
 
         # Attach the VGW to the VPC so decrypted traffic can enter the VPC.
-        ec2.CfnVPCGatewayAttachment(
+        attachment = ec2.CfnVPCGatewayAttachment(
             self,
             "VpnGatewayAttachment",
             vpc_id=self.vpc.vpc_id,
@@ -79,12 +79,14 @@ class NetworkingConstruct(Construct):
 
         # Adds VPN route propagation to each public subnet so that regardless of
         # which AZ the I-ALiRT EC2 lands in, it can receive traffic from the VPN.
+        # Must depend on the attachment being complete first.
         for i, subnet in enumerate(self.vpc.public_subnets):
-            ec2.CfnVPNGatewayRoutePropagation(
+            propagation = ec2.CfnVPNGatewayRoutePropagation(
                 self,
                 f"RoutePropagate{i}",
                 route_table_ids=[subnet.route_table.route_table_id],
                 vpn_gateway_id=vpn_gateway.ref,
             )
+            propagation.node.add_dependency(attachment)
 
         return vpn_gateway

--- a/sds_data_manager/constructs/networking_construct.py
+++ b/sds_data_manager/constructs/networking_construct.py
@@ -58,10 +58,10 @@ class NetworkingConstruct(Construct):
         # The VGW decrypts incoming IPSec packets from NOAA and hands them into the VPC.
         self.vpn_gateway = self._create_vpn_gateway()
 
-    def _create_vpn_gateway(self) -> ec2.CfnVpnGateway:
+    def _create_vpn_gateway(self) -> ec2.CfnVPNGateway:
         """Create a Virtual Private Gateway and attach it to the VPC."""
         # Create the Virtual Private Gateway (VGW).
-        vpn_gateway = ec2.CfnVpnGateway(
+        vpn_gateway = ec2.CfnVPNGateway(
             self,
             "VpnGateway",
             # IPSec version 1 is the standard protocol for encrypted VPN tunnels.

--- a/sds_data_manager/utils/ialirt_noaa_vpn.py
+++ b/sds_data_manager/utils/ialirt_noaa_vpn.py
@@ -1,0 +1,195 @@
+"""Helpers for building I-ALiRT's NOAA Site-to-Site VPN path."""
+
+from aws_cdk import Stack
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_secretsmanager as secretsmanager
+from aws_cdk import aws_ssm as ssm
+from aws_cdk import custom_resources as cr
+
+from sds_data_manager.constructs import ialirt_vpn_construct, networking_construct
+
+
+def build_noaa_vpn_tgw(
+    ialirt_stack: Stack,
+    networking: networking_construct.NetworkingConstruct,
+) -> None:
+    """Build the NOAA VPN Transit Gateway path for I-ALiRT.
+
+    Terminates NOAA's Site-to-Site VPN on a Transit Gateway attached to
+    I-ALiRT's VPC, so decrypted traffic reaches I-ALiRT via the existing
+    NAT Gateway / Elastic IP path.
+
+    Parameters
+    ----------
+    ialirt_stack : Stack
+        The I-ALiRT stack to parent these resources to.
+    networking : networking_construct.NetworkingConstruct
+        Networking construct providing the VPC to attach to the TGW.
+
+    """
+    # Retrieve the NOAA VPN pre-shared key from Secrets Manager.
+    # Store the PSK under the key "psk" in a secret named
+    # "/ialirt/noaa/noaa-vpn-psk" before deploying this stack.
+    noaa_vpn_psk = (
+        secretsmanager.Secret.from_secret_name_v2(
+            ialirt_stack, "NoaaVpnPsk", "/ialirt/noaa/noaa-vpn-psk"
+        )
+        .secret_value_from_json("psk")
+        .unsafe_unwrap()
+    )
+
+    # Retrieve NOAA's border router IPs from SSM Parameter Store.
+    # Store these before deploying:
+    #   aws ssm put-parameter --name "/ialirt/noaa-vpn/wash-ip"
+    #   --value "<ip>" --type String
+    #   aws ssm put-parameter --name "/ialirt/noaa-vpn/denv-ip"
+    #   --value "<ip>" --type String
+    noaa_wash_ip = ssm.StringParameter.value_for_string_parameter(
+        ialirt_stack, "/ialirt/noaa-vpn/wash-ip"
+    )
+    noaa_denv_ip = ssm.StringParameter.value_for_string_parameter(
+        ialirt_stack, "/ialirt/noaa-vpn/denv-ip"
+    )
+
+    # Create a Transit Gateway (TGW) to terminate the IPSec tunnel from NOAA.
+    ialirt_transit_gateway = ec2.CfnTransitGateway(
+        ialirt_stack,
+        "IalirtTransitGateway",
+        # ASN is BGP's identifier for a distinct network/routing domain —
+        # how two BGP peers identify themselves and each other.
+        # Default ASN, but stated explicitly here.
+        amazon_side_asn=64512,
+        # Use our own route table below instead of TGW's hidden default one.
+        default_route_table_association="disable",
+        default_route_table_propagation="disable",
+        description="I-ALiRT TGW for NOAA VPN",
+    )
+
+    # Attach the VPC to the TGW via the private subnets, whose route tables
+    # already have 0.0.0.0/0 -> NAT Gateway — so traffic arriving via the TGW
+    # attachment gets forwarded there automatically. The NAT Gateway then
+    # sends it out to the internet, where it reaches I-ALiRT's own Elastic
+    # IP the same way every other partner's traffic already does.
+    ialirt_vpc_attachment = ec2.CfnTransitGatewayVpcAttachment(
+        ialirt_stack,
+        "IalirtTransitGatewayVpcAttachment",
+        transit_gateway_id=ialirt_transit_gateway.attr_id,
+        vpc_id=networking.vpc.vpc_id,
+        subnet_ids=[subnet.subnet_id for subnet in networking.vpc.private_subnets],
+    )
+
+    ialirt_vpn = ialirt_vpn_construct.IalirtVpnConstruct(
+        scope=ialirt_stack,
+        construct_id="IalirtVpn",
+        transit_gateway_id=ialirt_transit_gateway.attr_id,
+        psk=noaa_vpn_psk,
+        wash_ip=noaa_wash_ip,
+        denv_ip=noaa_denv_ip,
+    )
+
+    # Create a TGW route table.
+    ialirt_tgw_route_table = ec2.CfnTransitGatewayRouteTable(
+        ialirt_stack,
+        "IalirtTransitGatewayRouteTable",
+        transit_gateway_id=ialirt_transit_gateway.attr_id,
+    )
+    tgw_route_table_id = ialirt_tgw_route_table.attr_transit_gateway_route_table_id
+
+    # VPC's connection to the Transit Gateway will use our route table to
+    # look up where to send traffic.
+    ec2.CfnTransitGatewayRouteTableAssociation(
+        ialirt_stack,
+        "IalirtTgwRouteTableAssociationVpc",
+        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
+        transit_gateway_route_table_id=tgw_route_table_id,
+    )
+
+    # Add the VPC's address range to our route table, so any other
+    # attachment using this table (e.g. the NOAA VPN connections) can route
+    # traffic destined for the VPC here.
+    ec2.CfnTransitGatewayRouteTablePropagation(
+        ialirt_stack,
+        "IalirtTgwRouteTablePropagationVpc",
+        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
+        transit_gateway_route_table_id=tgw_route_table_id,
+    )
+
+    # AWS::EC2::VPNConnection does not expose its Transit Gateway attachment
+    # ID as a CloudFormation attribute, so look it up via a custom resource
+    # that calls ec2:DescribeTransitGatewayAttachments, filtered to the VPN
+    # connection's resource ID.
+    for site, vpn_connection in ialirt_vpn.vpn_connections.items():
+        describe_vpn_attachment = cr.AwsSdkCall(
+            service="EC2",
+            action="describeTransitGatewayAttachments",
+            parameters={
+                "Filters": [
+                    {
+                        "Name": "resource-id",
+                        "Values": [vpn_connection.attr_vpn_connection_id],
+                    },
+                    {"Name": "resource-type", "Values": ["vpn"]},
+                ]
+            },
+            physical_resource_id=cr.PhysicalResourceId.of(
+                f"IalirtVpnTgwAttachmentLookup{site}"
+            ),
+        )
+        vpn_attachment_lookup = cr.AwsCustomResource(
+            ialirt_stack,
+            f"IalirtVpnTgwAttachmentLookup{site}",
+            on_create=describe_vpn_attachment,
+            on_update=describe_vpn_attachment,
+            policy=cr.AwsCustomResourcePolicy.from_sdk_calls(
+                resources=cr.AwsCustomResourcePolicy.ANY_RESOURCE
+            ),
+        )
+        vpn_attachment_id = vpn_attachment_lookup.get_response_field(
+            "TransitGatewayAttachments.0.TransitGatewayAttachmentId"
+        )
+
+        # Add the transit gateway attachments to the route table.
+
+        # Use this table to decide where to forward the traffic it receives.
+        ec2.CfnTransitGatewayRouteTableAssociation(
+            ialirt_stack,
+            f"IalirtTgwRouteTableAssociationVpn{site}",
+            transit_gateway_attachment_id=vpn_attachment_id,
+            transit_gateway_route_table_id=tgw_route_table_id,
+        )
+        # Installs NOAA's routes into the table so the VPC attachment can
+        # find its way back to NOAA on the return path.
+        ec2.CfnTransitGatewayRouteTablePropagation(
+            ialirt_stack,
+            f"IalirtTgwRouteTablePropagationVpn{site}",
+            transit_gateway_attachment_id=vpn_attachment_id,
+            transit_gateway_route_table_id=tgw_route_table_id,
+        )
+
+    # Static route: send traffic for I-ALiRT EC2's Elastic IP into the VPC
+    # attachment, where the NAT Gateway forwards it to the public internet.
+    ec2.CfnTransitGatewayRoute(
+        ialirt_stack,
+        "IalirtTgwDefaultRouteToVpc",
+        destination_cidr_block="0.0.0.0/0",
+        transit_gateway_route_table_id=tgw_route_table_id,
+        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
+    )
+
+    # If it's a private address (10.x, 172.16-31.x, 192.168.x),
+    # go back through the TGW instead of the public internet.
+    def _add_return_routes(subnet_group: str, subnets: list) -> None:
+        for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"):
+            cidr_suffix = cidr.split("/")[0].replace(".", "")
+            for i, subnet in enumerate(subnets):
+                route = ec2.CfnRoute(
+                    ialirt_stack,
+                    f"Ialirt{subnet_group}Subnet{i}ReturnRoute{cidr_suffix}",
+                    route_table_id=subnet.route_table.route_table_id,
+                    destination_cidr_block=cidr,
+                    transit_gateway_id=ialirt_transit_gateway.attr_id,
+                )
+                route.add_dependency(ialirt_vpc_attachment)
+
+    _add_return_routes("Private", networking.vpc.private_subnets)
+    _add_return_routes("Public", networking.vpc.public_subnets)

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -10,6 +10,7 @@ from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_rds as rds
 from aws_cdk import aws_secretsmanager as secretsmanager
 from aws_cdk import aws_ssm as ssm
+from aws_cdk import custom_resources as cr
 
 from sds_data_manager.constructs import (
     api_gateway_construct,
@@ -461,13 +462,134 @@ def build_sds(
         ialirt_stack, "/ialirt/noaa-vpn/denv-ip"
     )
 
-    ialirt_vpn_construct.IalirtVpnConstruct(
+    # Create a Transit Gateway (TGW) to terminate the IPSec tunnel from NOAA.
+    #
+    # A Virtual Private Gateway can't route decrypted VPN traffic to a NAT
+    # Gateway, but I-ALiRT needs a NAT Gateway so NOAA's traffic reaches a
+    # stable Elastic IP instead of an EC2 private IP that changes whenever
+    # the Auto Scaling Group replaces the instance. A TGW VPC attachment's
+    # traffic can be routed to a NAT Gateway, so we use a TGW instead.
+    ialirt_transit_gateway = ec2.CfnTransitGateway(
+        ialirt_stack,
+        "IalirtTransitGateway",
+        # ASN is BGP's identifier for a distinct network/routing domain —
+        # how two BGP peers identify themselves and each other.
+        # Default ASN, but stated explicitly here.
+        amazon_side_asn=64512,
+        # Use our own route table below instead of TGW's hidden default one.
+        default_route_table_association="disable",
+        default_route_table_propagation="disable",
+        description="I-ALiRT TGW for NOAA VPN",
+    )
+
+    # Attach the VPC to the TGW via the private subnets, whose route tables
+    # already have 0.0.0.0/0 -> NAT Gateway — so traffic arriving via the TGW
+    # attachment gets forwarded there automatically. The NAT Gateway then
+    # sends it out to the internet, where it reaches I-ALiRT's own Elastic
+    # IP the same way every other partner's traffic already does.
+    ialirt_vpc_attachment = ec2.CfnTransitGatewayVpcAttachment(
+        ialirt_stack,
+        "IalirtTransitGatewayVpcAttachment",
+        transit_gateway_id=ialirt_transit_gateway.attr_id,
+        vpc_id=networking.vpc.vpc_id,
+        subnet_ids=[subnet.subnet_id for subnet in networking.vpc.private_subnets],
+    )
+
+    ialirt_vpn = ialirt_vpn_construct.IalirtVpnConstruct(
         scope=ialirt_stack,
         construct_id="IalirtVpn",
-        vpn_gateway=networking.vpn_gateway,
+        transit_gateway_id=ialirt_transit_gateway.attr_id,
         psk=noaa_vpn_psk,
         wash_ip=noaa_wash_ip,
         denv_ip=noaa_denv_ip,
+    )
+
+    # Create a TGW route table.
+    ialirt_tgw_route_table = ec2.CfnTransitGatewayRouteTable(
+        ialirt_stack,
+        "IalirtTransitGatewayRouteTable",
+        transit_gateway_id=ialirt_transit_gateway.attr_id,
+    )
+
+    # VPC's connection to the Transit Gateway will use our route table to
+    # look up where to send traffic.
+    ec2.CfnTransitGatewayRouteTableAssociation(
+        ialirt_stack,
+        "IalirtTgwRouteTableAssociationVpc",
+        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
+        transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+    )
+
+    # Add the VPC's address range to our route table, so any other
+    # attachment using this table (e.g. the NOAA VPN connections) can route
+    # traffic destined for the VPC here.
+    ec2.CfnTransitGatewayRouteTablePropagation(
+        ialirt_stack,
+        "IalirtTgwRouteTablePropagationVpc",
+        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
+        transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+    )
+
+    # AWS::EC2::VPNConnection does not expose its Transit Gateway attachment
+    # ID as a CloudFormation attribute, so look it up via a custom resource
+    # that calls ec2:DescribeTransitGatewayAttachments, filtered to the VPN
+    # connection's resource ID.
+    for site, vpn_connection in ialirt_vpn.vpn_connections.items():
+        describe_vpn_attachment = cr.AwsSdkCall(
+            service="EC2",
+            action="describeTransitGatewayAttachments",
+            parameters={
+                "Filters": [
+                    {
+                        "Name": "resource-id",
+                        "Values": [vpn_connection.attr_vpn_connection_id],
+                    },
+                    {"Name": "resource-type", "Values": ["vpn"]},
+                ]
+            },
+            physical_resource_id=cr.PhysicalResourceId.of(
+                f"IalirtVpnTgwAttachmentLookup{site}"
+            ),
+        )
+        vpn_attachment_lookup = cr.AwsCustomResource(
+            ialirt_stack,
+            f"IalirtVpnTgwAttachmentLookup{site}",
+            on_create=describe_vpn_attachment,
+            on_update=describe_vpn_attachment,
+            policy=cr.AwsCustomResourcePolicy.from_sdk_calls(
+                resources=cr.AwsCustomResourcePolicy.ANY_RESOURCE
+            ),
+        )
+        vpn_attachment_id = vpn_attachment_lookup.get_response_field(
+            "TransitGatewayAttachments.0.TransitGatewayAttachmentId"
+        )
+
+        # Add the transit gateway attachments to the route table.
+
+        # Use this table to decide where to forward the traffic you receive.
+        ec2.CfnTransitGatewayRouteTableAssociation(
+            ialirt_stack,
+            f"IalirtTgwRouteTableAssociationVpn{site}",
+            transit_gateway_attachment_id=vpn_attachment_id,
+            transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+        )
+        # Installs NOAA's routes into the table so the VPC attachment can
+        # find its way back to NOAA on the return path.
+        ec2.CfnTransitGatewayRouteTablePropagation(
+            ialirt_stack,
+            f"IalirtTgwRouteTablePropagationVpn{site}",
+            transit_gateway_attachment_id=vpn_attachment_id,
+            transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+        )
+
+    # Static route: send traffic for I-ALiRT EC2's Elastic IP into the VPC
+    # attachment, where the NAT Gateway forwards it to the public internet.
+    ec2.CfnTransitGatewayRoute(
+        ialirt_stack,
+        "IalirtTgwDefaultRouteToVpc",
+        destination_cidr_block="0.0.0.0/0",
+        transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
     )
 
     reprocessing_tools_construct = instrument_lambdas.ReprocessingTools(

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -8,9 +8,6 @@ from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_rds as rds
-from aws_cdk import aws_secretsmanager as secretsmanager
-from aws_cdk import aws_ssm as ssm
-from aws_cdk import custom_resources as cr
 
 from sds_data_manager.constructs import (
     api_gateway_construct,
@@ -29,7 +26,6 @@ from sds_data_manager.constructs import (
     ialirt_processing_construct,
     ialirt_realtime_construct,
     ialirt_schedule_fetch_construct,
-    ialirt_vpn_construct,
     indexer_lambda_construct,
     instrument_lambdas,
     lambda_layer_construct,
@@ -43,6 +39,7 @@ from sds_data_manager.constructs import (
     spice_monitoring_construct,
     website_hosting,
 )
+from sds_data_manager.utils import ialirt_noaa_vpn
 
 
 def build_sds(
@@ -438,172 +435,7 @@ def build_sds(
         account_name=account_name,
     )
 
-    # Retrieve the NOAA VPN pre-shared key from Secrets Manager.
-    # Store the PSK under the key "psk" in a secret named
-    # "/ialirt/noaa/noaa-vpn-psk" before deploying this stack.
-    noaa_vpn_psk = (
-        secretsmanager.Secret.from_secret_name_v2(
-            ialirt_stack, "NoaaVpnPsk", "/ialirt/noaa/noaa-vpn-psk"
-        )
-        .secret_value_from_json("psk")
-        .unsafe_unwrap()
-    )
-
-    # Retrieve NOAA's border router IPs from SSM Parameter Store.
-    # Store these before deploying:
-    #   aws ssm put-parameter --name "/ialirt/noaa-vpn/wash-ip"
-    #   --value "<ip>" --type String
-    #   aws ssm put-parameter --name "/ialirt/noaa-vpn/denv-ip"
-    #   --value "<ip>" --type String
-    noaa_wash_ip = ssm.StringParameter.value_for_string_parameter(
-        ialirt_stack, "/ialirt/noaa-vpn/wash-ip"
-    )
-    noaa_denv_ip = ssm.StringParameter.value_for_string_parameter(
-        ialirt_stack, "/ialirt/noaa-vpn/denv-ip"
-    )
-
-    # Create a Transit Gateway (TGW) to terminate the IPSec tunnel from NOAA.
-    ialirt_transit_gateway = ec2.CfnTransitGateway(
-        ialirt_stack,
-        "IalirtTransitGateway",
-        # ASN is BGP's identifier for a distinct network/routing domain —
-        # how two BGP peers identify themselves and each other.
-        # Default ASN, but stated explicitly here.
-        amazon_side_asn=64512,
-        # Use our own route table below instead of TGW's hidden default one.
-        default_route_table_association="disable",
-        default_route_table_propagation="disable",
-        description="I-ALiRT TGW for NOAA VPN",
-    )
-
-    # Attach the VPC to the TGW via the private subnets, whose route tables
-    # already have 0.0.0.0/0 -> NAT Gateway — so traffic arriving via the TGW
-    # attachment gets forwarded there automatically. The NAT Gateway then
-    # sends it out to the internet, where it reaches I-ALiRT's own Elastic
-    # IP the same way every other partner's traffic already does.
-    ialirt_vpc_attachment = ec2.CfnTransitGatewayVpcAttachment(
-        ialirt_stack,
-        "IalirtTransitGatewayVpcAttachment",
-        transit_gateway_id=ialirt_transit_gateway.attr_id,
-        vpc_id=networking.vpc.vpc_id,
-        subnet_ids=[subnet.subnet_id for subnet in networking.vpc.private_subnets],
-    )
-
-    ialirt_vpn = ialirt_vpn_construct.IalirtVpnConstruct(
-        scope=ialirt_stack,
-        construct_id="IalirtVpn",
-        transit_gateway_id=ialirt_transit_gateway.attr_id,
-        psk=noaa_vpn_psk,
-        wash_ip=noaa_wash_ip,
-        denv_ip=noaa_denv_ip,
-    )
-
-    # Create a TGW route table.
-    ialirt_tgw_route_table = ec2.CfnTransitGatewayRouteTable(
-        ialirt_stack,
-        "IalirtTransitGatewayRouteTable",
-        transit_gateway_id=ialirt_transit_gateway.attr_id,
-    )
-    tgw_route_table_id = ialirt_tgw_route_table.attr_transit_gateway_route_table_id
-
-    # VPC's connection to the Transit Gateway will use our route table to
-    # look up where to send traffic.
-    ec2.CfnTransitGatewayRouteTableAssociation(
-        ialirt_stack,
-        "IalirtTgwRouteTableAssociationVpc",
-        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
-        transit_gateway_route_table_id=tgw_route_table_id,
-    )
-
-    # Add the VPC's address range to our route table, so any other
-    # attachment using this table (e.g. the NOAA VPN connections) can route
-    # traffic destined for the VPC here.
-    ec2.CfnTransitGatewayRouteTablePropagation(
-        ialirt_stack,
-        "IalirtTgwRouteTablePropagationVpc",
-        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
-        transit_gateway_route_table_id=tgw_route_table_id,
-    )
-
-    # AWS::EC2::VPNConnection does not expose its Transit Gateway attachment
-    # ID as a CloudFormation attribute, so look it up via a custom resource
-    # that calls ec2:DescribeTransitGatewayAttachments, filtered to the VPN
-    # connection's resource ID.
-    for site, vpn_connection in ialirt_vpn.vpn_connections.items():
-        describe_vpn_attachment = cr.AwsSdkCall(
-            service="EC2",
-            action="describeTransitGatewayAttachments",
-            parameters={
-                "Filters": [
-                    {
-                        "Name": "resource-id",
-                        "Values": [vpn_connection.attr_vpn_connection_id],
-                    },
-                    {"Name": "resource-type", "Values": ["vpn"]},
-                ]
-            },
-            physical_resource_id=cr.PhysicalResourceId.of(
-                f"IalirtVpnTgwAttachmentLookup{site}"
-            ),
-        )
-        vpn_attachment_lookup = cr.AwsCustomResource(
-            ialirt_stack,
-            f"IalirtVpnTgwAttachmentLookup{site}",
-            on_create=describe_vpn_attachment,
-            on_update=describe_vpn_attachment,
-            policy=cr.AwsCustomResourcePolicy.from_sdk_calls(
-                resources=cr.AwsCustomResourcePolicy.ANY_RESOURCE
-            ),
-        )
-        vpn_attachment_id = vpn_attachment_lookup.get_response_field(
-            "TransitGatewayAttachments.0.TransitGatewayAttachmentId"
-        )
-
-        # Add the transit gateway attachments to the route table.
-
-        # Use this table to decide where to forward the traffic it receives.
-        ec2.CfnTransitGatewayRouteTableAssociation(
-            ialirt_stack,
-            f"IalirtTgwRouteTableAssociationVpn{site}",
-            transit_gateway_attachment_id=vpn_attachment_id,
-            transit_gateway_route_table_id=tgw_route_table_id,
-        )
-        # Installs NOAA's routes into the table so the VPC attachment can
-        # find its way back to NOAA on the return path.
-        ec2.CfnTransitGatewayRouteTablePropagation(
-            ialirt_stack,
-            f"IalirtTgwRouteTablePropagationVpn{site}",
-            transit_gateway_attachment_id=vpn_attachment_id,
-            transit_gateway_route_table_id=tgw_route_table_id,
-        )
-
-    # Static route: send traffic for I-ALiRT EC2's Elastic IP into the VPC
-    # attachment, where the NAT Gateway forwards it to the public internet.
-    ec2.CfnTransitGatewayRoute(
-        ialirt_stack,
-        "IalirtTgwDefaultRouteToVpc",
-        destination_cidr_block="0.0.0.0/0",
-        transit_gateway_route_table_id=tgw_route_table_id,
-        transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
-    )
-
-    # If it's a private address (10.x, 172.16-31.x, 192.168.x),
-    # go back through the TGW instead of the public internet.
-    def _add_return_routes(subnet_group: str, subnets: list) -> None:
-        for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"):
-            cidr_suffix = cidr.split("/")[0].replace(".", "")
-            for i, subnet in enumerate(subnets):
-                route = ec2.CfnRoute(
-                    ialirt_stack,
-                    f"Ialirt{subnet_group}Subnet{i}ReturnRoute{cidr_suffix}",
-                    route_table_id=subnet.route_table.route_table_id,
-                    destination_cidr_block=cidr,
-                    transit_gateway_id=ialirt_transit_gateway.attr_id,
-                )
-                route.add_dependency(ialirt_vpc_attachment)
-
-    _add_return_routes("Private", networking.vpc.private_subnets)
-    _add_return_routes("Public", networking.vpc.public_subnets)
+    ialirt_noaa_vpn.build_noaa_vpn_tgw(ialirt_stack, networking)
 
     reprocessing_tools_construct = instrument_lambdas.ReprocessingTools(
         scope=sdc_stack,

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -510,6 +510,7 @@ def build_sds(
         "IalirtTransitGatewayRouteTable",
         transit_gateway_id=ialirt_transit_gateway.attr_id,
     )
+    tgw_route_table_id = ialirt_tgw_route_table.attr_transit_gateway_route_table_id
 
     # VPC's connection to the Transit Gateway will use our route table to
     # look up where to send traffic.
@@ -517,7 +518,7 @@ def build_sds(
         ialirt_stack,
         "IalirtTgwRouteTableAssociationVpc",
         transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
-        transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+        transit_gateway_route_table_id=tgw_route_table_id,
     )
 
     # Add the VPC's address range to our route table, so any other
@@ -527,7 +528,7 @@ def build_sds(
         ialirt_stack,
         "IalirtTgwRouteTablePropagationVpc",
         transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
-        transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+        transit_gateway_route_table_id=tgw_route_table_id,
     )
 
     # AWS::EC2::VPNConnection does not expose its Transit Gateway attachment
@@ -564,14 +565,13 @@ def build_sds(
             "TransitGatewayAttachments.0.TransitGatewayAttachmentId"
         )
 
-        # Add the transit gateway attachments to the route table.
-
-        # Use this table to decide where to forward the traffic you receive.
+        # Add this VPN attachment to the route table, so it's used to
+        # decide where to forward the traffic it receives.
         ec2.CfnTransitGatewayRouteTableAssociation(
             ialirt_stack,
             f"IalirtTgwRouteTableAssociationVpn{site}",
             transit_gateway_attachment_id=vpn_attachment_id,
-            transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+            transit_gateway_route_table_id=tgw_route_table_id,
         )
         # Installs NOAA's routes into the table so the VPC attachment can
         # find its way back to NOAA on the return path.
@@ -579,7 +579,7 @@ def build_sds(
             ialirt_stack,
             f"IalirtTgwRouteTablePropagationVpn{site}",
             transit_gateway_attachment_id=vpn_attachment_id,
-            transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+            transit_gateway_route_table_id=tgw_route_table_id,
         )
 
     # Static route: send traffic for I-ALiRT EC2's Elastic IP into the VPC
@@ -588,7 +588,7 @@ def build_sds(
         ialirt_stack,
         "IalirtTgwDefaultRouteToVpc",
         destination_cidr_block="0.0.0.0/0",
-        transit_gateway_route_table_id=ialirt_tgw_route_table.attr_transit_gateway_route_table_id,
+        transit_gateway_route_table_id=tgw_route_table_id,
         transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
     )
 
@@ -613,26 +613,21 @@ def build_sds(
     # This covers NOAA's real internal prefixes without needing to know
     # them in advance, since NOAA's ICD networks are already private
     # address space.
-    for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"):
-        cidr_suffix = cidr.split("/")[0].replace(".", "")
-        for i, subnet in enumerate(networking.vpc.private_subnets):
-            return_route = ec2.CfnRoute(
-                ialirt_stack,
-                f"IalirtPrivateSubnet{i}ReturnRoute{cidr_suffix}",
-                route_table_id=subnet.route_table.route_table_id,
-                destination_cidr_block=cidr,
-                transit_gateway_id=ialirt_transit_gateway.attr_id,
-            )
-            return_route.add_dependency(ialirt_vpc_attachment)
-        for i, subnet in enumerate(networking.vpc.public_subnets):
-            public_return_route = ec2.CfnRoute(
-                ialirt_stack,
-                f"IalirtPublicSubnet{i}ReturnRoute{cidr_suffix}",
-                route_table_id=subnet.route_table.route_table_id,
-                destination_cidr_block=cidr,
-                transit_gateway_id=ialirt_transit_gateway.attr_id,
-            )
-            public_return_route.add_dependency(ialirt_vpc_attachment)
+    def _add_return_routes(subnet_group: str, subnets: list) -> None:
+        for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"):
+            cidr_suffix = cidr.split("/")[0].replace(".", "")
+            for i, subnet in enumerate(subnets):
+                route = ec2.CfnRoute(
+                    ialirt_stack,
+                    f"Ialirt{subnet_group}Subnet{i}ReturnRoute{cidr_suffix}",
+                    route_table_id=subnet.route_table.route_table_id,
+                    destination_cidr_block=cidr,
+                    transit_gateway_id=ialirt_transit_gateway.attr_id,
+                )
+                route.add_dependency(ialirt_vpc_attachment)
+
+    _add_return_routes("Private", networking.vpc.private_subnets)
+    _add_return_routes("Public", networking.vpc.public_subnets)
 
     reprocessing_tools_construct = instrument_lambdas.ReprocessingTools(
         scope=sdc_stack,

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -445,7 +445,7 @@ def build_sds(
             ialirt_stack, "NoaaVpnPsk", "noaa-vpn-psk"
         )
         .secret_value_from_json("psk")
-        .unsafe_unwrap()
+        .to_string()
     )
 
     # Retrieve NOAA's border router IPs from SSM Parameter Store.

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -438,11 +438,11 @@ def build_sds(
     )
 
     # Retrieve the NOAA VPN pre-shared key from Secrets Manager.
-    # Store the PSK under the key "psk" in a secret named "noaa-vpn-psk"
-    # before deploying this stack.
+    # Store the PSK under the key "psk" in a secret named
+    # "/ialirt/noaa/noaa-vpn-psk" before deploying this stack.
     noaa_vpn_psk = (
         secretsmanager.Secret.from_secret_name_v2(
-            ialirt_stack, "NoaaVpnPsk", "noaa-vpn-psk"
+            ialirt_stack, "NoaaVpnPsk", "/ialirt/noaa/noaa-vpn-psk"
         )
         .secret_value_from_json("psk")
         .unsafe_unwrap()

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -8,6 +8,8 @@ from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_rds as rds
+from aws_cdk import aws_secretsmanager as secretsmanager
+from aws_cdk import aws_ssm as ssm
 
 from sds_data_manager.constructs import (
     api_gateway_construct,
@@ -26,6 +28,7 @@ from sds_data_manager.constructs import (
     ialirt_processing_construct,
     ialirt_realtime_construct,
     ialirt_schedule_fetch_construct,
+    ialirt_vpn_construct,
     indexer_lambda_construct,
     instrument_lambdas,
     lambda_layer_construct,
@@ -433,6 +436,41 @@ def build_sds(
         secret_name=ialirt_secret_name,
         account_name=account_name,
     )
+
+    # Retrieve the NOAA VPN pre-shared key from Secrets Manager.
+    # Store the PSK under the key "psk" in a secret named "noaa-vpn-psk"
+    # before deploying this stack.
+    noaa_vpn_psk = (
+        secretsmanager.Secret.from_secret_name_v2(
+            ialirt_stack, "NoaaVpnPsk", "noaa-vpn-psk"
+        )
+        .secret_value_from_json("psk")
+        .unsafe_unwrap()
+    )
+
+    # Retrieve NOAA's border router IPs from SSM Parameter Store.
+    # Store these before deploying:
+    #   aws ssm put-parameter --name "/ialirt/noaa-vpn/wash-ip"
+    #   --value "<ip>" --type String
+    #   aws ssm put-parameter --name "/ialirt/noaa-vpn/denv-ip"
+    #   --value "<ip>" --type String
+    noaa_wash_ip = ssm.StringParameter.value_from_lookup(
+        ialirt_stack, "/ialirt/noaa-vpn/wash-ip"
+    )
+    noaa_denv_ip = ssm.StringParameter.value_from_lookup(
+        ialirt_stack, "/ialirt/noaa-vpn/denv-ip"
+    )
+
+    ialirt_vpn_construct.IalirtVpnConstruct(
+        scope=ialirt_stack,
+        construct_id="IalirtVpn",
+        vpn_gateway=networking.vpn_gateway,
+        psk=noaa_vpn_psk,
+        wash_ip=noaa_wash_ip,
+        denv_ip=noaa_denv_ip,
+    )
+
+
 
     reprocessing_tools_construct = instrument_lambdas.ReprocessingTools(
         scope=sdc_stack,

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -445,7 +445,7 @@ def build_sds(
             ialirt_stack, "NoaaVpnPsk", "noaa-vpn-psk"
         )
         .secret_value_from_json("psk")
-        .to_string()
+        .unsafe_unwrap()
     )
 
     # Retrieve NOAA's border router IPs from SSM Parameter Store.
@@ -469,8 +469,6 @@ def build_sds(
         wash_ip=noaa_wash_ip,
         denv_ip=noaa_denv_ip,
     )
-
-
 
     reprocessing_tools_construct = instrument_lambdas.ReprocessingTools(
         scope=sdc_stack,

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -454,10 +454,10 @@ def build_sds(
     #   --value "<ip>" --type String
     #   aws ssm put-parameter --name "/ialirt/noaa-vpn/denv-ip"
     #   --value "<ip>" --type String
-    noaa_wash_ip = ssm.StringParameter.value_from_lookup(
+    noaa_wash_ip = ssm.StringParameter.value_for_string_parameter(
         ialirt_stack, "/ialirt/noaa-vpn/wash-ip"
     )
-    noaa_denv_ip = ssm.StringParameter.value_from_lookup(
+    noaa_denv_ip = ssm.StringParameter.value_for_string_parameter(
         ialirt_stack, "/ialirt/noaa-vpn/denv-ip"
     )
 

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -463,12 +463,6 @@ def build_sds(
     )
 
     # Create a Transit Gateway (TGW) to terminate the IPSec tunnel from NOAA.
-    #
-    # A Virtual Private Gateway can't route decrypted VPN traffic to a NAT
-    # Gateway, but I-ALiRT needs a NAT Gateway so NOAA's traffic reaches a
-    # stable Elastic IP instead of an EC2 private IP that changes whenever
-    # the Auto Scaling Group replaces the instance. A TGW VPC attachment's
-    # traffic can be routed to a NAT Gateway, so we use a TGW instead.
     ialirt_transit_gateway = ec2.CfnTransitGateway(
         ialirt_stack,
         "IalirtTransitGateway",
@@ -565,8 +559,9 @@ def build_sds(
             "TransitGatewayAttachments.0.TransitGatewayAttachmentId"
         )
 
-        # Add this VPN attachment to the route table, so it's used to
-        # decide where to forward the traffic it receives.
+        # Add the transit gateway attachments to the route table.
+
+        # Use this table to decide where to forward the traffic it receives.
         ec2.CfnTransitGatewayRouteTableAssociation(
             ialirt_stack,
             f"IalirtTgwRouteTableAssociationVpn{site}",
@@ -592,27 +587,8 @@ def build_sds(
         transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
     )
 
-    # The private subnets' route tables only have a default 0.0.0.0/0 -> NAT
-    # Gateway route. BGP routes learned from the NOAA VPN connections are
-    # only propagated into the TGW's own route table (above), never
-    # automatically into the VPC's subnet route tables the way a VGW would.
-    # So once the NAT Gateway un-NATs a reply destined for NOAA's real
-    # (private) address, the private subnets have no route back through the
-    # TGW for it - it falls through to the NAT Gateway default and dead-ends
-    # trying to send a private address out to the public internet.
-    #
-    # The NAT Gateway itself lives in a public subnet, and routes its own
-    # un-NAT'd reply traffic using that public subnet's route table - not
-    # the private subnets'. So the same fix is needed there too, or the
-    # NAT Gateway's reply falls through to the public subnet's own
-    # 0.0.0.0/0 -> Internet Gateway default instead of back to the TGW.
-    #
-    # Add explicit routes for RFC1918 space, in both the private and public
-    # subnets, so any private-address traffic prefers the TGW (a longer
-    # prefix match than 0.0.0.0/0) over the NAT Gateway/Internet Gateway.
-    # This covers NOAA's real internal prefixes without needing to know
-    # them in advance, since NOAA's ICD networks are already private
-    # address space.
+    # If it's a private address (10.x, 172.16-31.x, 192.168.x),
+    # go back through the TGW instead of the public internet.
     def _add_return_routes(subnet_group: str, subnets: list) -> None:
         for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"):
             cidr_suffix = cidr.split("/")[0].replace(".", "")

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -592,6 +592,48 @@ def build_sds(
         transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
     )
 
+    # The private subnets' route tables only have a default 0.0.0.0/0 -> NAT
+    # Gateway route. BGP routes learned from the NOAA VPN connections are
+    # only propagated into the TGW's own route table (above), never
+    # automatically into the VPC's subnet route tables the way a VGW would.
+    # So once the NAT Gateway un-NATs a reply destined for NOAA's real
+    # (private) address, the private subnets have no route back through the
+    # TGW for it - it falls through to the NAT Gateway default and dead-ends
+    # trying to send a private address out to the public internet.
+    #
+    # The NAT Gateway itself lives in a public subnet, and routes its own
+    # un-NAT'd reply traffic using that public subnet's route table - not
+    # the private subnets'. So the same fix is needed there too, or the
+    # NAT Gateway's reply falls through to the public subnet's own
+    # 0.0.0.0/0 -> Internet Gateway default instead of back to the TGW.
+    #
+    # Add explicit routes for RFC1918 space, in both the private and public
+    # subnets, so any private-address traffic prefers the TGW (a longer
+    # prefix match than 0.0.0.0/0) over the NAT Gateway/Internet Gateway.
+    # This covers NOAA's real internal prefixes without needing to know
+    # them in advance, since NOAA's ICD networks are already private
+    # address space.
+    for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"):
+        cidr_suffix = cidr.split("/")[0].replace(".", "")
+        for i, subnet in enumerate(networking.vpc.private_subnets):
+            return_route = ec2.CfnRoute(
+                ialirt_stack,
+                f"IalirtPrivateSubnet{i}ReturnRoute{cidr_suffix}",
+                route_table_id=subnet.route_table.route_table_id,
+                destination_cidr_block=cidr,
+                transit_gateway_id=ialirt_transit_gateway.attr_id,
+            )
+            return_route.add_dependency(ialirt_vpc_attachment)
+        for i, subnet in enumerate(networking.vpc.public_subnets):
+            public_return_route = ec2.CfnRoute(
+                ialirt_stack,
+                f"IalirtPublicSubnet{i}ReturnRoute{cidr_suffix}",
+                route_table_id=subnet.route_table.route_table_id,
+                destination_cidr_block=cidr,
+                transit_gateway_id=ialirt_transit_gateway.attr_id,
+            )
+            public_return_route.add_dependency(ialirt_vpc_attachment)
+
     reprocessing_tools_construct = instrument_lambdas.ReprocessingTools(
         scope=sdc_stack,
         construct_id="ReprocessingTools",


### PR DESCRIPTION
What we provide to NOAA:
  - IKE Gateway IPs 
  - BGP IP LASP
  - AWS-side ASN
  - I-ALiRT's EIP + port
  - LASP's advertised BGP prefixes

What NOAA provides to us:
  - Their border router public IPs (WASH + DENV) (stackbuilder.py:460)
  - Their ASN (ialirt_vpn_construct.py:124)
  - The PSK (stackbuilder.py:446)

 Neither side "provides" - needs to go back to NOAA as a platform limitation:
  - BGP MD5 string - AWS's managed Site-to-Site VPN doesn't support this.

**Notes:**

- NOAA has two border routers — one in McLean, VA (WASH) and one in Denver, CO (DENV) — each with a public IP. Two sites exist purely for redundancy: if one goes down, traffic reroutes through the other. Each NOAA router opens an IPSec (IKEv2) tunnel to AWS, authenticated with a shared secret (PSK).

**Why we used Transit Gateway:**

A Virtual Private Gateway (VGW) is the "default" way to terminate a Site-to-Site VPN. It attaches directly to a VPC and injects routes into that VPC's subnet route tables. A VGW cannot route decrypted VPN traffic to a NAT Gateway.

Why that's a problem here: I-ALiRT's actual endpoint is an EC2 instance in an Auto Scaling Group. Its private IP isn't stable. If the ASG replaces the instance, the private IP changes. What is stable is its Elastic IP, which is reached by going out through a NAT Gateway. So NOAA's decrypted traffic needs to land in the VPC and then get handed to the NAT Gateway so it can reach that Elastic IP - exactly the hop a VGW can't do.

A Transit Gateway can do that hop. A TGW attaches to the VPC and its traffic follows whatever the subnet's own route table says - including a NAT Gateway route. So terminating the VPN on a TGW instead of a VGW means the decrypted NOAA traffic gets funneled through the NAT Gateway, out to the Elastic IP, and hits the instance the same way everyone else's traffic does.

----------------------------------
<img width="1654" height="1096" alt="Screenshot 2026-07-22 at 9 40 03 AM" src="https://github.com/user-attachments/assets/18ac68eb-f287-4de5-abbd-52fa633c71a0" />


**- Step 1: NOAA sends data**

The packet has:
- **Source IP**: NOAA's internal private IP
- **Destination IP**: the I-ALiRT EIP

**- Step 2: NOAA's border router encrypts the packet**

The router has a rule: Traffic destined for the I-ALiRT EIP goes through the VPN tunnel

The router wraps the original packet in an encrypted IPSec envelope. The outer envelope has:
- **Source IP**: NOAA border router public IP  (WASH) or  (DENV)
- **Destination IP**: AWS's auto-assigned VPN tunnel endpoint public IP

**- Step 3: Travels across public internet**

**- Step 4: AWS Transit Gateway decrypts the packet**

* Note: NOAA border router public IPs go into the CfnCustomerGateway, which is essentially AWS's record of "this is NOAA's router, trust it.

 AWS decrypts the envelope using the pre-shared key (Secrets Manager, /ialirt/noaa/noaa-vpn-psk).

The outer envelope is discarded. The original inner packet is restored:
- **Source IP**: NOAA's private internal IP (TBD Wallops/Suitland address)
- **Destination IP**: the I-ALiRT EIP

**- Step 5: Transit Gateway routes the packet into the VPC**

  TGW route table sends it through the VPC attachment, into a private subnet. Packet is unchanged.

**- Step 6: Private subnet routes the packet to the NAT Gateway**

Default route (0.0.0.0/0) sends it there, since the EIP isn't inside the VPC's own address range. The NAT Gateway rewrites the source IP to its own EIP (NOAA's original source IP is gone at
  this point):
  - Source IP: NAT Gateway's own EIP
  - Destination IP: the I-ALiRT EIP

**- Step 7: NAT Gateway hands off to Internet Gateway, which translates EIP → private IP**

**- Step 8: Security group check**

  SG sees source = NAT Gateway's own EIP (not NOAA's real IP), checked against the allow-list.

**- Step 9: Container receives packet**

----------------------------------
**Testing**
To validate the NOAA N-Wave Site-to-Site VPN connection ahead of the real NOAA onboarding, I stood up an EC2 instance running strongSwan as a stand-in for NOAA's border router, configured
  with the IKEv2/AES-256-CBC/SHA2-256/DH group14 parameters specified in the ICD, and deployed the IalirtStack CDK infrastructure — which routes the NOAA VPN connection through a Transit
  Gateway to a NAT Gateway and I-ALiRT's stable Elastic IP in a sandbox AWS account for testing. This architecture was tested end-to-end on the WASH site's Tunnel 1, with a TCP connection successfully established from the strongSwan test host through the IPsec tunnel, BGP-derived routing, NAT Gateway, and security group to I-ALiRT's Elastic IP, confirming actual data packets traverse the full path.

**Detailed reproducible instructions**

 0. Prerequisites: A running EC2 acting as the test "NOAA router" with strongSwan + FRR already installed (we reused an existing one: dev account).
  
 1. Confirm the stack deployed the VPN resources
  aws cloudformation describe-stack-resources --stack-name IalirtStack \
    --profile lcs --region us-west-2
  Look for AWS::EC2::VPNConnection, AWS::EC2::CustomerGateway, AWS::EC2::TransitGateway* entries.

  2. Look up the tunnel endpoint you're bringing up (e.g. WASH)
  aws ec2 describe-vpn-connections --vpn-connection-ids <wash-vpn-id> \
    --region us-west-2 --profile lcs \
    --query 'VpnConnections[].Options.TunnelOptions[].{OutsideIp:OutsideIpAddress,InsideCidr:TunnelInsideCidr}' \
    --output json
  Take Tunnel 1's OutsideIp and InsideCidr.

  3. Point strongSwan at that tunnel
  On the test EC2, edit /etc/swanctl/conf.d/noaa-aws.conf: set remote_addrs, the remote { id = ... } block, and the secrets.ike-tunnel1.id-2 entry all to the OutsideIp from step 2.

  4. Point FRR's BGP config at the AWS-side inside IP
  Edit /etc/frr/frr.conf: router bgp <NOAA ASN, e.g. 64583>, neighbor <AWS-side inside IP, e.g. x.x.x.x/30's .1> remote-as 64512 (AWS's amazon_side_asn), and a network statement for whatever
  prefix you want to test-advertise.

  5. Bring the tunnel up
  sudo swanctl --load-all
  sudo swanctl --initiate --child aws-tunnel1

  6. Verify BGP came up
  sudo vtysh -c "show bgp summary"
  Expect ESTABLISHED against the AWS-side inside IP.

  7. Confirm from the AWS side
  aws ec2 describe-vpn-connections --vpn-connection-ids <wash-vpn-id> \
    --region us-west-2 --profile lcs --query 'VpnConnections[].VgwTelemetry' --output json
  Expect Status: UP and a nonzero AcceptedRouteCount on that tunnel's OutsideIpAddress.

  8. Find I-ALiRT's current Elastic IP (dynamically Lambda-assigned per instance, not static — always look it up fresh)
  aws ec2 describe-instances \
    --filters "Name=tag:aws:cloudformation:stack-name,Values=IalirtStack" "Name=instance-state-name,Values=running" \
    --region us-west-2 --profile lcs \
    --query 'Reservations[].Instances[].{InstanceId:InstanceId,PublicIp:PublicIpAddress}' --output json

  9. Send test traffic, explicitly sourced from the test EC2's private IP
  echo "test" | nc -v -s <test-ec2-private-ip> <ialirt-eip-from-previous-step> 7563 -i 1
  Expect "Connection ... succeeded!".