### PR TITLE
updated dependencies for lo/l1c/pset

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -845,9 +845,8 @@ leapseconds, spice, historical, lo, l1b, bgrates, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1b, bgrates, HARD_NO_TRIGGER, DOWNSTREAM
 
 lo, l1b, de, lo, l1c, pset, HARD, DOWNSTREAM
-lo, ancillary, good-times, lo, l1c, pset, HARD, DOWNSTREAM
-lo, ancillary, hydrogen-background, lo, l1c, pset, HARD, DOWNSTREAM
-lo, ancillary, oxygen-background, lo, l1c, pset, HARD, DOWNSTREAM
+lo, l1b, goodtimes, lo, l1c, pset, HARD, DOWNSTREAM
+lo, l1b, bgrates, lo, l1c, pset, HARD, DOWNSTREAM
 spin, spin, historical, lo, l1c, pset, HARD, DOWNSTREAM
 repoint, repoint, historical, lo, l1c, pset, HARD, DOWNSTREAM
 leapseconds, spice, historical, lo, l1c, pset, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
@@ -197,17 +197,14 @@ lo_esa_fit_factors: &lo_esa_fit_factors
     upstream_descriptor: historical
     kickoff_job: false
   - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: good-times
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: hydrogen-background
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: oxygen-background
-  - upstream_source: lo
     upstream_data_type: l1b
     upstream_descriptor: de
+  - upstream_source: lo
+    upstream_data_type: l1b
+    upstream_descriptor: goodtimes
+  - upstream_source: lo
+    upstream_data_type: l1b
+    upstream_descriptor: bgrate
 
 # ======== Level L2 ========
 (l2, l090-ena-h-hf-nsp-ram-hae-6deg-1yr):

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
@@ -204,7 +204,7 @@ lo_esa_fit_factors: &lo_esa_fit_factors
     upstream_descriptor: goodtimes
   - upstream_source: lo
     upstream_data_type: l1b
-    upstream_descriptor: bgrate
+    upstream_descriptor: bgrates
 
 # ======== Level L2 ========
 (l2, l090-ena-h-hf-nsp-ram-hae-6deg-1yr):


### PR DESCRIPTION
Closes #1337 

## Change Summary

## Overview

Updated dependencies for `lo_l1c_pset` to look for goodtimes/bgrates information from science dependencies (already being produced by the pipeline).

I'm not sure of the order of submitting PRs when updating dependencies and associated code in `imap_processing`, and if this will fail in the CI.
