### PR TITLE
[WIP] Add release api logic

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -1,4 +1,5 @@
 """Lambda function for release API endpoint."""
+
 import datetime
 import json
 import logging
@@ -66,27 +67,24 @@ def lambda_handler(event, context):
         )
         return response
 
-    logger.debug("Release Query Event: " + json.dumps(event, indent=2))
+    logger.info("Release Query Event: " + json.dumps(event, indent=2))
 
-    TableModels = namedtuple(
-        "TableModels", ["release", "science", "ancillary"]
-    )
-
-    table_models = TableModels(
-        science=models.ScienceFiles,
-        ancillary=models.AncillaryFiles,
-        release=models.ReleaseFiles
-    )
+    # tables to query for release operations
+    table_models = {
+        "release": models.ReleaseFiles,
+        "science": models.ScienceFiles,
+        "ancillary": models.AncillaryFiles,
+    }
 
     # add session, pick model
     query_params = event["queryStringParameters"]
-    # get desired table for query
-    query_table = "release"
-    logger.info(f"Querying table: {query_table}")
-    model = getattr(table_models, query_table)
+
+    # get desired table for release query
+    logger.info(f"Querying table: Release")
+    model = table_models.get("release")
 
     # select the given table for the query
-    query = select(model.__table__)
+    query = select(model)
 
     # get a list of all valid search parameters
     valid_parameters = [

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -1,6 +1,116 @@
 """Lambda function for release API endpoint."""
+import datetime
+import json
+import logging
+from collections import namedtuple
 
+from sqlalchemy import func, select
+
+from ..api_lambdas.utils import is_authenticated_user
+from ..database import database as db
+from ..database import models
+
+# Logger setup
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
-    """Lambda handler for release API."""
+    """Entry point to the release query API lambda.
+
+    imap-data-access release --instrument --start-date --end-date --release-type --release-number (optional)
+
+    Filename convention for release table records:
+        imap_<instrument>_<descriptor>_<start_date>_<end_date>_<version>.<extension>
+
+        The <descriptor> field options:
+
+        withhold-data-release-<###> - it will support integer value associated to a release number.
+        early-release  - it will support making an early release of selected files
+        unrelease - it will support un-releasing selected files after they've been released.
+
+    Parameters
+    ----------
+    event : dict
+        The JSON formatted document with the data required for the
+        lambda function to process
+    context : LambdaContext
+        This object provides methods and properties that provide
+        information about the invocation, function,
+        and runtime environment.
+
+    """
+    logger.debug("Release Query Event: " + json.dumps(event, indent=2))
+
+    TableModels = namedtuple(
+        "TableModels", ["release", "science", "ancillary"]
+    )
+
+    table_models = TableModels(
+        science=models.ScienceFiles,
+        ancillary=models.AncillaryFiles,
+        release=models.ReleaseFiles
+    )
+
+    # add session, pick model like in indexer and add query to filter_as
+    query_params = event["queryStringParameters"]
+    # get desired table for query
+    query_table = "release"
+
+    logger.info(f"Querying table: {query_table}")
+    model = getattr(table_models, query_table)
+
+    # select the given table for the query
+    query = select(model.__table__)
+    if not is_authenticated_user(event):
+        query = query.filter(model.released)
+
+    # get a list of all valid search parameters
+    valid_parameters = [
+        "instrument",
+        "start_time",
+        "end_time",
+        "release-type",
+        "release-number",
+    ]
+
+    # go through each query parameter to set up sqlalchemy query conditions
+    for param, value in query_params.items():
+        # confirm that the query parameter is valid
+        if param not in valid_parameters:
+            response = {
+                "statusCode": 400,
+                "body": json.dumps(
+                    f"{param} is not a valid query parameter. "
+                    + f"Valid query parameters are: {valid_parameters}"
+                ),
+            }
+            logger.debug(
+                f"Received an invalid query parameter [{param}],"
+                " valid options are: {valid_parameters}"
+            )
+            return response
+        try:
+            if param == "start_time":
+                query = query.where(model.max_date_j2000 >= int(value))
+            elif param == "end_time":
+                query = query.where(model.min_date_j2000 <= int(value))
+            elif param == "release-type":
+                # filter release-type in filename using a "contains" query on the file path
+                query = query.where(model.file_path.contains(value, autoescape=True))
+        except ValueError:
+            response = {
+                "statusCode": 400,
+                "body": json.dumps(f"Invalid value for {param}: {value}"),
+            }
+            logger.debug(f"Invalid value for {param}: {value}")
+            return response
+    with db.Session() as session:
+        # TODO: should this only return no more than one record?
+        search_results = session.execute(query).all()
+
+    # TODO:
+    # - download and read file for listing of products
+    # - query science and ancillary tables for products in time range and update release to True
+    #   except those in the release file.
+
     return {"statusCode": 200, "body": "Release API is working!"}

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -94,17 +94,22 @@ def lambda_handler(event, context):
             )
             return response
         try:
-            if param == "start_time":
-                query = query.where(model.max_date_j2000 >= int(value))
-            elif param == "end_time":
-                query = query.where(model.min_date_j2000 <= int(value))
-            elif param == "release-type":
+            if param == "start_date":
+                query = query.where(
+                    model.start_date >= datetime.datetime.strptime(value, "%Y%m%d")
+                )
+            elif param == "end_date":
+                # the date queries will only look at the file start_date.
+                query = query.where(
+                    model.end_date <= datetime.datetime.strptime(value, "%Y%m%d")
+                )
+            elif param == "release_type":
                 valid_release_types = [
                     "early-release",
                     "unrelease",
                     "withhold-data",  # TODO: make this one default if release-type isn't given?
                 ]
-                if param not in valid_release_types:
+                if value not in valid_release_types:
                     response = {
                         "statusCode": 400,
                         "body": json.dumps(

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -44,6 +44,18 @@ def lambda_handler(event, context):
     context : LambdaContext
         Lambda runtime context object.
     """
+    # Check authentication is valid
+    if not is_authenticated_user(event):
+        response = {
+            "statusCode": 400,
+            "body": json.dumps(
+                f"API authentication failed: {event['body']}."),
+        }
+        logger.debug(
+            f"API authentication failed: {event['body']}."
+        )
+        return response
+
     logger.debug("Release Query Event: " + json.dumps(event, indent=2))
 
     TableModels = namedtuple(
@@ -56,18 +68,15 @@ def lambda_handler(event, context):
         release=models.ReleaseFiles
     )
 
-    # add session, pick model like in indexer and add query to filter_as
+    # add session, pick model
     query_params = event["queryStringParameters"]
     # get desired table for query
     query_table = "release"
-
     logger.info(f"Querying table: {query_table}")
     model = getattr(table_models, query_table)
 
     # select the given table for the query
     query = select(model.__table__)
-    if not is_authenticated_user(event):
-        query = query.filter(model.released)
 
     # get a list of all valid search parameters
     valid_parameters = [
@@ -130,12 +139,18 @@ def lambda_handler(event, context):
             }
             logger.debug(f"Invalid value for {param}: {value}")
             return response
+
+    # Keep only rows at the highest version from the filtered result set.
+    filtered_subq = query.subquery()
+    max_version_subq = select(func.max(filtered_subq.c.version)).scalar_subquery()
+    query = select(filtered_subq).where(filtered_subq.c.version == max_version_subq)
+
     with db.Session() as session:
-        # TODO: should this return no more than one record?
+        # TODO: should this only return 1 or 0 results?
         search_results = session.execute(query).all()
 
     # TODO:
-    #  - download and read file to get list of products
+    #  - download and read file found to get list of products
     #  - query science and ancillary tables for products in specified time range
     #  - write logic for handling withhold, unrelease, and early release files
     #       - withhold - update release to False for listed products. update all other files in release to True.
@@ -143,8 +158,32 @@ def lambda_handler(event, context):
     #       - early release - update release to True for listed products.
 
     # TODO: for release-type, consider making it optional and default to withhold files if type isn't given.
-    #  This makes our regular releases a simple api call to release files for a date range given, and
+    #  This would make routine releases a simple api call to release files for a date range given, and
     #  by default, checks for any related withhold files to process. "early-release" and "unrelease" would be
     #  special cases that require the release-type param to be used.
 
-    return {"statusCode": 200, "body": "Release API is working!"}
+    # TODO: The release column may change from a boolean value to an integer representing
+    #  the release number the file pertains to. Needs further discussion
+
+    # TODO: Some of this code is borrowed from query_api.py. Look at ways to create helper
+    #  functions to reduce duplication
+
+    # Convert the search results (list of tuples) to a list of dicts
+    search_results = [result._asdict() for result in search_results]
+
+    # Convert datetimes to string values of format 'YYYYMMDD'
+    # Also remove values that are not needed by users
+    for result in search_results:
+        result["start_date"] = result["start_date"].strftime("%Y%m%d")
+        if result.get("end_date"):
+            result["end_date"] = result["end_date"].strftime("%Y%m%d")
+        d = result["ingestion_date"]
+        if d.tzinfo is not None:
+            # If the datetime has a timezone, convert it to UTC and remove the timezone
+            d = d.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        result["ingestion_date"] = d.strftime("%Y%m%d %H:%M:%S")
+
+    logger.info(
+        "Found [%s] Query Search Results: %s", len(search_results), str(search_results)
+    )
+    return {"statusCode": 200, "body": json.dumps(search_results)}

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -14,6 +14,16 @@ from ..database import models
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+
+# TODO:
+#   - For release-type, consider making it optional and default to withhold files if type isn't given.
+#     This would make routine releases a simple api call to release files for a date range given, and
+#     by default, checks for any related withhold files to process. "early-release" and "unrelease" would be
+#     special cases that require the release-type param to be used.
+#   - The release column may change from a boolean value to an integer representing
+#     the release number the file pertains to. Needs further discussion
+#   - Some of this code is borrowed from query_api.py. Refactor to reduce duplication
+
 def lambda_handler(event, context):
     """Entry point for the release API lambda.
 
@@ -149,25 +159,6 @@ def lambda_handler(event, context):
         # TODO: should this only return 1 or 0 results?
         search_results = session.execute(query).all()
 
-    # TODO:
-    #  - download and read file found to get list of products
-    #  - query science and ancillary tables for products in specified time range
-    #  - write logic for handling withhold, unrelease, and early release files
-    #       - withhold - update release to False for listed products. update all other files in release to True.
-    #       - unrelease - update release to False for listed products.
-    #       - early release - update release to True for listed products.
-
-    # TODO: for release-type, consider making it optional and default to withhold files if type isn't given.
-    #  This would make routine releases a simple api call to release files for a date range given, and
-    #  by default, checks for any related withhold files to process. "early-release" and "unrelease" would be
-    #  special cases that require the release-type param to be used.
-
-    # TODO: The release column may change from a boolean value to an integer representing
-    #  the release number the file pertains to. Needs further discussion
-
-    # TODO: Some of this code is borrowed from query_api.py. Look at ways to create helper
-    #  functions to reduce duplication
-
     # Convert the search results (list of tuples) to a list of dicts
     search_results = [result._asdict() for result in search_results]
 
@@ -186,4 +177,13 @@ def lambda_handler(event, context):
     logger.info(
         "Found [%s] Query Search Results: %s", len(search_results), str(search_results)
     )
+
+    # TODO: This function currently just queries the release table.
+    #       It also needs to update release status of products
+    #  - download and read release file found to get list of products
+    #  - query science and ancillary tables for products in specified time range
+    #  - write logic for handling withhold, unrelease, and early release files
+    #       - withhold - update release to False for listed products. update all other files in release to True.
+    #       - unrelease - update release to False for listed products.
+    #       - early release - update release to True for listed products.
     return {"statusCode": 200, "body": json.dumps(search_results)}

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -15,29 +15,34 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
-    """Entry point to the release query API lambda.
+    """Entry point for the release API lambda.
 
-    imap-data-access release --instrument --start-date --end-date --release-type --release-number (optional)
+    This API applies release policy to science and ancillary products by updating
+    their public visibility (`released` flag).
 
-    Filename convention for release table records:
+    Release workflows are driven by records in the `ReleaseFiles` table, where each
+    record defines a time range and a release operation.
+
+    Release file naming convention:
         imap_<instrument>_<descriptor>_<start_date>_<end_date>_<version>.<extension>
 
-        The <descriptor> field options:
+    Descriptor semantics:
+        - withhold-data-release-<###>:
+          Release all matching files for the period except those listed in the file.
+        - early-release:
+          Release only the files listed in the file before the scheduled release cadence.
+        - unrelease:
+          Mark previously released listed files as not released.
 
-        withhold-data-release-<###> - it will support integer value associated to a release number.
-        early-release  - it will support making an early release of selected files
-        unrelease - it will support un-releasing selected files after they've been released.
+    Expected API query parameters:
+        instrument, start_date, end_date, release_type, release_number (optional)
 
     Parameters
     ----------
     event : dict
-        The JSON formatted document with the data required for the
-        lambda function to process
+        Input event containing `queryStringParameters`.
     context : LambdaContext
-        This object provides methods and properties that provide
-        information about the invocation, function,
-        and runtime environment.
-
+        Lambda runtime context object.
     """
     logger.debug("Release Query Event: " + json.dumps(event, indent=2))
 
@@ -67,10 +72,10 @@ def lambda_handler(event, context):
     # get a list of all valid search parameters
     valid_parameters = [
         "instrument",
-        "start_time",
-        "end_time",
-        "release-type",
-        "release-number",
+        "start_date",
+        "end_date",
+        "release_type",
+        "release_number",
     ]
 
     # go through each query parameter to set up sqlalchemy query conditions
@@ -85,8 +90,7 @@ def lambda_handler(event, context):
                 ),
             }
             logger.debug(
-                f"Received an invalid query parameter [{param}],"
-                " valid options are: {valid_parameters}"
+                f"Received an invalid query parameter [{param}], valid options are: {valid_parameters}"
             )
             return response
         try:
@@ -95,6 +99,23 @@ def lambda_handler(event, context):
             elif param == "end_time":
                 query = query.where(model.min_date_j2000 <= int(value))
             elif param == "release-type":
+                valid_release_types = [
+                    "early-release",
+                    "unrelease",
+                    "withhold-data",  # TODO: make this one default if release-type isn't given?
+                ]
+                if param not in valid_release_types:
+                    response = {
+                        "statusCode": 400,
+                        "body": json.dumps(
+                            f"{param} is not a valid release_type parameter. "
+                            + f"Valid release_type parameters are: {valid_release_types}"
+                        ),
+                    }
+                    logger.debug(
+                        f"Received an invalid release_type parameter [{param}], valid options are: {valid_release_types}"
+                    )
+                    return response
                 # filter release-type in filename using a "contains" query on the file path
                 query = query.where(model.file_path.contains(value, autoescape=True))
         except ValueError:
@@ -105,12 +126,20 @@ def lambda_handler(event, context):
             logger.debug(f"Invalid value for {param}: {value}")
             return response
     with db.Session() as session:
-        # TODO: should this only return no more than one record?
+        # TODO: should this return no more than one record?
         search_results = session.execute(query).all()
 
     # TODO:
-    # - download and read file for listing of products
-    # - query science and ancillary tables for products in time range and update release to True
-    #   except those in the release file.
+    #  - download and read file to get list of products
+    #  - query science and ancillary tables for products in specified time range
+    #  - write logic for handling withhold, unrelease, and early release files
+    #       - withhold - update release to False for listed products. update all other files in release to True.
+    #       - unrelease - update release to False for listed products.
+    #       - early release - update release to True for listed products.
+
+    # TODO: for release-type, consider making it optional and default to withhold files if type isn't given.
+    #  This makes our regular releases a simple api call to release files for a date range given, and
+    #  by default, checks for any related withhold files to process. "early-release" and "unrelease" would be
+    #  special cases that require the release-type param to be used.
 
     return {"statusCode": 200, "body": "Release API is working!"}

--- a/tests/lambda_endpoints/test_release_api.py
+++ b/tests/lambda_endpoints/test_release_api.py
@@ -1,0 +1,226 @@
+"""Tests for the Release API."""
+
+import datetime
+import json
+
+from sds_data_manager.lambda_code.SDSCode.api_lambdas import release_api
+from sds_data_manager.lambda_code.SDSCode.database import models
+
+
+def _build_event(query_params, raw_path="/api-key/release"):
+    """Build an API event payload for release_api tests."""
+    return {"queryStringParameters": query_params, "rawPath": raw_path, "body": ""}
+
+
+def _insert_release_record(
+    session,
+    *,
+    file_path,
+    instrument="swe",
+    descriptor="withhold-data-release-001",
+    start_date="20250101",
+    end_date="20250331",
+    version="v001",
+    released=True,
+    ingestion_date="2025-04-09 21:12:53+00:00",
+):
+    """Insert one release-table record."""
+    session.add(
+        models.ReleaseFiles(
+            file_path=file_path,
+            instrument=instrument,
+            descriptor=descriptor,
+            start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
+            end_date=datetime.datetime.strptime(end_date, "%Y%m%d"),
+            version=version,
+            extension="txt",
+            ingestion_date=datetime.datetime.strptime(
+                ingestion_date, "%Y-%m-%d %H:%M:%S%z"
+            ),
+            released=released,
+        )
+    )
+    session.commit()
+
+
+def test_query_result_body(session):
+    """Tests that the query result body can be loaded."""
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v001.txt"
+        ),
+    )
+    event = _build_event({})
+
+    returned_query = release_api.lambda_handler(event=event, context={})
+
+    assert json.loads(returned_query["body"])
+
+
+def test_invalid_query_parameter(session):
+    """Test invalid parameters return a 400 status with explanation."""
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v001.txt"
+        ),
+    )
+    event = _build_event({"size": "500"})
+
+    returned_query = release_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 400
+    assert "size is not a valid query parameter" in returned_query["body"]
+
+
+def test_release_type_filter_contains(session):
+    """Test release_type applies a contains filter against file_path."""
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v001.txt"
+        ),
+        descriptor="withhold-data-release-001",
+        version="v001",
+    )
+    _insert_release_record(
+        session,
+        file_path="release/imap_swe_early-release_20250101_20250331_v002.txt",
+        descriptor="early-release",
+        version="v002",
+    )
+
+    event = _build_event({"release_type": "early-release"})
+    returned_query = release_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    body = json.loads(returned_query["body"])
+    assert len(body) == 1
+    assert body[0]["descriptor"] == "early-release"
+
+
+def test_invalid_release_type_value(session):
+    """Test invalid release_type values return 400."""
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v001.txt"
+        ),
+    )
+
+    event = _build_event({"release_type": "not-a-type"})
+    returned_query = release_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 400
+    assert "is not a valid release_type parameter" in returned_query["body"]
+
+
+def test_invalid_start_date_format_returns_400(session):
+    """Test invalid start_date format is rejected."""
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v001.txt"
+        ),
+    )
+
+    event = _build_event({"start_date": "2025-01-01"})
+    returned_query = release_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 400
+    assert "Invalid value for start_date" in returned_query["body"]
+
+
+def test_start_and_end_date_filters(session):
+    """Test start_date and end_date query filtering."""
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v001.txt"
+        ),
+        start_date="20250101",
+        end_date="20250331",
+        version="v001",
+    )
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250401_20250630_v002.txt"
+        ),
+        start_date="20250401",
+        end_date="20250630",
+        version="v002",
+    )
+
+    event = _build_event({"start_date": "20250301", "end_date": "20250701"})
+    returned_query = release_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    body = json.loads(returned_query["body"])
+    assert len(body) == 1
+    assert body[0]["version"] == "v002"
+
+
+def test_returns_only_latest_version_after_filters(session):
+    """Test query returns the highest version from filtered rows."""
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v001.txt"
+        ),
+        version="v001",
+    )
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v002.txt"
+        ),
+        version="v002",
+    )
+
+    event = _build_event(
+        {
+            "instrument": "swe",
+            "release_type": "withhold-data",
+            "start_date": "20250101",
+            "end_date": "20250331",
+        }
+    )
+    returned_query = release_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    body = json.loads(returned_query["body"])
+    assert len(body) == 1
+    assert body[0]["version"] == "v002"
+
+
+def test_unauthenticated_requests_return_400(session):
+    """Test non-authenticated requests are rejected by release API."""
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v001.txt"
+        ),
+        version="v001",
+        released=True,
+    )
+    _insert_release_record(
+        session,
+        file_path=(
+            "release/imap_swe_withhold-data-release-001_20250101_20250331_v002.txt"
+        ),
+        version="v002",
+        released=False,
+    )
+
+    unauth_event = _build_event(
+        {"release_type": "withhold-data"}, raw_path="/public/release"
+    )
+
+    unauth_response = release_api.lambda_handler(event=unauth_event, context={})
+
+    assert unauth_response["statusCode"] == 400
+    assert "API authentication failed" in unauth_response["body"]
+
+


### PR DESCRIPTION
This pull request updates the Release API Lambda handler, replacing the previous stub with functionality that supports query-based filtering of release records and enforces authentication. It also adds a test file to validate the new API's behavior, including query filtering, error handling, and authentication checks.

NOTE: This addresses part of ticket #1307. It handles querying the new release table. Work is still needed to implement updating the release status of data products.

**Release API Lambda Implementation:**

* Replaces the placeholder `lambda_handler` in `release_api.py` with functionality that:
  - Validates user authentication.
  - Supports query parameters (`instrument`, `start_date`, `end_date`, `release_type`, `release_number`) with type and value checks.
  - Filters release records using SQLAlchemy based on provided parameters, including date parsing and release type validation.
  - Ensures only the latest version of each filtered record is returned.
  - Formats response data, including date formatting and field filtering.

* Adds logging for debugging and error tracking throughout the API handler.

**Testing Enhancements:**

* Introduces a new test suite `test_release_api.py` that:
  - Covers valid and invalid query scenarios, including parameter validation, release type filtering, date parsing, and version selection.
  - Verifies authentication enforcement and correct API responses for both successful and error cases.
  - Provides utility functions for building test events and inserting test records.