### PR TITLE
Configure GLOWS L3a to depend on the  L2 calibration ancillary

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -124,7 +124,7 @@ science_frames, spice, historical, glows, l2, hist, HARD_NO_TRIGGER, DOWNSTREAM
 pointing_attitude, spice, historical, glows, l2, hist, HARD_NO_TRIGGER, DOWNSTREAM
 
 glows, l2, hist, glows, l3a, hist, HARD, DOWNSTREAM
-glows, ancillary, calibration-data, glows, l3a, hist, HARD, DOWNSTREAM
+glows, ancillary, l2-calibration, glows, l3a, hist, HARD, DOWNSTREAM
 glows, ancillary, l3a-time-dep-bckgrd, glows, l3a, hist, HARD, DOWNSTREAM
 glows, ancillary, l3a-map-of-extra-helio-bckgrd, glows, l3a, hist, HARD, DOWNSTREAM
 glows, ancillary, pipeline-settings, glows, l3a, hist, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_glows_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_glows_dependencies.yaml
@@ -106,7 +106,7 @@ hist_spice: &hist_spice
     upstream_descriptor: hist
   - upstream_source: glows
     upstream_data_type: ancillary
-    upstream_descriptor: calibration-data
+    upstream_descriptor: l2-calibration
   - upstream_source: glows
     upstream_data_type: ancillary
     upstream_descriptor: l3-time-dep-bckgrd


### PR DESCRIPTION
# Change Summary
GLOWS L3a uses the l2-calibration ancillary. With this update, L3a should trigger using all the newly generated L2 files.

NOTE: There are still some outstanding questions with L3a and this should not be merged or pushed to production until those have been answered.

## File changes
sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv