### PR TITLE
I-ALiRT - IPSec VPN Relay

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,11 +7,16 @@ The app defaults to a dev deployment via a default `account_name` value in
 To deploy to prod, specify `--context account_name=prod`.
 To deploy to the backup account (only deploys required backup stacks),
 specify `--context account_name=backup`.
+To deploy the SMCE relay, specify `--context account_name=smce`.
 """
 
 from aws_cdk import App, Environment
 
-from sds_data_manager.utils.stackbuilder import build_backup, build_sds
+from sds_data_manager.utils.stackbuilder import (
+    build_backup,
+    build_sds,
+    build_smce_relay,
+)
 
 app = App()
 
@@ -42,8 +47,15 @@ if account_name == "backup":
     source_account_config = app.node.get_context(source_account_name)
     source_account = source_account_config["account"]
     build_backup(app, env=env, source_account=source_account)
+# TODO: update cdk.json once we have account info.
+elif account_name == "smce":
+    build_smce_relay(app, env=env)
 else:
     # Deploy SDS resources. This is the default with no CLI context variables set.
-    build_sds(app, env=env, account_config=account_config)
+    build_sds(
+        app,
+        env=env,
+        account_config=account_config,
+    )
 
 app.synth()

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -1,0 +1,134 @@
+"""Configure the I-ALiRT VPN connections to NOAA N-Wave."""
+
+from aws_cdk import aws_ec2 as ec2
+from constructs import Construct
+
+
+class IalirtVpnConstruct(Construct):
+    """NOAA N-Wave customer gateways and VPN connections for I-ALiRT."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        transit_gateway_id: str,
+        psk: str,
+        wash_ip: str,
+        denv_ip: str,
+        **kwargs,
+    ) -> None:
+        """Create NOAA N-Wave customer gateways and VPN connections.
+
+        Parameters
+        ----------
+        scope : Construct
+            Parent construct.
+        construct_id : str
+            A unique string identifier for this construct.
+        transit_gateway_id : str
+            The Transit Gateway to attach the VPN connections to.
+        psk : str
+            Pre-shared key for IKE authentication. Pass a CDK token from
+            ``secret_value_from_json(...).to_string()`` so the value is resolved
+            by CloudFormation at deploy time and never appears in the template.
+        wash_ip : str
+            NOAA border router public IP at McLean, VA (WASH), retrieved from SSM.
+        denv_ip : str
+            NOAA border router public IP at Denver, CO (DENV), retrieved from SSM.
+        kwargs : dict
+            Keyword arguments.
+        """
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Define the crypto settings for the IPSec tunnel, as specified
+        # in the N-Wave ICD (NOAA0550).
+        #
+        # Phase 1 (IKE) — the handshake phase where both sides authenticate each other
+        # and agree on encryption keys. Uses pre-shared key (PSK)
+        # resolved at deploy time.
+        #   - IKEv2 only (NOAA requirement)
+        #   - AES-256 encryption
+        #   - SHA2-256 integrity
+        #   - DH group 14 for key exchange
+        #   - 28800s (8 hour) lifetime
+        #
+        # Phase 2 (ESP) — the data phase where actual traffic is encrypted.
+        #   - AES-128 or AES-256 encryption
+        #   - HMAC-SHA2-256-128 integrity
+        #   - DH group 14 (PFS — Perfect Forward Secrecy)
+        #   - 3600s (1 hour) lifetime
+        tunnel = ec2.CfnVPNConnection.VpnTunnelOptionsSpecificationProperty(
+            pre_shared_key=psk,
+            ike_versions=[
+                ec2.CfnVPNConnection.IKEVersionsRequestListValueProperty(value="ikev2")
+            ],
+            phase1_encryption_algorithms=[
+                ec2.CfnVPNConnection.Phase1EncryptionAlgorithmsRequestListValueProperty(
+                    value="AES256"
+                )
+            ],
+            phase1_integrity_algorithms=[
+                ec2.CfnVPNConnection.Phase1IntegrityAlgorithmsRequestListValueProperty(
+                    value="SHA2-256"
+                )
+            ],
+            phase1_dh_group_numbers=[
+                ec2.CfnVPNConnection.Phase1DHGroupNumbersRequestListValueProperty(
+                    value=14
+                )
+            ],
+            phase1_lifetime_seconds=28800,
+            phase2_encryption_algorithms=[
+                ec2.CfnVPNConnection.Phase2EncryptionAlgorithmsRequestListValueProperty(
+                    value="AES128"
+                ),
+                ec2.CfnVPNConnection.Phase2EncryptionAlgorithmsRequestListValueProperty(
+                    value="AES256"
+                ),
+            ],
+            phase2_integrity_algorithms=[
+                ec2.CfnVPNConnection.Phase2IntegrityAlgorithmsRequestListValueProperty(
+                    value="SHA2-256"
+                )
+            ],
+            phase2_dh_group_numbers=[
+                ec2.CfnVPNConnection.Phase2DHGroupNumbersRequestListValueProperty(
+                    value=14
+                )
+            ],
+            phase2_lifetime_seconds=3600,
+        )
+
+        # Customer Gateway - AWS's record of NOAA's router so that AWS can recognize
+        # and accept the incoming encrypted packets.
+
+        # Every AWS Site-to-Site VPN connection automatically provisions
+        # two auto-assigned tunnel IPs.
+        # These LASP IKE Gateways must be given to NOAA.
+        self.vpn_connections: dict[str, ec2.CfnVPNConnection] = {}
+        for site, ip in {"WASH": wash_ip, "DENV": denv_ip}.items():
+            # AWS needs to know the router's public IP and ASN to establish the tunnel.
+            # bgp_asn=64583 is NOAA's ASN per the ICD.
+            cgw = ec2.CfnCustomerGateway(
+                self,
+                f"NoaaCustomerGateway{site}",
+                bgp_asn=64583,
+                ip_address=ip,
+                type="ipsec.1",
+            )
+
+            # Create the VPN connection between our Transit Gateway (TGW)
+            # and NOAA's customer gateway. Each connection gets two tunnels by default
+            # (AWS requirement for redundancy) — both use the same crypto settings.
+            # BGP is used (static_routes_only=False) so that if one site (WASH or DENV)
+            # goes down, BGP automatically reroutes traffic through the other.
+            # Data flows one way: NOAA sends to us. We do not send to NOAA.
+            self.vpn_connections[site] = ec2.CfnVPNConnection(
+                self,
+                f"NoaaVpnConnection{site}",
+                customer_gateway_id=cgw.ref,
+                transit_gateway_id=transit_gateway_id,
+                type="ipsec.1",
+                static_routes_only=False,
+                vpn_tunnel_options_specifications=[tunnel, tunnel],
+            )

--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -1,5 +1,6 @@
 """Configure the I-ALiRT VPN connections to NOAA N-Wave."""
 
+import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
 from constructs import Construct
 
@@ -15,6 +16,7 @@ class IalirtVpnConstruct(Construct):
         psk: str,
         wash_ip: str,
         denv_ip: str,
+        noaa_asn: str,
         **kwargs,
     ) -> None:
         """Create NOAA N-Wave customer gateways and VPN connections.
@@ -35,6 +37,8 @@ class IalirtVpnConstruct(Construct):
             NOAA border router public IP at McLean, VA (WASH), retrieved from SSM.
         denv_ip : str
             NOAA border router public IP at Denver, CO (DENV), retrieved from SSM.
+        noaa_asn : str
+            NOAA's BGP ASN per the N-Wave ICD (NOAA0550), retrieved from SSM.
         kwargs : dict
             Keyword arguments.
         """
@@ -108,11 +112,10 @@ class IalirtVpnConstruct(Construct):
         self.vpn_connections: dict[str, ec2.CfnVPNConnection] = {}
         for site, ip in {"WASH": wash_ip, "DENV": denv_ip}.items():
             # AWS needs to know the router's public IP and ASN to establish the tunnel.
-            # bgp_asn=64583 is NOAA's ASN per the ICD.
             cgw = ec2.CfnCustomerGateway(
                 self,
                 f"NoaaCustomerGateway{site}",
-                bgp_asn=64583,
+                bgp_asn=cdk.Token.as_number(noaa_asn),
                 ip_address=ip,
                 type="ipsec.1",
             )

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -8,6 +8,9 @@ from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_rds as rds
+from aws_cdk import aws_secretsmanager as secretsmanager
+from aws_cdk import aws_ssm as ssm
+from aws_cdk import custom_resources as cr
 
 from sds_data_manager.constructs import (
     api_gateway_construct,
@@ -26,6 +29,7 @@ from sds_data_manager.constructs import (
     ialirt_processing_construct,
     ialirt_realtime_construct,
     ialirt_schedule_fetch_construct,
+    ialirt_vpn_construct,
     indexer_lambda_construct,
     instrument_lambdas,
     lambda_layer_construct,
@@ -501,6 +505,191 @@ def build_sds(
         db_secret=dagster_database_construct.db_secret,
     )
     dagster_ecs_stack.node.add_dependency(dagster_image_construct)
+
+
+def build_smce_relay(
+    scope: App,
+    env: Environment,
+) -> None:
+    """Build the I-ALiRT SMCE relay account infrastructure.
+
+    Provisions a VPN tunnel to NOAA N-Wave and VPC peering to the SDS
+    account so NOAA telemetry flows directly over the AWS backbone.
+
+    Parameters
+    ----------
+    scope : App
+        CDK app.
+    env : Environment
+        SMCE account and region.
+
+    Notes
+    -----
+    Pre-deploy SSM parameters (in SMCE account):
+        /ialirt/noaa-vpn/wash-ip
+        /ialirt/noaa-vpn/denv-ip
+
+    Pre-deploy Secrets Manager secret (in SMCE account):
+        /ialirt/noaa/noaa-vpn-psk
+
+    Post-deploy (store in SDS account SSM so IalirtStack can read it):
+        /ialirt/smce/nat-gw-eip  — EIP of the SMCE NAT Gateway, available
+                                   from VPC -> NAT Gateways in the console
+                                   after deploying this stack.
+    """
+    networking_stack = Stack(scope, "SmceNetworkingStack", env=env)
+    networking = networking_construct.NetworkingConstruct(
+        networking_stack, "Networking"
+    )
+
+    # Create a Transit Gateway (TGW) to terminate the IPSec tunnel from NOAA.
+    #
+    # A TGW VPC attachment's traffic can be routed to a NAT
+    # Gateway, which I-ALiRT requires to forward NOAA telemetry to the
+    # destination EC2 instance's Elastic IP in the imap-dev account.
+    transit_gateway = ec2.CfnTransitGateway(
+        networking_stack,
+        "TransitGateway",
+        # ASN is BGP's identifier for a
+        # distinct network/routing domain —
+        # how two BGP peers identify themselves and each other.
+        # Default ASN, but stated explicitly here.
+        amazon_side_asn=64512,
+        # Use our own route table below instead of TGW's hidden default one.
+        default_route_table_association="disable",
+        default_route_table_propagation="disable",
+        description="I-ALiRT relay TGW for NOAA VPN",
+    )
+
+    # Attach the SMCE VPC to the TGW via the private subnets, whose route
+    # tables already have 0.0.0.0/0 -> NAT Gateway — so traffic arriving
+    # via the TGW attachment gets forwarded there automatically.
+    vpc_attachment = ec2.CfnTransitGatewayVpcAttachment(
+        networking_stack,
+        "TransitGatewayVpcAttachment",
+        transit_gateway_id=transit_gateway.attr_id,
+        vpc_id=networking.vpc.vpc_id,
+        subnet_ids=[subnet.subnet_id for subnet in networking.vpc.private_subnets],
+    )
+
+    # Retrieve the IKE pre-shared key from Secrets Manager. Resolved by
+    # CloudFormation at deploy time so it never appears in the template.
+    noaa_vpn_psk = (
+        secretsmanager.Secret.from_secret_name_v2(
+            networking_stack, "NoaaVpnPsk", "/ialirt/noaa/noaa-vpn-psk"
+        )
+        .secret_value_from_json("psk")
+        .unsafe_unwrap()
+    )
+
+    # Retrieve NOAA border router IPs from SSM. These are the public IPs
+    # of NOAA's N-Wave routers at WASH (McLean, VA) and DENV (Denver, CO).
+    noaa_wash_ip = ssm.StringParameter.value_for_string_parameter(
+        networking_stack, "/ialirt/noaa-vpn/wash-ip"
+    )
+    noaa_denv_ip = ssm.StringParameter.value_for_string_parameter(
+        networking_stack, "/ialirt/noaa-vpn/denv-ip"
+    )
+
+    # Create the IPSec VPN tunnel to NOAA N-Wave. Provisions two VPN
+    # connections (WASH + DENV) with BGP routing for automatic failover.
+    ialirt_vpn = ialirt_vpn_construct.IalirtVpnConstruct(
+        scope=networking_stack,
+        construct_id="IalirtVpn",
+        transit_gateway_id=transit_gateway.attr_id,
+        psk=noaa_vpn_psk,
+        wash_ip=noaa_wash_ip,
+        denv_ip=noaa_denv_ip,
+    )
+
+    # Create a TGW route table.
+    tgw_route_table = ec2.CfnTransitGatewayRouteTable(
+        networking_stack,
+        "TransitGatewayRouteTable",
+        transit_gateway_id=transit_gateway.attr_id,
+    )
+
+    # VPC's connection to the Transit Gateway will use our route table
+    # to look up where to send traffic.
+    ec2.CfnTransitGatewayRouteTableAssociation(
+        networking_stack,
+        "TgwRouteTableAssociationVpc",
+        transit_gateway_attachment_id=vpc_attachment.attr_id,
+        transit_gateway_route_table_id=tgw_route_table.attr_transit_gateway_route_table_id,
+    )
+
+    # Add the SMCE VPC's address range (10.0.0.0/16) to our route table, so
+    # any other attachment using this table (e.g. the NOAA VPN connections)
+    # can route traffic destined for the VPC here.
+    ec2.CfnTransitGatewayRouteTablePropagation(
+        networking_stack,
+        "TgwRouteTablePropagationVpc",
+        transit_gateway_attachment_id=vpc_attachment.attr_id,
+        transit_gateway_route_table_id=tgw_route_table.attr_transit_gateway_route_table_id,
+    )
+
+    # AWS::EC2::VPNConnection does not expose its Transit Gateway attachment
+    # ID as a CloudFormation attribute, so look it up via a custom resource
+    # that calls ec2:DescribeTransitGatewayAttachments, filtered to the VPN
+    # connection's resource ID.
+    for site, vpn_connection in ialirt_vpn.vpn_connections.items():
+        describe_vpn_attachment = cr.AwsSdkCall(
+            service="EC2",
+            action="describeTransitGatewayAttachments",
+            parameters={
+                "Filters": [
+                    {
+                        "Name": "resource-id",
+                        "Values": [vpn_connection.attr_vpn_connection_id],
+                    },
+                    {"Name": "resource-type", "Values": ["vpn"]},
+                ]
+            },
+            physical_resource_id=cr.PhysicalResourceId.of(
+                f"VpnTgwAttachmentLookup{site}"
+            ),
+        )
+        vpn_attachment_lookup = cr.AwsCustomResource(
+            networking_stack,
+            f"VpnTgwAttachmentLookup{site}",
+            on_create=describe_vpn_attachment,
+            on_update=describe_vpn_attachment,
+            policy=cr.AwsCustomResourcePolicy.from_sdk_calls(
+                resources=cr.AwsCustomResourcePolicy.ANY_RESOURCE
+            ),
+        )
+        vpn_attachment_id = vpn_attachment_lookup.get_response_field(
+            "TransitGatewayAttachments.0.TransitGatewayAttachmentId"
+        )
+
+        # Add the transit gateway attachments to the route table.
+
+        # Use this table to decide where to forward the traffic you receive.
+        ec2.CfnTransitGatewayRouteTableAssociation(
+            networking_stack,
+            f"TgwRouteTableAssociationVpn{site}",
+            transit_gateway_attachment_id=vpn_attachment_id,
+            transit_gateway_route_table_id=tgw_route_table.attr_transit_gateway_route_table_id,
+        )
+        # Installs NOAA's routes into the table so the VPC attachment
+        # can find its way back to NOAA on the return path.
+        ec2.CfnTransitGatewayRouteTablePropagation(
+            networking_stack,
+            f"TgwRouteTablePropagationVpn{site}",
+            transit_gateway_attachment_id=vpn_attachment_id,
+            transit_gateway_route_table_id=tgw_route_table.attr_transit_gateway_route_table_id,
+        )
+
+    # Static route: send traffic for I-ALiRT EC2's Elastic IP
+    # into the SMCE VPC attachment, where the NAT Gateway forwards it to the
+    # public internet.
+    ec2.CfnTransitGatewayRoute(
+        networking_stack,
+        "TgwDefaultRouteToVpc",
+        destination_cidr_block="0.0.0.0/0",
+        transit_gateway_route_table_id=tgw_route_table.attr_transit_gateway_route_table_id,
+        transit_gateway_attachment_id=vpc_attachment.attr_id,
+    )
 
 
 def build_backup(scope: App, env: Environment, source_account: str):

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -513,8 +513,8 @@ def build_smce_relay(
 ) -> None:
     """Build the I-ALiRT SMCE relay account infrastructure.
 
-    Provisions a VPN tunnel to NOAA N-Wave and VPC peering to the SDS
-    account so NOAA telemetry flows directly over the AWS backbone.
+    Provisions a VPN tunnel to NOAA N-Wave and routes the decrypted
+    traffic through a NAT Gateway to the SDS account's Elastic IP.
 
     Parameters
     ----------
@@ -579,7 +579,7 @@ def build_smce_relay(
             networking_stack, "NoaaVpnPsk", "/ialirt/noaa/noaa-vpn-psk"
         )
         .secret_value_from_json("psk")
-        .unsafe_unwrap()
+        .to_string()
     )
 
     # Retrieve NOAA border router IPs from SSM. These are the public IPs

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -591,6 +591,12 @@ def build_smce_relay(
         networking_stack, "/ialirt/noaa-vpn/denv-ip"
     )
 
+    # Retrieve NOAA's BGP ASN from SSM. Per the N-Wave ICD (NOAA0550),
+    # this is the same for both WASH and DENV.
+    noaa_bgp_asn = ssm.StringParameter.value_for_string_parameter(
+        networking_stack, "/ialirt/noaa-vpn/bgp-asn"
+    )
+
     # Create the IPSec VPN tunnel to NOAA N-Wave. Provisions two VPN
     # connections (WASH + DENV) with BGP routing for automatic failover.
     ialirt_vpn = ialirt_vpn_construct.IalirtVpnConstruct(
@@ -600,6 +606,7 @@ def build_smce_relay(
         psk=noaa_vpn_psk,
         wash_ip=noaa_wash_ip,
         denv_ip=noaa_denv_ip,
+        noaa_asn=noaa_bgp_asn,
     )
 
     # Create a TGW route table.


### PR DESCRIPTION
# Change Summary

## Overview

Added:
- Site-to-Site VPN - NOAA (external) → Transit Gateway. How NOAA's traffic enters AWS.
- Transit Gateway — terminates the Site-to-Site VPN connections and routes decrypted NOAA traffic to the SMCE VPC attachment.
- NAT Gateway - SMCE VPC → SDS EIP. After VPN termination and TGW routing; the NAT Gateway rewrites the source to a stable EIP.

## File changes
- stackbuilder.py
   - Created build_smce_relay: provisions a Transit Gateway and Site-to-Site VPN connections to NOAA (WASH + DENV)
   - Created a TGW route table and wired up routing,
- app.py
   - Add account deployment info
 - ialirt_vpn_construct.py
    - Customer Gateway - registers NOAA's border router (IP + ASN) in AWS, one per site (WASH + DENV)
    - VPN Connection - creates the IPSec tunnel to NOAA's border router, attached to the Transit Gateway
    - Two tunnels per connection - AWS automatically provisions two tunnels per VPN connection for redundancy (×4 endpoint IPs total across WASH + DENV)
    - This results in two VPN connections (WASH + DENV), each with BGP enabled — NOAA's advertised routes are then propagated into the TGW route table (in stackbuilder.py) for return-path


## Testing

A test environment was set up to validate the new TGW-based VPN path end-to-end:

1. Launched a small EC2 in the dev account to act as NOAA's border router (strongSwan + BGP via FRR), and registered its public IP as the NOAA Customer Gateway IP.
2. Deployed `SmceNetworkingStack` (this branch) to create the Transit Gateway, VPN connections, and NAT Gateway, then deployed `IalirtStack` and opened the I-ALiRT security group to the NAT Gateway EIP.
3. Brought up the IPsec tunnel and BGP session from the test EC2 to the new VPN connection, and added a return-path route in the SMCE route table pointing back to the test EC2 through the Transit Gateway.
4. From the test EC2, sent test TCP traffic to the I-ALiRT EC2 on port 7564 and confirmed via `tcpdump` that the full SYN/SYN-ACK/ACK + payload arrived.

**Result:** PASSED — full path verified: strongSwan EC2 → IPsec tunnel (BGP) → Transit Gateway → SMCE NAT Gateway → internet → I-ALiRT EC2.

## Notes
  1. Populate SSM parameters in the SMCE account (before deployment):
       /ialirt/noaa-vpn/wash-ip
       /ialirt/noaa-vpn/denv-ip
  
     Populate Secrets Manager in the SMCE account (before deployment):
       /ialirt/noaa/noaa-vpn-psk

  2. Deploy SMCE stack:
     cdk deploy SmceNetworkingStack --context account_name=smce

  3. Retrieve the NAT Gateway EIP from the AWS console (make certain security group is open to this gateway):
     VPC → NAT Gateways → select the SMCE NAT Gateway → Elastic IP address

  4. Deploy IalirtStack:
     cdk deploy IalirtStack --context account_name=dev

## To give NOAA:
  1. LASP IKE Gateway IPs (x4 total - 2 tunnels, WASH + DENV) — pulled from AWS after deploying the SMCE stack
  2. LASP ASN — the Transit Gateway's BGP ASN
  3. SDS EIP - destination IP NOAA sends traffic to
  4. Port - TCP 7565

## Flow
  **Step 1**: NOAA sends data
  - Source IP: NOAA's internal private IP (Wallops/Suitland)
  - Destination IP: SDS EIP

  **Step 2**: NOAA's border router encrypts the packet
  - Router rule: traffic destined for SDS EIP goes through the VPN tunnel
  - Outer envelope: Source=NOAA border router public IP (WASH or DENV), Dest=one of the LASP IKE Gateways (the AWS Site-to-Site VPN connection's two tunnel endpoint IPs — NOAA's router is
  configured with both for redundancy, but each packet goes to one)

  **Step 3**: Travels across public internet (encrypted)

  **Step 4:** AWS Site-to-Site VPN connection (attached to Transit Gateway, SMCE account) decrypts
  - Outer envelope discarded, inner packet restored: Source=NOAA private IP, Dest=SDS EIP
  - Decrypted packet handed to transit gateway

  **Step 5**: Transit Gateway route table directs the packet to the SMCE VPC attachment

  **Step 6**: SMCE VPC route table directs to NAT Gateway

  **Step 7**: SMCE NAT Gateway performs SNAT
  - Rewrites source: NOAA private IP → SMCE NAT GW EIP
  - Forwards packet to public internet: Source=SMCE NAT GW EIP, Dest=SDS EIP

  **Step 8**: Travels across public internet 

  **Step 9**: SDS Internet Gateway performs DNAT
  - Dest=SDS EIP → private IP of I-ALiRT ECS host

  **Step 10**: Container receives packet

## Diagram showing the transit gateway.
<img width="354" height="636" alt="Screenshot 2026-06-11 at 4 45 04 PM" src="https://github.com/user-attachments/assets/d527b798-72fe-4e35-a95d-9ccc4c987b29" />

