### PR TITLE
I-ALiRT - update alarm schedule

### DIFF
--- a/sds_data_manager/constructs/ialirt_alarm_construct.py
+++ b/sds_data_manager/constructs/ialirt_alarm_construct.py
@@ -261,11 +261,12 @@ class IalirtAlarmConstruct(Construct):
 
         instrument_alarm_lambda.apply_removal_policy(RemovalPolicy.DESTROY)
 
+        # Run at 11:00 UTC daily.
         daily_rule = events.Rule(
             self,
             "IalirtInstrumentAlarmSchedule",
             rule_name="ialirt-instrument-alarm-schedule",
-            schedule=events.Schedule.rate(Duration.hours(8)),
+            schedule=events.Schedule.cron(hour="11", minute="0"),
         )
         daily_rule.add_target(targets.LambdaFunction(instrument_alarm_lambda))
 


### PR DESCRIPTION
This pull request updates the scheduling of the `instrument_alarm_lambda` in the `ialirt_alarm_construct.py` file. Instead of running every 8 hours, the Lambda function will now run once daily at 11:00 UTC.

- Scheduling changes:
  * Changed the `events.Rule` schedule for `instrument_alarm_lambda` from running every 8 hours to running once daily at 11:00 UTC, using a cron expression.