### PR TITLE
Dagster output list in dependency yaml config files

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_codice_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_codice_dependencies.yaml
@@ -6,234 +6,367 @@
 
 # ====== Common Data Dependencies ======
 lo_l3a_dist_common: &lo_l3a_dist_common
-  - upstream_source: codice
-    upstream_data_type: l3a
-    upstream_descriptor: lo-direct-events
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-sw-priority
-    kickoff_job: false
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-nsw-priority
-    kickoff_job: false
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: lo-mass-species-bin-lookup
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-lo-gfactor
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: lo-energy-per-charge
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-lo-efficiency
+  - source: codice
+    data_type: l3a
+    descriptor: lo-direct-events
+  - source: codice
+    data_type: l1a
+    descriptor: lo-sw-priority
+    trigger_job: false
+  - source: codice
+    data_type: l1a
+    descriptor: lo-nsw-priority
+    trigger_job: false
+  - source: codice
+    data_type: ancillary
+    descriptor: lo-mass-species-bin-lookup
+  - source: codice
+    data_type: ancillary
+    descriptor: l2-lo-gfactor
+  - source: codice
+    data_type: ancillary
+    descriptor: lo-energy-per-charge
+  - source: codice
+    data_type: ancillary
+    descriptor: l2-lo-efficiency
 
 # ====== Specific Product Dependencies ======
 (l1a, all):
-  - upstream_source: codice
-    upstream_data_type: l0
-    upstream_descriptor: raw
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l1a-sci-lut
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: codice
+      data_type: l0
+      descriptor: raw
+    - source: codice
+      data_type: ancillary
+      descriptor: l1a-sci-lut
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: codice
+      data_type: l1a
+      descriptor: hi-counters-aggregated
+    - source: codice
+      data_type: l1a
+      descriptor: hi-counters-singles
+    - source: codice
+      data_type: l1a
+      descriptor: hi-omni
+    - source: codice
+      data_type: l1a
+      descriptor: hi-priority
+    - source: codice
+      data_type: l1a
+      descriptor: hi-sectored
+    - source: codice
+      data_type: l1a
+      descriptor: lo-counters-aggregated
+    - source: codice
+      data_type: l1a
+      descriptor: lo-counters-singles
+    - source: codice
+      data_type: l1a
+      descriptor: lo-nsw-priority
+    - source: codice
+      data_type: l1a
+      descriptor: lo-sw-priority
+    - source: codice
+      data_type: l1a
+      descriptor: lo-sw-species
 
 (l1b, hi-counters-aggregated):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: hi-counters-aggregated
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: hi-counters-aggregated
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: hi-counters-aggregated
 
 (l1b, hi-counters-singles):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: hi-counters-singles
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: hi-counters-singles
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: hi-counters-singles
 
 (l1b, hi-omni):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: hi-omni
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: hi-omni
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: hi-omni
 
 (l1b, hi-priority):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: hi-priority
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: hi-priority
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: hi-priority
 
 (l1b, hi-sectored):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: hi-sectored
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: hi-sectored
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: hi-sectored
 
 (l1b, lo-counters-aggregated):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-counters-aggregated
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: lo-counters-aggregated
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: lo-counters-aggregated
 
 (l1b, lo-counters-singles):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-counters-singles
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: lo-counters-singles
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: lo-counters-singles
 
 (l1b, lo-nsw-priority):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-nsw-priority
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: lo-nsw-priority
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: lo-nsw-priority
 
 (l1b, lo-sw-priority):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-sw-priority
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: lo-sw-priority
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: lo-sw-priority
 
 (l1b, lo-sw-species):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-sw-species
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: lo-sw-species
+  outputs:
+    - source: codice
+      data_type: l1b
+      descriptor: lo-sw-species
 
 (l2, hi-direct-events):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: hi-direct-events
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-hi-energy-table
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-hi-tof-table
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: hi-direct-events
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-hi-energy-table
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-hi-tof-table
+  outputs:
+    - source: codice
+      data_type: l2
+      descriptor: hi-direct-events
 
 (l2, hi-omni):
-  - upstream_source: codice
-    upstream_data_type: l1b
-    upstream_descriptor: hi-omni
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-hi-omni-efficiency
-
+  inputs:
+    - source: codice
+      data_type: l1b
+      descriptor: hi-omni
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-hi-omni-efficiency
+  outputs:
+    - source: codice
+      data_type: l2
+      descriptor: hi-omni
 
 (l2, hi-sectored):
-  - upstream_source: codice
-    upstream_data_type: l1b
-    upstream_descriptor: hi-sectored
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-hi-sectored-efficiency
-
+  inputs:
+    - source: codice
+      data_type: l1b
+      descriptor: hi-sectored
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-hi-sectored-efficiency
+  outputs:
+    - source: codice
+      data_type: l2
+      descriptor: hi-sectored
 
 (l2, lo-direct-events):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-direct-events
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-lo-onboard-energy-table
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-lo-onboard-energy-bins
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-lo-onboard-mpq-cal
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: lo-direct-events
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-lo-onboard-energy-table
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-lo-onboard-energy-bins
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-lo-onboard-mpq-cal
+  outputs:
+    - source: codice
+      data_type: l2
+      descriptor: lo-direct-events
 
 (l2, lo-sw-species):
-  - upstream_source: codice
-    upstream_data_type: l1b
-    upstream_descriptor: lo-sw-species
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-lo-gfactor
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-lo-efficiency
-
+  inputs:
+    - source: codice
+      data_type: l1b
+      descriptor: lo-sw-species
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-lo-gfactor
+    - source: codice
+      data_type: ancillary
+      descriptor: l2-lo-efficiency
+  outputs:
+    - source: codice
+      data_type: l2
+      descriptor: lo-sw-species
 
 (l3a, hi-direct-events):
-  - upstream_source: codice
-    upstream_data_type: l2
-    upstream_descriptor: hi-direct-events
-
+  inputs:
+    - source: codice
+      data_type: l2
+      descriptor: hi-direct-events
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: hi-direct-events
 
 (l3a, lo-direct-events):
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-sw-priority
-  - upstream_source: codice
-    upstream_data_type: l1a
-    upstream_descriptor: lo-nsw-priority
-  - upstream_source: codice
-    upstream_data_type: l2
-    upstream_descriptor: lo-direct-events
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: lo-energy-per-charge
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: mass-coefficient-lookup
-
+  inputs:
+    - source: codice
+      data_type: l1a
+      descriptor: lo-sw-priority
+    - source: codice
+      data_type: l1a
+      descriptor: lo-nsw-priority
+    - source: codice
+      data_type: l2
+      descriptor: lo-direct-events
+    - source: codice
+      data_type: ancillary
+      descriptor: lo-energy-per-charge
+    - source: codice
+      data_type: ancillary
+      descriptor: mass-coefficient-lookup
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-direct-events
 
 (l3a, lo-heplus-3d-distribution):
-  - *lo_l3a_dist_common
-
+  inputs:
+    - *lo_l3a_dist_common
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-heplus-3d-distribution
 
 (l3a, lo-heplusplus-3d-distribution):
-  - *lo_l3a_dist_common
-
+  inputs:
+    - *lo_l3a_dist_common
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-heplusplus-3d-distribution
 
 (l3a, lo-hplus-3d-distribution):
-  - *lo_l3a_dist_common
-
+  inputs:
+    - *lo_l3a_dist_common
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-hplus-3d-distribution
 
 (l3a, lo-oplus6-3d-distribution):
-  - *lo_l3a_dist_common
-
+  inputs:
+    - *lo_l3a_dist_common
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-oplus6-3d-distribution
 
 (l3a, lo-partial-densities):
-  - upstream_source: codice
-    upstream_data_type: l2
-    upstream_descriptor: lo-sw-species
-  - upstream_source: codice
-    upstream_data_type: ancillary
-    upstream_descriptor: mass-per-charge
-
+  inputs:
+    - source: codice
+      data_type: l2
+      descriptor: lo-sw-species
+    - source: codice
+      data_type: ancillary
+      descriptor: mass-per-charge
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-partial-densities
 
 (l3a, lo-sw-charge-state-distributions):
-  - upstream_source: codice
-    upstream_data_type: l3a
-    upstream_descriptor: lo-partial-densities
-
+  inputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-partial-densities
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-sw-charge-state-distributions
 
 (l3a, lo-sw-ratios):
-  - upstream_source: codice
-    upstream_data_type: l3a
-    upstream_descriptor: lo-partial-densities
-
+  inputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-partial-densities
+  outputs:
+    - source: codice
+      data_type: l3a
+      descriptor: lo-sw-ratios
 
 (l3b, hi-pitch-angle):
-  - upstream_source: mag
-    upstream_data_type: l1d
-    upstream_descriptor: norm-dsrf
-  - upstream_source: mag
-    upstream_data_type: l2
-    upstream_descriptor: norm-dsrf
-    kickoff_job: false
-  - upstream_source: codice
-    upstream_data_type: l2
-    upstream_descriptor: hi-sectored
+  inputs:
+    - source: mag
+      data_type: l1d
+      descriptor: norm-dsrf
+    - source: mag
+      data_type: l2
+      descriptor: norm-dsrf
+      trigger_job: false
+    - source: codice
+      data_type: l2
+      descriptor: hi-sectored
+  outputs:
+    - source: codice
+      data_type: l3b
+      descriptor: hi-pitch-angle
+

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_glows_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_glows_dependencies.yaml
@@ -5,115 +5,136 @@
 # and how to properly configure them for your pipeline lambdas.
 # ===== Common dependencies ===========
 pipline_settings: &pipeline_settings
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: pipeline-settings
+  - source: glows
+    data_type: ancillary
+    descriptor: pipeline-settings
 
 spice_basics: &spice_basics
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 hist_spice: &hist_spice
   - *spice_basics
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: imap_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: pointing_attitude
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 # ======== Product-specific dependencies ===========
 (l1a, all):
-  - *spice_basics
-  - upstream_source: glows
-    upstream_data_type: l0
-    upstream_descriptor: raw
-
+  inputs:
+    - *spice_basics
+    - source: glows
+      data_type: l0
+      descriptor: raw
+  outputs:
+    - source: glows
+      data_type: l1a
+      descriptor: de
+    - source: glows
+      data_type: l1a
+      descriptor: hist
 
 (l1b, de):
-  - upstream_source: glows
-    upstream_data_type: l1a
-    upstream_descriptor: de
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-conversion-table-for-anc-data
-
+  inputs:
+    - source: glows
+      data_type: l1a
+      descriptor: de
+    - source: glows
+      data_type: ancillary
+      descriptor: l1b-conversion-table-for-anc-data
+  outputs:
+    - source: glows
+      data_type: l1b
+      descriptor: de
 
 (l1b, hist):
-  - *pipeline_settings
-  - *hist_spice
-  - upstream_source: glows
-    upstream_data_type: l1a
-    upstream_descriptor: hist
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-exclusions-by-instr-team
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-map-of-excluded-regions
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-map-of-uv-sources
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-suspected-transients
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-conversion-table-for-anc-data
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - *pipeline_settings
+    - *hist_spice
+    - source: glows
+      data_type: l1a
+      descriptor: hist
+    - source: spin
+      data_type: spin
+      descriptor: historical
+    - source: glows
+      data_type: ancillary
+      descriptor: l1b-exclusions-by-instr-team
+    - source: glows
+      data_type: ancillary
+      descriptor: l1b-map-of-excluded-regions
+    - source: glows
+      data_type: ancillary
+      descriptor: l1b-map-of-uv-sources
+    - source: glows
+      data_type: ancillary
+      descriptor: l1b-suspected-transients
+    - source: glows
+      data_type: ancillary
+      descriptor: l1b-conversion-table-for-anc-data
+    - source: attitude_history
+      data_type: spice
+      descriptor: historical
+    - source: ephemeris_reconstructed
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_ephemeris
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: glows
+      data_type: l1b
+      descriptor: hist
 
 (l2, hist):
-  - *pipeline_settings
-  - *hist_spice
-  - upstream_source: glows
-    upstream_data_type: l1b
-    upstream_descriptor: hist
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-calibration
-
+  inputs:
+    - *pipeline_settings
+    - *hist_spice
+    - source: glows
+      data_type: l1b
+      descriptor: hist
+    - source: glows
+      data_type: ancillary
+      descriptor: l2-calibration
+  outputs:
+    - source: glows
+      data_type: l2
+      descriptor: hist
 
 (l3a, hist):
-  - *pipeline_settings
-  - upstream_source: glows
-    upstream_data_type: l2
-    upstream_descriptor: hist
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-calibration
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l3-time-dep-bckgrd
-  - upstream_source: glows
-    upstream_data_type: ancillary
-    upstream_descriptor: l3-map-of-extra-helio-bckgrd
+  inputs:
+    - *pipeline_settings
+    - source: glows
+      data_type: l2
+      descriptor: hist
+    - source: glows
+      data_type: ancillary
+      descriptor: l2-calibration
+    - source: glows
+      data_type: ancillary
+      descriptor: l3-time-dep-bckgrd
+    - source: glows
+      data_type: ancillary
+      descriptor: l3-map-of-extra-helio-bckgrd
+  outputs:
+    - source: glows
+      data_type: l3a
+      descriptor: hist
+

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_hi_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_hi_dependencies.yaml
@@ -7,551 +7,943 @@
 # ========= Common Dependency Groups =========
 # Common dependencies shared by multiple products
 spice_basic: &spice_basic
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 spice_common: &spice_common
   - *spice_basic
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: best
-    kickoff_job: false
-  - upstream_source: ephemeris_90days
-    upstream_data_type: spice
-    upstream_descriptor: best
-    kickoff_job: false
+  - source: imap_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: planetary_ephemeris
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: attitude_history
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_reconstructed
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_predicted
+    data_type: spice
+    descriptor: best
+    trigger_job: false
+  - source: ephemeris_90days
+    data_type: spice
+    descriptor: best
+    trigger_job: false
 
 # ----- Sub section of common dependencies for data level ----
 # common SPICE dependencies
 spice_l1b: &spice_l1b
   - *spice_common
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: spin
+    data_type: spin
+    descriptor: historical
+    trigger_job: false
 
 spice_l1c: &spice_l1c
   - *spice_common
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: pointing_attitude
+    data_type: spice
+    descriptor: historical
+  - source: repoint
+    data_type: repoint
+    descriptor: historical
+    trigger_job: false
+  - source: spin
+    data_type: spin
+    descriptor: historical
+    trigger_job: false
 
 
 spice_l2: &spice_l2
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: planetary_ephemeris
+    data_type: spice
+    descriptor: historical
+  - source: ephemeris_reconstructed
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_predicted
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 # common ancillary dependencies
 ancillary_45sensor_l2: &ancillary_45sensor_l2
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 45sensor-cal-prod
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 45sensor-esa-energies
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 45sensor-esa-eta-fit-factors
+  - source: hi
+    data_type: ancillary
+    descriptor: 45sensor-cal-prod
+  - source: hi
+    data_type: ancillary
+    descriptor: 45sensor-esa-energies
+  - source: hi
+    data_type: ancillary
+    descriptor: 45sensor-esa-eta-fit-factors
 
 ancillary_90sensor_l2: &ancillary_90sensor_l2
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 90sensor-cal-prod
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 90sensor-esa-energies
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 90sensor-esa-eta-fit-factors
+  - source: hi
+    data_type: ancillary
+    descriptor: 90sensor-cal-prod
+  - source: hi
+    data_type: ancillary
+    descriptor: 90sensor-esa-energies
+  - source: hi
+    data_type: ancillary
+    descriptor: 90sensor-esa-eta-fit-factors
 
 # common science dependencies
 l0_data: &l0_data
-  - upstream_source: hi
-    upstream_data_type: l0
-    upstream_descriptor: raw
+  - source: hi
+    data_type: l0
+    descriptor: raw
 
 sensor45_l1c_pset: &sensor45_l1c_pset
-  - upstream_source: hi
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-pset
+  - source: hi
+    data_type: l1c
+    descriptor: 45sensor-pset
 
 sensor90_l1c_pset: &sensor90_l1c_pset
-  - upstream_source: hi
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-pset
+  - source: hi
+    data_type: l1c
+    descriptor: 90sensor-pset
 
 # ======== Product-Specific Dependencies ========
 (l1a, all):
-  - *spice_basic
-  - *l0_data
+  inputs:
+    - *spice_basic
+    - *l0_data
+  outputs:
+    - source: hi
+      data_type: l1a
+      descriptor: 45sensor-de
+    - source: hi
+      data_type: l1a
+      descriptor: 90sensor-de
+    - source: hi
+      data_type: l1a
+      descriptor: 45sensor-diagfee
+    - source: hi
+      data_type: l1a
+      descriptor: 90sensor-diagfee
+    - source: hi
+      data_type: l1a
+      descriptor: 45sensor-hist
+    - source: hi
+      data_type: l1a
+      descriptor: 90sensor-hist
+    - source: hi
+      data_type: l1a
+      descriptor: 45sensor-hk
+    - source: hi
+      data_type: l1a
+      descriptor: 90sensor-hk
+    - source: hi
+      data_type: l1a
+      descriptor: 45sensor-memdmp
+    - source: hi
+      data_type: l1a
+      descriptor: 90sensor-memdmp
 
 (l1b, hk):
-  - *spice_basic
-  - *l0_data
+  inputs:
+    - *spice_basic
+    - *l0_data
+  outputs:
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-hk
+    - source: hi
+      data_type: l1b
+      descriptor: 90sensor-hk
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-de
+    - source: hi
+      data_type: l1b
+      descriptor: 90sensor-de
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-goodtimes
+    - source: hi
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
 
 (l1b, 45sensor-de):
-  - *spice_l1b
-  - upstream_source: hi
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-de
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-hk
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 45sensor-esa-energies
+  inputs:
+    - *spice_l1b
+    - source: hi
+      data_type: l1a
+      descriptor: 45sensor-de
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-hk
+    - source: hi
+      data_type: ancillary
+      descriptor: 45sensor-esa-energies
+  outputs:
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-de
 
 (l1b, 45sensor-goodtimes):
-  - *spice_basic
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 45sensor-cal-prod
-  - upstream_source: hi
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-diagfee
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-de
-    date_range: ["6np",]
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-hk
+  inputs:
+    - *spice_basic
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+      trigger_job: false
+    - source: hi
+      data_type: ancillary
+      descriptor: 45sensor-cal-prod
+    - source: hi
+      data_type: l1a
+      descriptor: 45sensor-diagfee
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-de
+      date_range: ["6np",]
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-hk
+  outputs:
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-goodtimes
 
 (l1c, 45sensor-pset):
-  - *spice_l1c
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 45sensor-cal-prod
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 45sensor-backgrounds
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-de
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-goodtimes
+  inputs:
+    - *spice_l1c
+    - source: hi
+      data_type: ancillary
+      descriptor: 45sensor-cal-prod
+    - source: hi
+      data_type: ancillary
+      descriptor: 45sensor-backgrounds
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-de
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-goodtimes
+  outputs:
+    - source: hi
+      data_type: l1c
+      descriptor: 45sensor-pset
 
 (l1b, 90sensor-de):
-  - *spice_l1b
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 90sensor-esa-energies
-  - upstream_source: hi
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-de
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-hk
+  inputs:
+    - *spice_l1b
+    - source: hi
+      data_type: ancillary
+      descriptor: 90sensor-esa-energies
+    - source: hi
+      data_type: l1a
+      descriptor: 90sensor-de
+    - source: hi
+      data_type: l1b
+      descriptor: 90sensor-hk
+  outputs:
+    - source: hi
+      data_type: l1b
+      descriptor: 90sensor-de
 
 (l1c, 90sensor-pset):
-  - *spice_l1c
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 90sensor-cal-prod
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 90sensor-backgrounds
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-de
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-goodtimes
+  inputs:
+    - *spice_l1c
+    - source: hi
+      data_type: ancillary
+      descriptor: 90sensor-cal-prod
+    - source: hi
+      data_type: ancillary
+      descriptor: 90sensor-backgrounds
+    - source: hi
+      data_type: l1b
+      descriptor: 90sensor-de
+    - source: hi
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
+  outputs:
+    - source: hi
+      data_type: l1c
+      descriptor: 90sensor-pset
 
 (l1b, 90sensor-goodtimes):
-  - *spice_basic
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: hi
-    upstream_data_type: ancillary
-    upstream_descriptor: 45sensor-cal-prod
-  - upstream_source: hi
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-diagfee
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-de
-    date_range: ["6np",]
-  - upstream_source: hi
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-hk
+  inputs:
+    - *spice_basic
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+      trigger_job: false
+    - source: hi
+      data_type: ancillary
+      descriptor: 45sensor-cal-prod
+    - source: hi
+      data_type: l1a
+      descriptor: 45sensor-diagfee
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-de
+      date_range: ["6np",]
+    - source: hi
+      data_type: l1b
+      descriptor: 45sensor-hk
 
 # L2 Products - 45sensor
+  outputs:
+    - source: hi
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
 
 (l2, h45-ena-h-hf-nsp-anti-hae-4deg-1yr):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-anti-hae-4deg-1yr
 
 (l2, h45-ena-h-hf-nsp-anti-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-anti-hae-4deg-6mo
 
 (l2, h45-ena-h-hf-nsp-anti-hae-6deg-1yr):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-anti-hae-6deg-1yr
 
 (l2, h45-ena-h-hf-nsp-anti-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-anti-hae-6deg-6mo
 
 (l2, h45-ena-h-hf-nsp-full-hae-4deg-3mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-full-hae-4deg-3mo
 
 (l2, h45-ena-h-hf-nsp-full-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-full-hae-4deg-6mo
 
 (l2, h45-ena-h-hf-nsp-full-hae-6deg-3mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-full-hae-6deg-3mo
 
 (l2, h45-ena-h-hf-nsp-full-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-full-hae-6deg-6mo
 
 (l2, h45-ena-h-hf-nsp-ram-hae-4deg-1yr):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-ram-hae-4deg-1yr
 
 (l2, h45-ena-h-hf-nsp-ram-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-ram-hae-4deg-6mo
 
 (l2, h45-ena-h-hf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-ram-hae-6deg-1yr
 
 (l2, h45-ena-h-hf-nsp-ram-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-hf-nsp-ram-hae-6deg-6mo
 
 (l2, h45-ena-h-sf-nsp-anti-hae-4deg-1yr):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
-
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-anti-hae-4deg-1yr
 
 (l2, h45-ena-h-sf-nsp-anti-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-anti-hae-4deg-6mo
 
 (l2, h45-ena-h-sf-nsp-anti-hae-6deg-1yr):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-anti-hae-6deg-1yr
 
 (l2, h45-ena-h-sf-nsp-anti-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-anti-hae-6deg-6mo
 
 (l2, h45-ena-h-sf-nsp-full-hae-4deg-3mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-full-hae-4deg-3mo
 
 (l2, h45-ena-h-sf-nsp-full-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-full-hae-4deg-6mo
 
 (l2, h45-ena-h-sf-nsp-full-hae-6deg-3mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-full-hae-6deg-3mo
 
 (l2, h45-ena-h-sf-nsp-full-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-full-hae-6deg-6mo
 
 (l2, h45-ena-h-sf-nsp-ram-hae-4deg-1yr):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-ram-hae-4deg-1yr
 
 (l2, h45-ena-h-sf-nsp-ram-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-ram-hae-4deg-6mo
 
 (l2, h45-ena-h-sf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-ram-hae-6deg-1yr
 
 (l2, h45-ena-h-sf-nsp-ram-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_45sensor_l2
-  - *sensor45_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_45sensor_l2
+    - *sensor45_l1c_pset
 
 
 # L2 Products - 90sensor
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h45-ena-h-sf-nsp-ram-hae-6deg-6mo
 
 (l2, h90-ena-h-hf-nsp-anti-hae-4deg-1yr):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-anti-hae-4deg-1yr
 
 (l2, h90-ena-h-hf-nsp-anti-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-anti-hae-4deg-6mo
 
 (l2, h90-ena-h-hf-nsp-anti-hae-6deg-1yr):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-anti-hae-6deg-1yr
 
 (l2, h90-ena-h-hf-nsp-anti-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-anti-hae-6deg-6mo
 
 (l2, h90-ena-h-hf-nsp-full-hae-4deg-3mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-full-hae-4deg-3mo
 
 (l2, h90-ena-h-hf-nsp-full-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-full-hae-4deg-6mo
 
 (l2, h90-ena-h-hf-nsp-full-hae-6deg-3mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-full-hae-6deg-3mo
 
 (l2, h90-ena-h-hf-nsp-full-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-full-hae-6deg-6mo
 
 (l2, h90-ena-h-hf-nsp-ram-hae-4deg-1yr):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-ram-hae-4deg-1yr
 
 (l2, h90-ena-h-hf-nsp-ram-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-ram-hae-4deg-6mo
 
 (l2, h90-ena-h-hf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-ram-hae-6deg-1yr
 
 (l2, h90-ena-h-hf-nsp-ram-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-hf-nsp-ram-hae-6deg-6mo
 
 (l2, h90-ena-h-sf-nsp-anti-hae-4deg-1yr):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-anti-hae-4deg-1yr
 
 (l2, h90-ena-h-sf-nsp-anti-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-anti-hae-4deg-6mo
 
 (l2, h90-ena-h-sf-nsp-anti-hae-6deg-1yr):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-anti-hae-6deg-1yr
 
 (l2, h90-ena-h-sf-nsp-anti-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-anti-hae-6deg-6mo
 
 (l2, h90-ena-h-sf-nsp-full-hae-4deg-3mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-full-hae-4deg-3mo
 
 (l2, h90-ena-h-sf-nsp-full-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-full-hae-4deg-6mo
 
 (l2, h90-ena-h-sf-nsp-full-hae-6deg-3mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-full-hae-6deg-3mo
 
 (l2, h90-ena-h-sf-nsp-full-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-full-hae-6deg-6mo
 
 (l2, h90-ena-h-sf-nsp-ram-hae-4deg-1yr):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-ram-hae-4deg-1yr
 
 (l2, h90-ena-h-sf-nsp-ram-hae-4deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-ram-hae-4deg-6mo
 
 (l2, h90-ena-h-sf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-ram-hae-6deg-1yr
 
 (l2, h90-ena-h-sf-nsp-ram-hae-6deg-6mo):
-  - *spice_l2
-  - *ancillary_90sensor_l2
-  - *sensor90_l1c_pset
+  inputs:
+    - *spice_l2
+    - *ancillary_90sensor_l2
+    - *sensor90_l1c_pset
 
 # L3 Products - 45sensor
+  outputs:
+    - source: hi
+      data_type: l2
+      descriptor: h90-ena-h-sf-nsp-ram-hae-6deg-6mo
 
 (l3, h45-spx-h-hf-sp-anti-hae-4deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h45-ena-h-hf-sp-anti-hae-4deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-anti-hae-4deg-1yr
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-spx-h-hf-sp-anti-hae-4deg-1yr
 
 (l3, h45-spx-h-hf-sp-anti-hae-6deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h45-ena-h-hf-sp-anti-hae-6deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-anti-hae-6deg-1yr
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-spx-h-hf-sp-anti-hae-6deg-1yr
 
 (l3, h45-spx-h-hf-sp-full-hae-4deg-6mo):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h45-ena-h-hf-sp-full-hae-4deg-6mo
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-full-hae-4deg-6mo
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-spx-h-hf-sp-full-hae-4deg-6mo
 
 (l3, h45-spx-h-hf-sp-full-hae-6deg-6mo):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h45-ena-h-hf-sp-full-hae-6deg-6mo
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-full-hae-6deg-6mo
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-spx-h-hf-sp-full-hae-6deg-6mo
 
 (l3, h45-spx-h-hf-sp-ram-hae-4deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h45-ena-h-hf-sp-ram-hae-4deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-ram-hae-4deg-1yr
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-spx-h-hf-sp-ram-hae-4deg-1yr
 
 (l3, h45-spx-h-hf-sp-ram-hae-6deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h45-ena-h-hf-sp-ram-hae-6deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-ram-hae-6deg-1yr
 
 # L3 Products - Spectral Index - 90sensor
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h45-spx-h-hf-sp-ram-hae-6deg-1yr
 
 (l3, h90-spx-h-hf-sp-anti-hae-4deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h90-ena-h-hf-sp-anti-hae-4deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-anti-hae-4deg-1yr
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-spx-h-hf-sp-anti-hae-4deg-1yr
 
 (l3, h90-spx-h-hf-sp-anti-hae-6deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h90-ena-h-hf-sp-anti-hae-6deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-anti-hae-6deg-1yr
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-spx-h-hf-sp-anti-hae-6deg-1yr
 
 (l3, h90-spx-h-hf-sp-full-hae-4deg-6mo):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h90-ena-h-hf-sp-full-hae-4deg-6mo
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-full-hae-4deg-6mo
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-spx-h-hf-sp-full-hae-4deg-6mo
 
 (l3, h90-spx-h-hf-sp-full-hae-6deg-6mo):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h90-ena-h-hf-sp-full-hae-6deg-6mo
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-full-hae-6deg-6mo
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-spx-h-hf-sp-full-hae-6deg-6mo
 
 (l3, h90-spx-h-hf-sp-ram-hae-4deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h90-ena-h-hf-sp-ram-hae-4deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-ram-hae-4deg-1yr
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-spx-h-hf-sp-ram-hae-4deg-1yr
 
 (l3, h90-spx-h-hf-sp-ram-hae-6deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: h90-ena-h-hf-sp-ram-hae-6deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-ram-hae-6deg-1yr
 
 # L3 products - hic
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: h90-spx-h-hf-sp-ram-hae-6deg-1yr
 
 (l3, hic-spx-h-hf-sp-full-hae-4deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: hic-ena-h-hf-sp-full-hae-4deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: hic-ena-h-hf-sp-full-hae-4deg-1yr
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: hic-spx-h-hf-sp-full-hae-4deg-1yr
 
 (l3, hic-spx-h-hf-sp-full-hae-6deg-1yr):
-  - upstream_source: hi
-    upstream_data_type: l3
-    upstream_descriptor: hic-ena-h-hf-sp-full-hae-6deg-1yr
+  inputs:
+    - source: hi
+      data_type: l3
+      descriptor: hic-ena-h-hf-sp-full-hae-6deg-1yr
+  outputs:
+    - source: hi
+      data_type: l3
+      descriptor: hic-spx-h-hf-sp-full-hae-6deg-1yr
+

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_hit_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_hit_dependencies.yaml
@@ -6,164 +6,222 @@
 
 # ====== Common dependencies =============
 spice_basics: &spice_basics
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 l0_data: &l0_data
-  - upstream_source: hit
-    upstream_data_type: l0
-    upstream_descriptor: raw
+  - source: hit
+    data_type: l0
+    descriptor: raw
 
 (l1a, all):
-  - *spice_basics
-  - *l0_data
+  inputs:
+    - *spice_basics
+    - *l0_data
+  outputs:
+    - source: hit
+      data_type: l1a
+      descriptor: counts-standard
+    - source: hit
+      data_type: l1a
+      descriptor: counts-sectored
+    - source: hit
+      data_type: l1a
+      descriptor: direct-events
 
 (l1b, hk):
-  - *spice_basics
-  - *l0_data
+  inputs:
+    - *spice_basics
+    - *l0_data
+  outputs:
+    - source: hit
+      data_type: l1b
+      descriptor: hk
 
 (l1a, pha-telemetry-corrected):
-  - upstream_source: hit
-    upstream_data_type: l0
-    upstream_descriptor: pha-telemetry-corrected
+  inputs:
+    - source: hit
+      data_type: l0
+      descriptor: pha-telemetry-corrected
+  outputs:
+    - source: hit
+      data_type: l1a
+      descriptor: counts-standard
+    - source: hit
+      data_type: l1a
+      descriptor: direct-events
 
 (l1b, sectored-rates):
-  - upstream_source: hit
-    upstream_data_type: l1a
-    upstream_descriptor: counts-sectored
-
+  inputs:
+    - source: hit
+      data_type: l1a
+      descriptor: counts-sectored
+  outputs:
+    - source: hit
+      data_type: l1b
+      descriptor: sectored-rates
 
 (l1b, standard-rates):
-  - upstream_source: hit
-    upstream_data_type: l1a
-    upstream_descriptor: counts-standard
-
+  inputs:
+    - source: hit
+      data_type: l1a
+      descriptor: counts-standard
+  outputs:
+    - source: hit
+      data_type: l1b
+      descriptor: standard-rates
 
 (l1b, summed-rates):
-  - upstream_source: hit
-    upstream_data_type: l1a
-    upstream_descriptor: counts-standard
-
+  inputs:
+    - source: hit
+      data_type: l1a
+      descriptor: counts-standard
+  outputs:
+    - source: hit
+      data_type: l1b
+      descriptor: summed-rates
 
 (l2, macropixel-intensity):
-  - upstream_source: hit
-    upstream_data_type: l1b
-    upstream_descriptor: sectored-rates
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-macropixel-dt0-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-macropixel-dt1-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-macropixel-dt2-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-macropixel-dt3-factors
-
+  inputs:
+    - source: hit
+      data_type: l1b
+      descriptor: sectored-rates
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-macropixel-dt0-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-macropixel-dt1-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-macropixel-dt2-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-macropixel-dt3-factors
+  outputs:
+    - source: hit
+      data_type: l2
+      descriptor: macropixel-intensity
 
 (l2, standard-intensity):
-  - upstream_source: hit
-    upstream_data_type: l1b
-    upstream_descriptor: standard-rates
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-standard-dt0-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-standard-dt1-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-standard-dt2-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-standard-dt3-factors
-
+  inputs:
+    - source: hit
+      data_type: l1b
+      descriptor: standard-rates
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-standard-dt0-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-standard-dt1-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-standard-dt2-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-standard-dt3-factors
+  outputs:
+    - source: hit
+      data_type: l2
+      descriptor: standard-intensity
 
 (l2, summed-intensity):
-  - upstream_source: hit
-    upstream_data_type: l1b
-    upstream_descriptor: summed-rates
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-summed-dt0-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-summed-dt1-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-summed-dt2-factors
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-to-l2-summed-dt3-factors
-
+  inputs:
+    - source: hit
+      data_type: l1b
+      descriptor: summed-rates
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-summed-dt0-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-summed-dt1-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-summed-dt2-factors
+    - source: hit
+      data_type: ancillary
+      descriptor: l1b-to-l2-summed-dt3-factors
+  outputs:
+    - source: hit
+      data_type: l2
+      descriptor: summed-intensity
 
 (l3, direct-events):
-  - upstream_source: hit
-    upstream_data_type: l1a
-    upstream_descriptor: direct-events
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-2A-cosine-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-3A-cosine-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-4A-cosine-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-2B-cosine-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-3B-cosine-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-4B-cosine-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: lo-gain-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: hi-gain-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-2A-charge-fit-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-3A-charge-fit-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-4A-charge-fit-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-2B-charge-fit-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-3B-charge-fit-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: range-4B-charge-fit-lookup
-  - upstream_source: hit
-    upstream_data_type: ancillary
-    upstream_descriptor: hit-event-type-lookup
-
+  inputs:
+    - source: hit
+      data_type: l1a
+      descriptor: direct-events
+    - source: hit
+      data_type: ancillary
+      descriptor: range-2A-cosine-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-3A-cosine-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-4A-cosine-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-2B-cosine-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-3B-cosine-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-4B-cosine-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: lo-gain-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: hi-gain-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-2A-charge-fit-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-3A-charge-fit-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-4A-charge-fit-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-2B-charge-fit-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-3B-charge-fit-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: range-4B-charge-fit-lookup
+    - source: hit
+      data_type: ancillary
+      descriptor: hit-event-type-lookup
+  outputs:
+    - source: hit
+      data_type: l3
+      descriptor: direct-events
 
 (l3, macropixel):
-  - upstream_source: hit
-    upstream_data_type: l2
-    upstream_descriptor: macropixel-intensity
-  - upstream_source: mag
-    upstream_data_type: l1d
-    upstream_descriptor: norm-dsrf
-  - upstream_source: mag
-    upstream_data_type: l2
-    upstream_descriptor: norm-dsrf
-    kickoff_job: false
+  inputs:
+    - source: hit
+      data_type: l2
+      descriptor: macropixel-intensity
+    - source: mag
+      data_type: l1d
+      descriptor: norm-dsrf
+    - source: mag
+      data_type: l2
+      descriptor: norm-dsrf
+      trigger_job: false
+  outputs:
+    - source: hit
+      data_type: l3
+      descriptor: macropixel
+

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_idex_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_idex_dependencies.yaml
@@ -6,75 +6,110 @@
 
 # ======= Common dependencies =============
 spice_basics: &spice_basics
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 # ====== IDEX dependencies =============
 
 (l1a, all):
-  - *spice_basics
-  - upstream_source: idex
-    upstream_data_type: l0
-    upstream_descriptor: raw
+  inputs:
+    - *spice_basics
+    - source: idex
+      data_type: l0
+      descriptor: raw
+  outputs:
+    - source: idex
+      data_type: l1a
+      descriptor: sci-1week
+    - source: idex
+      data_type: l1a
+      descriptor: msg
+    - source: idex
+      data_type: l1a
+      descriptor: catlst
+    - source: idex
+      data_type: l1b
+      descriptor: catlst
 
 (l1a, msg):
-  - upstream_source: idex
-    upstream_data_type: l1a
-    upstream_descriptor: msg
+  inputs:
+    - source: idex
+      data_type: l1a
+      descriptor: msg
+  outputs:
+    - source: idex
+      data_type: l1a
+      descriptor: msg
 
 (l1b, sci-1week):
-  - *spice_basics
-  - upstream_source: idex
-    upstream_data_type: l1a
-    upstream_descriptor: sci-1week
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - *spice_basics
+    - source: idex
+      data_type: l1a
+      descriptor: sci-1week
+    - source: spin
+      data_type: spin
+      descriptor: historical
+    - source: ephemeris_reconstructed
+      data_type: spice
+      descriptor: historical
+    - source: ephemeris_predicted
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: attitude_history
+      data_type: spice
+      descriptor: historical
+    - source: planetary_ephemeris
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: imap_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: idex
+      data_type: l1b
+      descriptor: sci-1week
 
 (l2a, sci-1week):
-  - upstream_source: idex
-    upstream_data_type: l1b
-    upstream_descriptor: sci-1week
-  - upstream_source: idex
-    upstream_data_type: ancillary
-    upstream_descriptor: l2a-calibration-curve-yield-params
-  - upstream_source: idex
-    upstream_data_type: ancillary
-    upstream_descriptor: l2a-calibration-curve-t-rise
-
+  inputs:
+    - source: idex
+      data_type: l1b
+      descriptor: sci-1week
+    - source: idex
+      data_type: ancillary
+      descriptor: l2a-calibration-curve-yield-params
+    - source: idex
+      data_type: ancillary
+      descriptor: l2a-calibration-curve-t-rise
+  outputs:
+    - source: idex
+      data_type: l2a
+      descriptor: sci-1week
 
 (l2b, all-1mo):
-  - *spice_basics
-  - upstream_source: idex
-    upstream_data_type: l2a
-    upstream_descriptor: sci-1week
-    kickoff_job: false
-  - upstream_source: idex
-    upstream_data_type: l1b
-    upstream_descriptor: msg
-    kickoff_job: false
+  inputs:
+    - *spice_basics
+    - source: idex
+      data_type: l2a
+      descriptor: sci-1week
+      trigger_job: false
+    - source: idex
+      data_type: l1b
+      descriptor: msg
+      trigger_job: false
+  outputs:
+    - source: idex
+      data_type: l2b
+      descriptor: sci-1mo
+    - source: idex
+      data_type: l2c
+      descriptor: rectangular-map-1mo

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
@@ -7,287 +7,455 @@
 # ========= Common Dependency Groups =========
 # Common spice dependencies shared by multiple products
 spice_basic: &spice_basic
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 spice_common: &spice_common
   - *spice_basic
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: best
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
+  - source: imap_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: planetary_ephemeris
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: attitude_history
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_reconstructed
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_predicted
+    data_type: spice
+    descriptor: best
+    trigger_job: false
+  - source: pointing_attitude
+    data_type: spice
+    descriptor: historical
 
 spice_l2: &spice_l2
   - *spice_basic
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: ephemeris_reconstructed
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_predicted
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: imap_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: planetary_ephemeris
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 lo_90_pset: &lo_90_pset
-  - upstream_source: lo
-    upstream_data_type: l1c
-    upstream_descriptor: pset
-    kickoff_job: false
+  - source: lo
+    data_type: l1c
+    descriptor: pset
+    trigger_job: false
 
 lo_esa_fit_factors: &lo_esa_fit_factors
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: esa-eta-fit-factors
+  - source: lo
+    data_type: ancillary
+    descriptor: esa-eta-fit-factors
 
 # ======== Product-Specific Dependencies ========
 
 # ======== Level L1A ========
 (l1a, all):
-  - upstream_source: lo
-    upstream_data_type: l0
-    upstream_descriptor: raw
-  - *spice_basic
+  inputs:
+    - source: lo
+      data_type: l0
+      descriptor: raw
+    - *spice_basic
+  outputs:
+    - source: lo
+      data_type: l1a
+      descriptor: histogram
+    - source: lo
+      data_type: l1a
+      descriptor: nhk
+    - source: lo
+      data_type: l1a
+      descriptor: shk
+    - source: lo
+      data_type: l1a
+      descriptor: spin
+    - source: lo
+      data_type: l1a
+      descriptor: star
+    - source: lo
+      data_type: l1a
+      descriptor: de
 
 # ======== Level L1B ========
+
 (l1b, all-rates):
-  - *spice_basic
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: sweep-table
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: esa-mode-lut
-  - upstream_source: lo
-    upstream_data_type: l1a
-    upstream_descriptor: histogram
-  - upstream_source: lo
-    upstream_data_type: l1a
-    upstream_descriptor: spin
+  inputs:
+    - *spice_basic
+    - source: spin
+      data_type: spin
+      descriptor: historical
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - source: lo
+      data_type: ancillary
+      descriptor: sweep-table
+    - source: lo
+      data_type: ancillary
+      descriptor: esa-mode-lut
+    - source: lo
+      data_type: l1a
+      descriptor: histogram
+    - source: lo
+      data_type: l1a
+      descriptor: spin
+  outputs:
+    - source: lo
+      data_type: l1b
+      descriptor: histrates
+    - source: lo
+      data_type: l1b
+      descriptor: monitorrates
+    - source: lo
+      data_type: l1b
+      descriptor: instrument-status-summary
+    - source: lo
+      data_type: l1b
+      descriptor: badtimes
+    - source: lo
+      data_type: l1b
+      descriptor: de
+    - source: lo
+      data_type: l1b
+      descriptor: derates
+    - source: lo
+      data_type: l1b
+      descriptor: prostar
+    - source: lo
+      data_type: l1b
+      descriptor: nhk
+    - source: lo
+      data_type: l1b
+      descriptor: shk
+    - source: lo
+      data_type: l1b
+      descriptor: goodtimes
+    - source: lo
+      data_type: l1b
+      descriptor: bgrates
 
 (l1b, badtimes):
-  - *spice_basic
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: lo
-    upstream_data_type: l1b
-    upstream_descriptor: nhk
+  inputs:
+    - *spice_basic
+    - source: spin
+      data_type: spin
+      descriptor: historical
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - source: lo
+      data_type: l1b
+      descriptor: nhk
+  outputs:
+    - source: lo
+      data_type: l1b
+      descriptor: badtimes
 
 (l1b, de):
-  - *spice_common
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: bad-times
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: sweep-table
-  - upstream_source: lo
-    upstream_data_type: l1a
-    upstream_descriptor: de
-  - upstream_source: lo
-    upstream_data_type: l1a
-    upstream_descriptor: spin
-  - upstream_source: lo
-    upstream_data_type: l1b
-    upstream_descriptor: nhk
+  inputs:
+    - *spice_common
+    - source: spin
+      data_type: spin
+      descriptor: historical
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - source: lo
+      data_type: ancillary
+      descriptor: bad-times
+    - source: lo
+      data_type: ancillary
+      descriptor: sweep-table
+    - source: lo
+      data_type: l1a
+      descriptor: de
+    - source: lo
+      data_type: l1a
+      descriptor: spin
+    - source: lo
+      data_type: l1b
+      descriptor: nhk
+  outputs:
+    - source: lo
+      data_type: l1b
+      descriptor: de
 
 (l1b, derates):
-  - *spice_basic
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: sweep-table
-  - upstream_source: lo
-    upstream_data_type: ancillary
-    upstream_descriptor: esa-mode-lut
-  - upstream_source: lo
-    upstream_data_type: l1b
-    upstream_descriptor: de
-  - upstream_source: lo
-    upstream_data_type: l1a
-    upstream_descriptor: spin
+  inputs:
+    - *spice_basic
+    - source: spin
+      data_type: spin
+      descriptor: historical
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - source: lo
+      data_type: ancillary
+      descriptor: sweep-table
+    - source: lo
+      data_type: ancillary
+      descriptor: esa-mode-lut
+    - source: lo
+      data_type: l1b
+      descriptor: de
+    - source: lo
+      data_type: l1a
+      descriptor: spin
+  outputs:
+    - source: lo
+      data_type: l1b
+      descriptor: derates
 
 (l1b, prostar):
-  - *spice_basic
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: lo
-    upstream_data_type: l1a
-    upstream_descriptor: star
-  - upstream_source: lo
-    upstream_data_type: l1a
-    upstream_descriptor: spin
-  - upstream_source: lo
-    upstream_data_type: l1b
-    upstream_descriptor: nhk
+  inputs:
+    - *spice_basic
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - source: lo
+      data_type: l1a
+      descriptor: star
+    - source: lo
+      data_type: l1a
+      descriptor: spin
+    - source: lo
+      data_type: l1b
+      descriptor: nhk
 
 # ======== Level L1C ========
+  outputs:
+    - source: lo
+      data_type: l1b
+      descriptor: prostar
+
 (l1c, pset):
-  - *spice_common
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_90days
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: lo
-    upstream_data_type: l1b
-    upstream_descriptor: de
-  - upstream_source: lo
-    upstream_data_type: l1b
-    upstream_descriptor: goodtimes
-  - upstream_source: lo
-    upstream_data_type: l1b
-    upstream_descriptor: bgrates
+  inputs:
+    - *spice_common
+    - source: spin
+      data_type: spin
+      descriptor: historical
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - source: ephemeris_90days
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: lo
+      data_type: l1b
+      descriptor: de
+    - source: lo
+      data_type: l1b
+      descriptor: goodtimes
+    - source: lo
+      data_type: l1b
+      descriptor: bgrates
 
 # ======== Level L2 ========
+  outputs:
+    - source: lo
+      data_type: l1c
+      descriptor: pset
+
 (l2, l090-ena-h-hf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *lo_esa_fit_factors
-  - *lo_90_pset
+  inputs:
+    - *spice_l2
+    - *lo_esa_fit_factors
+    - *lo_90_pset
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-ena-h-hf-nsp-ram-hae-6deg-1yr
 
 (l2, l090-ena-h-hk-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *lo_esa_fit_factors
-  - *lo_90_pset
+  inputs:
+    - *spice_l2
+    - *lo_esa_fit_factors
+    - *lo_90_pset
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-ena-h-hk-nsp-ram-hae-6deg-1yr
 
 (l2, l090-ena-h-sf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *lo_esa_fit_factors
-  - *lo_90_pset
+  inputs:
+    - *spice_l2
+    - *lo_esa_fit_factors
+    - *lo_90_pset
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-ena-h-sf-nsp-ram-hae-6deg-1yr
 
 (l2, l090-ena-o-sf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *lo_esa_fit_factors
-  - *lo_90_pset
+  inputs:
+    - *spice_l2
+    - *lo_esa_fit_factors
+    - *lo_90_pset
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-ena-o-sf-nsp-ram-hae-6deg-1yr
 
 (l2, l090-isn-h-sf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *lo_esa_fit_factors
-  - *lo_90_pset
+  inputs:
+    - *spice_l2
+    - *lo_esa_fit_factors
+    - *lo_90_pset
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-isn-h-sf-nsp-ram-hae-6deg-1yr
 
 (l2, l090-isn-o-sf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *lo_esa_fit_factors
-  - *lo_90_pset
+  inputs:
+    - *spice_l2
+    - *lo_esa_fit_factors
+    - *lo_90_pset
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-isn-o-sf-nsp-ram-hae-6deg-1yr
 
 (l2, t090-ena-h-sf-nsp-ram-hae-6deg-1yr):
-  - *lo_esa_fit_factors
-  - *lo_esa_fit_factors
+  inputs:
+    - *lo_esa_fit_factors
+    - *lo_esa_fit_factors
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: t090-ena-h-sf-nsp-ram-hae-6deg-1yr
 
 (l2, t090-isn-h-sf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *lo_90_pset
+  inputs:
+    - *spice_l2
+    - *lo_90_pset
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: t090-isn-h-sf-nsp-ram-hae-6deg-1yr
 
 (l2, t090-isn-o-sf-nsp-ram-hae-6deg-1yr):
-  - *spice_l2
-  - *lo_90_pset
+  inputs:
+    - *spice_l2
+    - *lo_90_pset
 
 # ======== Level L3 ========
+  outputs:
+    - source: lo
+      data_type: l2
+      descriptor: t090-isn-o-sf-nsp-ram-hae-6deg-1yr
+
 (l3, l090-isn-h-sf-nsp-ram-hae-6deg-1yr):
-  - upstream_source: lo
-    upstream_data_type: l2
-    upstream_descriptor: l090-enanbs-h-sf-nsp-ram-hae-6deg-1yr
+  inputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-enanbs-h-sf-nsp-ram-hae-6deg-1yr
+  outputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-isn-h-sf-nsp-ram-hae-6deg-1yr
 
 (l3, l090-isn-o-sf-nsp-ram-hae-6deg-1yr):
-  - upstream_source: lo
-    upstream_data_type: l2
-    upstream_descriptor: l090-enanbs-o-sf-nsp-ram-hae-6deg-1yr
+  inputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-enanbs-o-sf-nsp-ram-hae-6deg-1yr
+  outputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-isn-o-sf-nsp-ram-hae-6deg-1yr
 
 (l3, l090-spx-h-hf-nsp-ram-hae-6deg-1yr):
-  - upstream_source: lo
-    upstream_data_type: l2
-    upstream_descriptor: l090-ena-h-hf-nsp-ram-hae-6deg-1yr
+  inputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-ena-h-hf-nsp-ram-hae-6deg-1yr
+  outputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-spx-h-hf-nsp-ram-hae-6deg-1yr
 
 (l3, l090-spx-h-hf-sp-ram-hae-6deg-1yr):
-  - upstream_source: lo
-    upstream_data_type: l3
-    upstream_descriptor: l090-ena-h-hf-sp-ram-hae-6deg-1yr
+  inputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-ena-h-hf-sp-ram-hae-6deg-1yr
+  outputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-spx-h-hf-sp-ram-hae-6deg-1yr
 
 (l3, l090-spx-h-sf-nsp-ram-hae-6deg-1yr):
-  - upstream_source: lo
-    upstream_data_type: l2
-    upstream_descriptor: l090-ena-h-sf-nsp-ram-hae-6deg-1yr
+  inputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-ena-h-sf-nsp-ram-hae-6deg-1yr
+  outputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-spx-h-sf-nsp-ram-hae-6deg-1yr
 
 (l3, l090-spx-h-sf-sp-ram-hae-6deg-1yr):
-  - upstream_source: lo
-    upstream_data_type: l3
-    upstream_descriptor: l090-ena-h-sf-sp-ram-hae-6deg-1yr
+  inputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-ena-h-sf-sp-ram-hae-6deg-1yr
+  outputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-spx-h-sf-sp-ram-hae-6deg-1yr
 
 (l3, l090-spxnbs-h-hk-nsp-ram-hae-6deg-1yr):
-  - upstream_source: lo
-    upstream_data_type: l2
-    upstream_descriptor: l090-enanbs-h-hk-nsp-ram-hae-6deg-1yr
+  inputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-enanbs-h-hk-nsp-ram-hae-6deg-1yr
+  outputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-spxnbs-h-hk-nsp-ram-hae-6deg-1yr
 
 (l3, l090-spxnbs-h-sf-nsp-ram-hae-6deg-1yr):
-  - upstream_source: lo
-    upstream_data_type: l2
-    upstream_descriptor: l090-enanbs-h-sf-nsp-ram-hae-6deg-1yr
-
+  inputs:
+    - source: lo
+      data_type: l2
+      descriptor: l090-enanbs-h-sf-nsp-ram-hae-6deg-1yr
+  outputs:
+    - source: lo
+      data_type: l3
+      descriptor: l090-spxnbs-h-sf-nsp-ram-hae-6deg-1yr
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_mag_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_mag_dependencies.yaml
@@ -6,278 +6,367 @@
 
 
 (l1a, all):
-  - upstream_source: mag
-    upstream_data_type: l0
-    upstream_descriptor: raw
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: mag
+      data_type: l0
+      descriptor: raw
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l1a
+      descriptor: norm-magi
+    - source: mag
+      data_type: l1a
+      descriptor: burst-magi
+    - source: mag
+      data_type: l1a
+      descriptor: norm-mago
+    - source: mag
+      data_type: l1a
+      descriptor: burst-mago
 
 (l1b, burst-magi):
-  - upstream_source: mag
-    upstream_data_type: l1a
-    upstream_descriptor: burst-magi
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-calibration
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: mag
+      data_type: l1a
+      descriptor: burst-magi
+    - source: mag
+      data_type: ancillary
+      descriptor: l1b-calibration
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l1b
+      descriptor: burst-magi
 
 (l1b, burst-mago):
-  - upstream_source: mag
-    upstream_data_type: l1a
-    upstream_descriptor: burst-mago
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-calibration
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: mag
+      data_type: l1a
+      descriptor: burst-mago
+    - source: mag
+      data_type: ancillary
+      descriptor: l1b-calibration
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l1b
+      descriptor: burst-mago
 
 (l1b, norm-magi):
-  - upstream_source: mag
-    upstream_data_type: l1a
-    upstream_descriptor: norm-magi
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-calibration
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: mag
+      data_type: l1a
+      descriptor: norm-magi
+    - source: mag
+      data_type: ancillary
+      descriptor: l1b-calibration
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l1b
+      descriptor: norm-magi
 
 (l1b, norm-mago):
-  - upstream_source: mag
-    upstream_data_type: l1a
-    upstream_descriptor: norm-mago
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-calibration
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: mag
+      data_type: l1a
+      descriptor: norm-mago
+    - source: mag
+      data_type: ancillary
+      descriptor: l1b-calibration
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l1b
+      descriptor: norm-mago
 
 (l1c, norm-magi):
-  - upstream_source: mag
-    upstream_data_type: l1b
-    upstream_descriptor: norm-magi
-    required: false
-  - upstream_source: mag
-    upstream_data_type: l1b
-    upstream_descriptor: burst-magi
-    required: false
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: mag
+      data_type: l1b
+      descriptor: norm-magi
+      required: false
+    - source: mag
+      data_type: l1b
+      descriptor: burst-magi
+      required: false
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l1c
+      descriptor: norm-magi
 
 (l1c, norm-mago):
-  - upstream_source: mag
-    upstream_data_type: l1b
-    upstream_descriptor: norm-mago
-    required: false
-  - upstream_source: mag
-    upstream_data_type: l1b
-    upstream_descriptor: burst-mago
-    required: false
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: mag
+      data_type: l1b
+      descriptor: norm-mago
+      required: false
+    - source: mag
+      data_type: l1b
+      descriptor: burst-mago
+      required: false
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l1c
+      descriptor: norm-mago
 
 (l1d, norm-srf):
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l1d-calibration
-  - upstream_source: mag
-    upstream_data_type: l1c
-    upstream_descriptor: norm-mago
-  - upstream_source: mag
-    upstream_data_type: l1c
-    upstream_descriptor: norm-magi
-  - upstream_source: mag
-    upstream_data_type: l1b
-    upstream_descriptor: burst-mago
-    required: false
-  - upstream_source: mag
-    upstream_data_type: l1b
-    upstream_descriptor: burst-magi
-    required: false
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_constants
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-
+  inputs:
+    - source: mag
+      data_type: ancillary
+      descriptor: l1d-calibration
+    - source: mag
+      data_type: l1c
+      descriptor: norm-mago
+    - source: mag
+      data_type: l1c
+      descriptor: norm-magi
+    - source: mag
+      data_type: l1b
+      descriptor: burst-mago
+      required: false
+    - source: mag
+      data_type: l1b
+      descriptor: burst-magi
+      required: false
+    - source: imap_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: science_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: pointing_attitude
+      data_type: spice
+      descriptor: historical
+    - source: attitude_history
+      data_type: spice
+      descriptor: historical
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: ephemeris_reconstructed
+      data_type: spice
+      descriptor: historical
+    - source: ephemeris_predicted
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_ephemeris
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_constants
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spin
+      data_type: spin
+      descriptor: historical
+  outputs:
+    - source: mag
+      data_type: l1d
+      descriptor: norm-srf
+    - source: mag
+      data_type: l1d
+      descriptor: norm-dsrf
+    - source: mag
+      data_type: l1d
+      descriptor: norm-gse
+    - source: mag
+      data_type: l1d
+      descriptor: norm-rtn
+    - source: mag
+      data_type: l1d
+      descriptor: burst-srf
+    - source: mag
+      data_type: l1d
+      descriptor: burst-dsrf
+    - source: mag
+      data_type: l1d
+      descriptor: burst-gse
+    - source: mag
+      data_type: l1d
+      descriptor: burst-rtn
 
 (l2, burst-srf):
-  - upstream_source: mag
-    upstream_data_type: l1b
-    upstream_descriptor: burst-mago
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-calibration
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-burst-offsets
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_constants
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: mag
+      data_type: l1b
+      descriptor: burst-mago
+    - source: mag
+      data_type: ancillary
+      descriptor: l2-calibration
+    - source: mag
+      data_type: ancillary
+      descriptor: l2-burst-offsets
+    - source: imap_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: science_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: pointing_attitude
+      data_type: spice
+      descriptor: historical
+    - source: attitude_history
+      data_type: spice
+      descriptor: historical
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: ephemeris_reconstructed
+      data_type: spice
+      descriptor: historical
+    - source: ephemeris_predicted
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_ephemeris
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_constants
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l2
+      descriptor: burst-srf
+    - source: mag
+      data_type: l2
+      descriptor: burst-dsrf
+    - source: mag
+      data_type: l2
+      descriptor: burst-gse
+    - source: mag
+      data_type: l2
+      descriptor: burst-rtn
 
 (l2, norm-srf):
-  - upstream_source: mag
-    upstream_data_type: l1c
-    upstream_descriptor: norm-mago
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-calibration
-  - upstream_source: mag
-    upstream_data_type: ancillary
-    upstream_descriptor: l2-norm-offsets
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_constants
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  inputs:
+    - source: mag
+      data_type: l1c
+      descriptor: norm-mago
+    - source: mag
+      data_type: ancillary
+      descriptor: l2-calibration
+    - source: mag
+      data_type: ancillary
+      descriptor: l2-norm-offsets
+    - source: imap_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: science_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: pointing_attitude
+      data_type: spice
+      descriptor: historical
+    - source: attitude_history
+      data_type: spice
+      descriptor: historical
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: ephemeris_reconstructed
+      data_type: spice
+      descriptor: historical
+    - source: ephemeris_predicted
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_ephemeris
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_constants
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: mag
+      data_type: l2
+      descriptor: norm-srf
+    - source: mag
+      data_type: l2
+      descriptor: norm-dsrf
+    - source: mag
+      data_type: l2
+      descriptor: norm-gse
+    - source: mag
+      data_type: l2
+      descriptor: norm-rtn

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_spacecraft_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_spacecraft_dependencies.yaml
@@ -5,40 +5,50 @@
 # and how to properly configure them for your pipeline lambdas.
 
 (l1a, pointing-attitude):
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  inputs:
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - source: attitude_history
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: imap_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: science_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: spacecraft
+      data_type: l1a
+      descriptor: pointing-attitude
 
 
 (l1a, quaternions):
-  - upstream_source: spacecraft
-    upstream_data_type: l0
-    upstream_descriptor: raw
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  inputs:
+    - source: spacecraft
+      data_type: l0
+      descriptor: raw
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: spacecraft
+      data_type: l1a
+      descriptor: quaternions

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_swapi_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_swapi_dependencies.yaml
@@ -4,234 +4,265 @@
 # It contains important information such as the default values and expected behavior of these dependencies,
 # and how to properly configure them for your pipeline lambdas.
 l3a_ancillary_common: &l3a_ancillary_common
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: azimuthal-transmission
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: central-effective-area
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: passband-fit-coefficients
+  - source: swapi
+    data_type: ancillary
+    descriptor: azimuthal-transmission
+  - source: swapi
+    data_type: ancillary
+    descriptor: central-effective-area
+  - source: swapi
+    data_type: ancillary
+    descriptor: passband-fit-coefficients
 
 
 l3a_spice_common: &l3a_spice_common
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_constants
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
+  - source: ephemeris_reconstructed
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_predicted
+    data_type: spice
+    descriptor: historical
+  - source: planetary_ephemeris
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: planetary_constants
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: attitude_history
+    data_type: spice
+    descriptor: historical
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: imap_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: pointing_attitude
+    data_type: spice
+    descriptor: historical
 
 (l1, hk):
-  - upstream_source: swapi
-    upstream_data_type: l0
-    upstream_descriptor: raw
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: swapi
+      data_type: l0
+      descriptor: raw
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: swapi
+      data_type: l1
+      descriptor: hk
 
 (l1, sci):
-  - upstream_source: swapi
-    upstream_data_type: l0
-    upstream_descriptor: raw
-  - upstream_source: swapi
-    upstream_data_type: l1a
-    upstream_descriptor: hk
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: swapi
+      data_type: l0
+      descriptor: raw
+    - source: swapi
+      data_type: l1a
+      descriptor: hk
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: swapi
+      data_type: l1
+      descriptor: sci
 
 (l2, sci):
-  - upstream_source: swapi
-    upstream_data_type: l1
-    upstream_descriptor: sci
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: esa-unit-conversion
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: lut-notes
-
+  inputs:
+    - source: swapi
+      data_type: l1
+      descriptor: sci
+    - source: swapi
+      data_type: ancillary
+      descriptor: esa-unit-conversion
+    - source: swapi
+      data_type: ancillary
+      descriptor: lut-notes
+  outputs:
+    - source: swapi
+      data_type: l2
+      descriptor: sci
 
 (l3a, alpha-sw):
-  - *l3a_spice_common
-  - *l3a_ancillary_common
-  - upstream_source: swapi
-    upstream_data_type: l2
-    upstream_descriptor: sci
-  - upstream_source: mag
-    upstream_data_type: l1d
-    upstream_descriptor: norm-rtn
-  - upstream_source: mag
-    upstream_data_type: l2
-    upstream_descriptor: norm-rtn
-    required: false
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: clock-angle-and-flow-deflection-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: proton-density-temperature-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: alpha-density-temperature-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: energy-gf-pui-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: instrument-response-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: density-of-neutral-helium-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: efficiency-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: helium-inflow-vector
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: hydrogen-inflow-vector
-    kickoff_job: false
+  inputs:
+    - *l3a_spice_common
+    - *l3a_ancillary_common
+    - source: swapi
+      data_type: l2
+      descriptor: sci
+    - source: mag
+      data_type: l1d
+      descriptor: norm-rtn
+    - source: mag
+      data_type: l2
+      descriptor: norm-rtn
+      required: false
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: clock-angle-and-flow-deflection-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: proton-density-temperature-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: alpha-density-temperature-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: energy-gf-pui-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: instrument-response-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: density-of-neutral-helium-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: efficiency-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: helium-inflow-vector
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: hydrogen-inflow-vector
+      trigger_job: false
+  outputs:
+    - source: swapi
+      data_type: l3a
+      descriptor: alpha-sw
 
 (l3a, proton-sw):
-  - *l3a_spice_common
-  - *l3a_ancillary_common
-  - upstream_source: swapi
-    upstream_data_type: l2
-    upstream_descriptor: sci
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: clock-angle-and-flow-deflection-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: proton-density-temperature-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: alpha-density-temperature-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: energy-gf-pui-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: instrument-response-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: density-of-neutral-helium-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: efficiency-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: helium-inflow-vector
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: hydrogen-inflow-vector
-    kickoff_job: false
-
+  inputs:
+    - *l3a_spice_common
+    - *l3a_ancillary_common
+    - source: swapi
+      data_type: l2
+      descriptor: sci
+    - source: swapi
+      data_type: ancillary
+      descriptor: clock-angle-and-flow-deflection-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: proton-density-temperature-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: alpha-density-temperature-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: energy-gf-pui-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: instrument-response-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: density-of-neutral-helium-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: efficiency-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: helium-inflow-vector
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: hydrogen-inflow-vector
+      trigger_job: false
+  outputs:
+    - source: swapi
+      data_type: l3a
+      descriptor: proton-sw
 
 (l3a, pui-he):
-  - *l3a_spice_common
-  - *l3a_ancillary_common
-  - upstream_source: swapi
-    upstream_data_type: l2
-    upstream_descriptor: sci
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: clock-angle-and-flow-deflection-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: proton-density-temperature-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: alpha-density-temperature-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: energy-gf-pui-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: instrument-response-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: density-of-neutral-helium-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: efficiency-lut
-    kickoff_job: false
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: helium-inflow-vector
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: hydrogen-inflow-vector
-
+  inputs:
+    - *l3a_spice_common
+    - *l3a_ancillary_common
+    - source: swapi
+      data_type: l2
+      descriptor: sci
+    - source: swapi
+      data_type: ancillary
+      descriptor: clock-angle-and-flow-deflection-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: proton-density-temperature-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: alpha-density-temperature-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: energy-gf-pui-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: instrument-response-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: density-of-neutral-helium-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: efficiency-lut
+      trigger_job: false
+    - source: swapi
+      data_type: ancillary
+      descriptor: helium-inflow-vector
+    - source: swapi
+      data_type: ancillary
+      descriptor: hydrogen-inflow-vector
+  outputs:
+    - source: swapi
+      data_type: l3a
+      descriptor: pui-he
 
 (l3b, combined):
-  - upstream_source: swapi
-    upstream_data_type: l2
-    upstream_descriptor: sci
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: efficiency-lut
-  - upstream_source: swapi
-    upstream_data_type: ancillary
-    upstream_descriptor: energy-gf-sw-lut
+  inputs:
+    - source: swapi
+      data_type: l2
+      descriptor: sci
+    - source: swapi
+      data_type: ancillary
+      descriptor: efficiency-lut
+    - source: swapi
+      data_type: ancillary
+      descriptor: energy-gf-sw-lut
+  outputs:
+    - source: swapi
+      data_type: l3b
+      descriptor: combined
+

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_swe_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_swe_dependencies.yaml
@@ -6,103 +6,127 @@
 
 
 (l1a, all):
-  - upstream_source: swe
-    upstream_data_type: l0
-    upstream_descriptor: raw
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: swe
+      data_type: l0
+      descriptor: raw
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: swe
+      data_type: l1a
+      descriptor: sci
+    - source: swe
+      data_type: l1a
+      descriptor: hk
+    - source: swe
+      data_type: l1a
+      descriptor: cem-raw
 
 (l1b, sci):
-  - upstream_source: swe
-    upstream_data_type: l1a
-    upstream_descriptor: sci
-  - upstream_source: swe
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-in-flight-cal
-  - upstream_source: swe
-    upstream_data_type: ancillary
-    upstream_descriptor: esa-lut
-  - upstream_source: swe
-    upstream_data_type: ancillary
-    upstream_descriptor: eu-conversion
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-
+  inputs:
+    - source: swe
+      data_type: l1a
+      descriptor: sci
+    - source: swe
+      data_type: ancillary
+      descriptor: l1b-in-flight-cal
+    - source: swe
+      data_type: ancillary
+      descriptor: esa-lut
+    - source: swe
+      data_type: ancillary
+      descriptor: eu-conversion
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: swe
+      data_type: l1b
+      descriptor: sci
 
 (l2, sci):
-  - upstream_source: swe
-    upstream_data_type: l1b
-    upstream_descriptor: sci
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-
+  inputs:
+    - source: swe
+      data_type: l1b
+      descriptor: sci
+    - source: spin
+      data_type: spin
+      descriptor: historical
+  outputs:
+    - source: swe
+      data_type: l2
+      descriptor: sci
 
 (l3, sci):
-  - upstream_source: swe
-    upstream_data_type: l1b
-    upstream_descriptor: sci
-  - upstream_source: swe
-    upstream_data_type: l2
-    upstream_descriptor: sci
-  - upstream_source: swe
-    upstream_data_type: ancillary
-    upstream_descriptor: config
-  - upstream_source: swapi
-    upstream_data_type: l3a
-    upstream_descriptor: proton-sw
-  - upstream_source: mag
-    upstream_data_type: l1d
-    upstream_descriptor: norm-dsrf
-  - upstream_source: mag
-    upstream_data_type: l2
-    upstream_descriptor: norm-dsrf
-    kickoff_job: false
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_constants
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  inputs:
+    - source: swe
+      data_type: l1b
+      descriptor: sci
+    - source: swe
+      data_type: l2
+      descriptor: sci
+    - source: swe
+      data_type: ancillary
+      descriptor: config
+    - source: swapi
+      data_type: l3a
+      descriptor: proton-sw
+    - source: mag
+      data_type: l1d
+      descriptor: norm-dsrf
+    - source: mag
+      data_type: l2
+      descriptor: norm-dsrf
+      trigger_job: false
+    - source: imap_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: science_frames
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: ephemeris_reconstructed
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: ephemeris_predicted
+      data_type: spice
+      descriptor: historical
+    - source: leapseconds
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: spacecraft_clock
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: pointing_attitude
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_ephemeris
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+    - source: planetary_constants
+      data_type: spice
+      descriptor: historical
+      trigger_job: false
+  outputs:
+    - source: swe
+      data_type: l3
+      descriptor: sci
+

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_ultra_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_ultra_dependencies.yaml
@@ -8,1156 +8,1441 @@
 # Common spice dependencies shared by multiple products
 spice_basic: &spice_basic
 
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 
 spice_l1b_de: &spice_l1b_de
 
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_90days
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_reconstructed
+    data_type: spice
+    descriptor: historical
+  - source: ephemeris_predicted
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_90days
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: attitude_history
+    data_type: spice
+    descriptor: historical
+  - source: imap_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: planetary_ephemeris
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: pointing_attitude
+    data_type: spice
+    descriptor: historical
+  - source: repoint
+    data_type: repoint
+    descriptor: historical
+  - source: spin
+    data_type: spin
+    descriptor: historical
 
 
 spice_l1c_common: &spice_l1c_common
 
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: ephemeris_90days
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_reconstructed
+    data_type: spice
+    descriptor: historical
+  - source: ephemeris_predicted
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: ephemeris_90days
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: attitude_history
+    data_type: spice
+    descriptor: historical
+  - source: imap_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: planetary_ephemeris
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: pointing_attitude
+    data_type: spice
+    descriptor: historical
+  - source: spin
+    data_type: spin
+    descriptor: historical
+    trigger_job: false
 
 
 spice_l1c_spacecraft: &spice_l1c_spacecraft
 
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: planetary_ephemeris
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: attitude_history
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_reconstructed
-    upstream_data_type: spice
-    upstream_descriptor: historical
-  - upstream_source: ephemeris_predicted
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: repoint
+    data_type: repoint
+    descriptor: historical
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: planetary_ephemeris
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: pointing_attitude
+    data_type: spice
+    descriptor: historical
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spin
+    data_type: spin
+    descriptor: historical
+    trigger_job: false
+  - source: attitude_history
+    data_type: spice
+    descriptor: historical
+  - source: ephemeris_reconstructed
+    data_type: spice
+    descriptor: historical
+  - source: ephemeris_predicted
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 
 spice_l2: &spice_l2
 
-  - upstream_source: science_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: spacecraft_clock
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: leapseconds
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: pointing_attitude
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
-  - upstream_source: imap_frames
-    upstream_data_type: spice
-    upstream_descriptor: historical
-    kickoff_job: false
+  - source: science_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: spacecraft_clock
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: leapseconds
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: pointing_attitude
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
+  - source: imap_frames
+    data_type: spice
+    descriptor: historical
+    trigger_job: false
 
 
 # ======== Product-Specific Dependencies ========
 
 (l1a, all):
-  - upstream_source: ultra
-    upstream_data_type: l0
-    upstream_descriptor: raw
-  - *spice_basic
-
-
+  inputs:
+    - source: ultra
+      data_type: l0
+      descriptor: raw
+    - *spice_basic
+  outputs:
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-de
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-aux
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-params
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-rates
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-de
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-aux
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-params
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-rates
 
 (l1b, 45sensor-badtimes):
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-extendedspin
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-goodtimes
-
-
+  inputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-extendedspin
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-goodtimes
+  outputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-de
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-extendedspin
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-de
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-extendedspin
 
 (l1b, 45sensor-de):
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-de
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-aux
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-logistic-interpolation
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-leftslit-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-rightslit-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-egynorm-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-imgparams-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-back-pos-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-tdc-norm-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-sensor-gf-blades
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-sensor-gf-noblades
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-yadjust-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-tofxeflat
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-tofxemedium
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-tofxesteep
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-tofxph
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-spbtphcorr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-sptpphcorr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-scattering-calibration-data
-  - *spice_l1b_de
-
-
+  inputs:
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-de
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-aux
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-logistic-interpolation
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-leftslit-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-rightslit-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-egynorm-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-imgparams-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-back-pos-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-tdc-norm-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-sensor-gf-blades
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-sensor-gf-noblades
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-yadjust-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-tofxeflat
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-tofxemedium
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-tofxesteep
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-tofxph
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-spbtphcorr
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-sptpphcorr
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-scattering-calibration-data
+    - *spice_l1b_de
+  outputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-de
 
 (l1b, 45sensor-extendedspin):
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-params
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-rates
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-aux
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-de
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-
-
+  inputs:
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-params
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-rates
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-aux
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-de
+    - source: spin
+      data_type: spin
+      descriptor: historical
+  outputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-extendedspin
 
 (l1b, 45sensor-goodtimes):
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-extendedspin
-
-
-
+  inputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-extendedspin
+  outputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-de
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-extendedspin
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-de
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-extendedspin
 (l1b, 90sensor-badtimes):
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-extendedspin
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-goodtimes
-
-
+  inputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-extendedspin
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
+  outputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-de
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-extendedspin
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-de
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-extendedspin
 
 (l1b, 90sensor-de):
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-de
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-aux
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-logistic-interpolation
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-leftslit-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-rightslit-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-egynorm-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-imgparams-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-back-pos-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-tdc-norm-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-sensor-gf-blades
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-sensor-gf-noblades
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-yadjust-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-tofxeflat
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-tofxemedium
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-tofxesteep
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-tofxph
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-spbtphcorr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-sptpphcorr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-scattering-calibration-data
-  - *spice_l1b_de
-
-
+  inputs:
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-de
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-aux
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-logistic-interpolation
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-leftslit-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-rightslit-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-egynorm-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-imgparams-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-back-pos-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-tdc-norm-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-sensor-gf-blades
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-sensor-gf-noblades
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-yadjust-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-tofxeflat
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-tofxemedium
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-tofxesteep
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-tofxph
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-spbtphcorr
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-sptpphcorr
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-scattering-calibration-data
+    - *spice_l1b_de
+  outputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-de
 
 (l1b, 90sensor-extendedspin):
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-params
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-rates
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-aux
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-de
-  - upstream_source: spin
-    upstream_data_type: spin
-    upstream_descriptor: historical
-
-
+  inputs:
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-params
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-rates
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-aux
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-de
+    - source: spin
+      data_type: spin
+      descriptor: historical
+  outputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-extendedspin
 
 (l1b, 90sensor-goodtimes):
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-extendedspin
-
-
+  inputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-extendedspin
+  outputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
 
 (l1c, 45sensor-heliopset):
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-de
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-rates
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-aux
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-goodtimes
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-scattering-calibration-data
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-sensor-gf-blades
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-logistic-interpolation
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-imgparams-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-45sensor-static-dead-times
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - *spice_l1c_common
-
-
+  inputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-de
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-rates
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-aux
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-goodtimes
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-scattering-calibration-data
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-sensor-gf-blades
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-logistic-interpolation
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-imgparams-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-45sensor-static-dead-times
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - *spice_l1c_common
+  outputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
 
 (l1c, 45sensor-spacecraftpset):
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-de
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-rates
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 45sensor-aux
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 45sensor-goodtimes
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-scattering-calibration-data
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-45sensor-sc-pointing-theta
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-45sensor-sc-pointing-phi
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-45sensor-sc-pointing-index
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-45sensor-sc-pointing-bsf
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-sensor-gf-blades
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-logistic-interpolation
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-imgparams-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-45sensor-static-dead-times
-  - *spice_l1c_spacecraft
-
-
+  inputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-de
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-rates
+    - source: ultra
+      data_type: l1a
+      descriptor: 45sensor-aux
+    - source: ultra
+      data_type: l1b
+      descriptor: 45sensor-goodtimes
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-scattering-calibration-data
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-45sensor-sc-pointing-theta
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-45sensor-sc-pointing-phi
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-45sensor-sc-pointing-index
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-45sensor-sc-pointing-bsf
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-sensor-gf-blades
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-logistic-interpolation
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-imgparams-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-45sensor-static-dead-times
+    - *spice_l1c_spacecraft
+  outputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
 
 (l1c, 90sensor-heliopset):
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-de
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-rates
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-aux
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-goodtimes
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-scattering-calibration-data
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-sensor-gf-blades
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-logistic-interpolation
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-imgparams-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-90sensor-static-dead-times
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
-  - *spice_l1c_common
-
-
+  inputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-de
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-rates
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-aux
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-scattering-calibration-data
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-sensor-gf-blades
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-logistic-interpolation
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-imgparams-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-90sensor-static-dead-times
+    - source: repoint
+      data_type: repoint
+      descriptor: historical
+    - *spice_l1c_common
+  outputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
 
 (l1c, 90sensor-spacecraftpset):
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-de
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-rates
-  - upstream_source: ultra
-    upstream_data_type: l1a
-    upstream_descriptor: 90sensor-aux
-  - upstream_source: ultra
-    upstream_data_type: l1b
-    upstream_descriptor: 90sensor-goodtimes
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-scattering-calibration-data
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-90sensor-sc-pointing-theta
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-90sensor-sc-pointing-phi
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-90sensor-sc-pointing-index
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-90sensor-sc-pointing-bsf
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-sensor-gf-blades
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-45sensor-logistic-interpolation
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-scattering-thresholds-per-energy
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1b-90sensor-imgparams-lookup
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: l1c-90sensor-static-dead-times
-  - *spice_l1c_spacecraft
-
-
+  inputs:
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-de
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-rates
+    - source: ultra
+      data_type: l1a
+      descriptor: 90sensor-aux
+    - source: ultra
+      data_type: l1b
+      descriptor: 90sensor-goodtimes
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-scattering-calibration-data
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-90sensor-sc-pointing-theta
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-90sensor-sc-pointing-phi
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-90sensor-sc-pointing-index
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-90sensor-sc-pointing-bsf
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-sensor-gf-blades
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-45sensor-logistic-interpolation
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-scattering-thresholds-per-energy
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1b-90sensor-imgparams-lookup
+    - source: ultra
+      data_type: ancillary
+      descriptor: l1c-90sensor-static-dead-times
+    - *spice_l1c_spacecraft
+  outputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
 
 (l2, u45-ena-h-hf-nsp-full-hae-2deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-2deg-1yr
 
 (l2, u45-ena-h-hf-nsp-full-hae-2deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-2deg-3mo
 
 (l2, u45-ena-h-hf-nsp-full-hae-2deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-2deg-6mo
 
 (l2, u45-ena-h-hf-nsp-full-hae-4deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-4deg-1yr
 
 (l2, u45-ena-h-hf-nsp-full-hae-4deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-4deg-3mo
 
 (l2, u45-ena-h-hf-nsp-full-hae-4deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-4deg-6mo
 
 (l2, u45-ena-h-hf-nsp-full-hae-6deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-6deg-1yr
 
 (l2, u45-ena-h-hf-nsp-full-hae-6deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-6deg-3mo
 
 (l2, u45-ena-h-hf-nsp-full-hae-6deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-hf-nsp-full-hae-6deg-6mo
 
 (l2, u45-ena-h-sf-nsp-full-hae-2deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-2deg-1yr
 
 (l2, u45-ena-h-sf-nsp-full-hae-2deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-2deg-3mo
 
 (l2, u45-ena-h-sf-nsp-full-hae-2deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-2deg-6mo
 
 (l2, u45-ena-h-sf-nsp-full-hae-4deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-4deg-1yr
 
 (l2, u45-ena-h-sf-nsp-full-hae-4deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-4deg-3mo
 
 (l2, u45-ena-h-sf-nsp-full-hae-4deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-4deg-6mo
 
 (l2, u45-ena-h-sf-nsp-full-hae-6deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-6deg-1yr
 
 (l2, u45-ena-h-sf-nsp-full-hae-6deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-6deg-3mo
 
 (l2, u45-ena-h-sf-nsp-full-hae-6deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 45sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 45sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u45-ena-h-sf-nsp-full-hae-6deg-6mo
 
 (l2, u90-ena-h-hf-nsp-full-hae-2deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-2deg-1yr
 
 (l2, u90-ena-h-hf-nsp-full-hae-2deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-2deg-3mo
 
 (l2, u90-ena-h-hf-nsp-full-hae-2deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-2deg-6mo
 
 (l2, u90-ena-h-hf-nsp-full-hae-4deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-4deg-1yr
 
 (l2, u90-ena-h-hf-nsp-full-hae-4deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-4deg-3mo
 
 (l2, u90-ena-h-hf-nsp-full-hae-4deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-4deg-6mo
 
 (l2, u90-ena-h-hf-nsp-full-hae-6deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-6deg-1yr
 
 (l2, u90-ena-h-hf-nsp-full-hae-6deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-6deg-3mo
 
 (l2, u90-ena-h-hf-nsp-full-hae-6deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-heliopset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-heliopset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-hf-nsp-full-hae-6deg-6mo
 
 (l2, u90-ena-h-sf-nsp-full-hae-2deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-2deg-1yr
 
 (l2, u90-ena-h-sf-nsp-full-hae-2deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-2deg-3mo
 
 (l2, u90-ena-h-sf-nsp-full-hae-2deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-2deg-6mo
 
 (l2, u90-ena-h-sf-nsp-full-hae-4deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-4deg-1yr
 
 (l2, u90-ena-h-sf-nsp-full-hae-4deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-4deg-3mo
 
 (l2, u90-ena-h-sf-nsp-full-hae-4deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-4deg-6mo
 
 (l2, u90-ena-h-sf-nsp-full-hae-6deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-6deg-1yr
 
 (l2, u90-ena-h-sf-nsp-full-hae-6deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-6deg-3mo
 
 (l2, u90-ena-h-sf-nsp-full-hae-6deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l1c
-    upstream_descriptor: 90sensor-spacecraftpset
-    kickoff_job: false
-  - *spice_l2
-
-
+  inputs:
+    - source: ultra
+      data_type: l1c
+      descriptor: 90sensor-spacecraftpset
+      trigger_job: false
+    - *spice_l2
+  outputs:
+    - source: ultra
+      data_type: l2
+      descriptor: u90-ena-h-sf-nsp-full-hae-6deg-6mo
 
 (l3, u45-spx-h-hf-sp-full-hae-2deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-2deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-2deg-1yr
 
 (l3, u45-spx-h-hf-sp-full-hae-2deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-2deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-2deg-3mo
 
 (l3, u45-spx-h-hf-sp-full-hae-2deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-2deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-2deg-6mo
 
 (l3, u45-spx-h-hf-sp-full-hae-4deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-4deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-4deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-4deg-1yr
 
 (l3, u45-spx-h-hf-sp-full-hae-4deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-4deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-4deg-3mo
 
 (l3, u45-spx-h-hf-sp-full-hae-4deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-4deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-4deg-6mo
 
 (l3, u45-spx-h-hf-sp-full-hae-6deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-6deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-6deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-6deg-1yr
 
 (l3, u45-spx-h-hf-sp-full-hae-6deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-6deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-6deg-3mo
 
 (l3, u45-spx-h-hf-sp-full-hae-6deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u45-ena-h-hf-sp-full-hae-6deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u45-spx-h-hf-sp-full-hae-6deg-6mo
 
 (l3, u90-spx-h-hf-sp-full-hae-2deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-2deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-2deg-1yr
 
 (l3, u90-spx-h-hf-sp-full-hae-2deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-2deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-2deg-3mo
 
 (l3, u90-spx-h-hf-sp-full-hae-2deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-2deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-2deg-6mo
 
 (l3, u90-spx-h-hf-sp-full-hae-4deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-4deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-4deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-4deg-1yr
 
 (l3, u90-spx-h-hf-sp-full-hae-4deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-4deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-4deg-3mo
 
 (l3, u90-spx-h-hf-sp-full-hae-4deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-4deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-4deg-6mo
 
 (l3, u90-spx-h-hf-sp-full-hae-6deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-6deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-6deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-6deg-1yr
 
 (l3, u90-spx-h-hf-sp-full-hae-6deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-6deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-6deg-3mo
 
 (l3, u90-spx-h-hf-sp-full-hae-6deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: u90-ena-h-hf-sp-full-hae-6deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-spx-h-hf-sp-full-hae-6deg-6mo
 
 (l3, ulc-spx-h-hf-sp-full-hae-2deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-2deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-2deg-1yr
 
 (l3, ulc-spx-h-hf-sp-full-hae-2deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-2deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-2deg-3mo
 
 (l3, ulc-spx-h-hf-sp-full-hae-2deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-2deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-2deg-6mo
 
 (l3, ulc-spx-h-hf-sp-full-hae-4deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-4deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-4deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-4deg-1yr
 
 (l3, ulc-spx-h-hf-sp-full-hae-4deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-4deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-4deg-3mo
 
 (l3, ulc-spx-h-hf-sp-full-hae-4deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-4deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-4deg-6mo
 
 (l3, ulc-spx-h-hf-sp-full-hae-6deg-1yr):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-6deg-1yr
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-6deg-1yr
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-6deg-1yr
 
 (l3, ulc-spx-h-hf-sp-full-hae-6deg-3mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-6deg-3mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-6deg-3mo
 
 (l3, ulc-spx-h-hf-sp-full-hae-6deg-6mo):
-  - upstream_source: ultra
-    upstream_data_type: l3
-    upstream_descriptor: ulc-ena-h-hf-sp-full-hae-6deg-6mo
-  - upstream_source: ultra
-    upstream_data_type: ancillary
-    upstream_descriptor: ulc-spx-energy-ranges
-
+  inputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: ancillary
+      descriptor: ulc-spx-energy-ranges
+  outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-spx-h-hf-sp-full-hae-6deg-6mo
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependency_new.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependency_new.py
@@ -9,7 +9,7 @@ import yaml
 from imap_data_access import VALID_INSTRUMENTS
 
 from ...api_lambdas import upload_api
-from .types import DependencyNode, ProcessingJobNode, format_upstream_node_input
+from .types import DependencyNode, ProcessingJobNode
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ class DependencyConfigReader:
                 )
 
             # Parse YAML keys to construct (source, data_type, descriptor) tuples
-            for key_str, upstream_list in instrument_config.items():
+            for key_str, value in instrument_config.items():
                 # Skip any anchor definitions (common dependency groups).
                 if not key_str.startswith("("):
                     continue
@@ -117,13 +117,23 @@ class DependencyConfigReader:
                     )
                     potential_job_node = (instrument, data_type, descriptor)
 
+                    upstream_list = value["inputs"]
                     flattened_upstream_deps = self.recursive_flatten_list(upstream_list)
 
                     upstream_deps_nodes = []
-                    # Validate each upstream node
                     for upstream in flattened_upstream_deps:
-                        upstream_node = format_upstream_node_input(upstream)
-                        upstream_deps_nodes.append(upstream_node)
+                        upstream_deps_nodes.append(
+                            DependencyNode(
+                                source=upstream["source"],
+                                data_type=upstream["data_type"],
+                                descriptor=upstream["descriptor"],
+                                required=upstream.get("required", True),
+                                trigger_job=upstream.get("trigger_job", True),
+                                dependency_query_time_range=upstream.get(
+                                    "date_range", []
+                                ),
+                            )
+                        )
 
                     dependencies[potential_job_node] = upstream_deps_nodes
 
@@ -142,27 +152,28 @@ class DependencyConfigReader:
 
         For example:
         spice_basic: &spice_basic
-            - upstream_source: leapseconds
-                upstream_data_type: spice
-                upstream_descriptor: historical
-                kickoff_job: false
-            - upstream_source: spacecraft_clock
-                upstream_data_type: spice
-                upstream_descriptor: historical
-                kickoff_job: false
+            - source: leapseconds
+                data_type: spice
+                descriptor: historical
+                trigger_job: false
+            - source: spacecraft_clock
+                data_type: spice
+                descriptor: historical
+                trigger_job: false
 
         spice_45sensor_l1b: &spice_45sensor_l1b
             - *spice_basic
-            - upstream_source: imap_frames
-                upstream_data_type: spice
-                upstream_descriptor: historical
-                kickoff_job: false
+            - source: imap_frames
+                data_type: spice
+                descriptor: historical
+                trigger_job: false
 
         (l1b, 45sensor-de):
-            - *spice_45sensor_l1b
-            - upstream_source: hi
-                upstream_data_type: l1a
-                upstream_descriptor: 45sensor-de
+            inputs:
+              - *spice_45sensor_l1b
+              - source: hi
+                  data_type: l1a
+                  descriptor: 45sensor-de
 
         Parameters
         ----------

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/types.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/types.py
@@ -153,7 +153,7 @@ class DependencyNode(Node):
             data_type,
             descriptor,
             required,
-            kickoff_job,
+            trigger_job,
             Optional([past, future])
         ]
     If it includes past/future date ranges, it should follow the following format:
@@ -178,13 +178,13 @@ class DependencyNode(Node):
     """
 
     required: bool = True
-    kickoff_job: bool = True
+    trigger_job: bool = True
     dependency_query_time_range: list = field(default_factory=list)
 
     def __post_init__(self):
         """Validate all fields on construction."""
         super().__post_init__()
-        self._validate_boolean_fields(self.required, self.kickoff_job)
+        self._validate_boolean_fields(self.required, self.trigger_job)
         self._validate_date_range(self.dependency_query_time_range)
 
     def serialize(self) -> dict[str, Any]:
@@ -196,10 +196,10 @@ class DependencyNode(Node):
         """Deserialize dictionary to dependency node."""
         return cls(**json_object)
 
-    def _validate_boolean_fields(self, required: bool, kickoff_job: bool) -> None:
-        """Validate required and kickoff_job are booleans."""
-        if not isinstance(required, bool) or not isinstance(kickoff_job, bool):
-            raise ValueError("'required' and 'kickoff_job' must be boolean values")
+    def _validate_boolean_fields(self, required: bool, trigger_job: bool) -> None:
+        """Validate required and trigger_job are booleans."""
+        if not isinstance(required, bool) or not isinstance(trigger_job, bool):
+            raise ValueError("'required' and 'trigger_job' must be boolean values")
 
     def _validate_date_range(self, date_range) -> None:
         """Validate date range format if provided."""
@@ -363,45 +363,3 @@ def get_cadence_duration(descriptor: str) -> str | None:
         return cadence
 
     return None
-
-
-def format_upstream_node_input(yaml_dict: dict) -> DependencyNode:
-    """Convert a YAML upstream dependency dict to a DependencyNode.
-
-    YAML upstream entries use ``upstream_source``, ``upstream_data_type``,
-    and ``upstream_descriptor`` as keys. This function maps those keys
-    to the DependencyNode field names and constructs the node directly.
-
-    Parameters
-    ----------
-    yaml_dict : dict
-        A dict with keys ``upstream_source``, ``upstream_data_type``,
-        ``upstream_descriptor``, and optionally ``required``,
-        ``kickoff_job``, ``date_range``.
-
-    Returns
-    -------
-    DependencyNode
-        A fully validated DependencyNode instance.
-    """
-    # Accept only dictionary format
-    if not isinstance(yaml_dict, dict):
-        raise ValueError(f"Node must be a dict, got {type(yaml_dict).__name__}")
-
-    required_keys = {
-        "upstream_source",
-        "upstream_data_type",
-        "upstream_descriptor",
-    }
-    if not required_keys.issubset(yaml_dict.keys()):
-        raise ValueError(
-            f"Node dict must contain keys {required_keys}, got {set(yaml_dict.keys())}"
-        )
-    return DependencyNode(
-        source=yaml_dict["upstream_source"],
-        data_type=yaml_dict["upstream_data_type"],
-        descriptor=yaml_dict["upstream_descriptor"],
-        required=yaml_dict.get("required", True),
-        kickoff_job=yaml_dict.get("kickoff_job", True),
-        dependency_query_time_range=yaml_dict.get("date_range", []),
-    )

--- a/tests/lambda_endpoints/test_dependency_new.py
+++ b/tests/lambda_endpoints/test_dependency_new.py
@@ -13,7 +13,6 @@ from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.dependency_refactorin
 )
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.dependency_refactoring.types import (  # noqa: E501
     DependencyNode,
-    format_upstream_node_input,
 )
 
 # Use a short list of instruments that have valid YAML files for testing
@@ -35,159 +34,77 @@ def mock_valid_instruments():
         yield
 
 
-# Tests for node validation via format_upstream_node_input
+# ---------------------------------------------------------------------------
+# DependencyNode validation tests
+# ---------------------------------------------------------------------------
 def test_validate_node_valid_instrument():
     """Test that valid instrument nodes instantiate without error."""
-    format_upstream_node_input(
-        {
-            "upstream_source": "codice",
-            "upstream_data_type": "l1a",
-            "upstream_descriptor": "all",
-            "required": True,
-            "kickoff_job": True,
-        }
+    node = DependencyNode(source="codice", data_type="l1a", descriptor="all")
+    assert node.source == "codice"
+    assert node.data_type == "l1a"
+    assert node.descriptor == "all"
+
+    node = DependencyNode(
+        source="hi",
+        data_type="l1b",
+        descriptor="hi-counters-aggregated",
+        trigger_job=False,
     )
-    format_upstream_node_input(
-        {
-            "upstream_source": "hi",
-            "upstream_data_type": "l1b",
-            "upstream_descriptor": "hi-counters-aggregated",
-            "required": True,
-            "kickoff_job": False,
-        }
-    )
+    assert node.trigger_job is False
 
 
 def test_validate_node_valid_spice():
     """Test that valid SPICE nodes instantiate without error."""
-    format_upstream_node_input(
-        {
-            "upstream_source": "leapseconds",
-            "upstream_data_type": "spice",
-            "upstream_descriptor": "historical",
-            "required": True,
-            "kickoff_job": False,
-        }
+    node = DependencyNode(
+        source="leapseconds",
+        data_type="spice",
+        descriptor="historical",
+        trigger_job=False,
     )
+    assert node.source == "leapseconds"
+    assert node.trigger_job is False
 
 
-def test_validate_node_dict_valid():
-    """Test that valid dict-formatted nodes instantiate without error."""
-    format_upstream_node_input(
-        {
-            "upstream_source": "codice",
-            "upstream_data_type": "l1a",
-            "upstream_descriptor": "all",
-            "required": True,
-            "kickoff_job": False,
-        }
+def test_validate_node_with_defaults():
+    """Test that nodes with omitted optional fields use correct defaults."""
+    node = DependencyNode(
+        source="leapseconds", data_type="spice", descriptor="historical"
     )
+    assert node.required is True
+    assert node.trigger_job is True
+    assert node.dependency_query_time_range == []
 
 
-def test_validate_node_dict_with_defaults():
-    """Test that dict nodes with omitted optional fields instantiate without error."""
-    format_upstream_node_input(
-        {
-            "upstream_source": "leapseconds",
-            "upstream_data_type": "spice",
-            "upstream_descriptor": "historical",
-        }
+def test_validate_node_with_date_range():
+    """Test that nodes with date range instantiate without error."""
+    node = DependencyNode(
+        source="hi",
+        data_type="l1b",
+        descriptor="45sensor-goodtimes",
+        dependency_query_time_range=["-3p", "3p"],
     )
-
-
-def test_validate_node_dict_with_date_range():
-    """Test that dict nodes with date range instantiate without error."""
-    format_upstream_node_input(
-        {
-            "upstream_source": "hi",
-            "upstream_data_type": "l1b",
-            "upstream_descriptor": "45sensor-goodtimes",
-            "date_range": ["-3p", "3p"],
-        }
-    )
-
-
-def test_validate_node_dict_missing_required_key():
-    """Test that dict missing required key raises ValueError."""
-    with pytest.raises(ValueError, match="must contain keys"):
-        format_upstream_node_input(
-            {"upstream_source": "codice", "upstream_descriptor": "all"}
-        )
-
-
-def test_validate_node_not_list_or_dict():
-    """Test that non-dict raises ValueError."""
-    with pytest.raises(ValueError, match=r"Node must be a dict|must contain keys"):
-        format_upstream_node_input("not_a_dict")
-
-
-def test_validate_node_legacy_list_wrong_length():
-    """Test that dict missing required key raises ValueError."""
-    with pytest.raises(ValueError, match=r"Node must be a dict|must contain keys"):
-        format_upstream_node_input(
-            {
-                "upstream_source": "codice",
-                "upstream_data_type": "l1a",
-            }
-        )
+    assert node.dependency_query_time_range == ["-3p", "3p"]
 
 
 def test_validate_node_invalid_source():
     """Test that invalid source raises ValueError."""
     with pytest.raises(ValueError, match="Invalid data source"):
-        format_upstream_node_input(
-            {
-                "upstream_source": "invalid_source",
-                "upstream_data_type": "l1a",
-                "upstream_descriptor": "all",
-                "required": True,
-                "kickoff_job": True,
-            }
-        )
+        DependencyNode(source="invalid_source", data_type="l1a", descriptor="all")
 
 
 def test_validate_node_invalid_data_type():
     """Test that invalid data type raises ValueError."""
     with pytest.raises(ValueError, match="Invalid data type"):
-        format_upstream_node_input(
-            {
-                "upstream_source": "codice",
-                "upstream_data_type": "invalid_type",
-                "upstream_descriptor": "all",
-                "required": True,
-                "kickoff_job": True,
-            }
-        )
+        DependencyNode(source="codice", data_type="invalid_type", descriptor="all")
 
 
 def test_validate_node_empty_descriptor():
     """Test that empty descriptor raises ValueError."""
     with pytest.raises(ValueError, match="non-empty string"):
-        format_upstream_node_input(
-            {
-                "upstream_source": "codice",
-                "upstream_data_type": "l1a",
-                "upstream_descriptor": "",
-                "required": True,
-                "kickoff_job": True,
-            }
-        )
-
-
-def test_validate_node_dict_empty_descriptor():
-    """Test that dict with empty descriptor raises ValueError."""
-    with pytest.raises(ValueError, match="non-empty string"):
-        format_upstream_node_input(
-            {
-                "upstream_source": "codice",
-                "upstream_data_type": "l1a",
-                "upstream_descriptor": "",
-            }
-        )
+        DependencyNode(source="codice", data_type="l1a", descriptor="")
 
 
 # ---------------------------------------------------------------------------
-# _validate_date_range tests
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "dependency_query_time_range",
@@ -357,19 +274,19 @@ def test_swe_dependency_config():
     assert l0_upstream_dependency.data_type == "l0"
     assert l0_upstream_dependency.descriptor == "raw"
     assert l0_upstream_dependency.required is True
-    assert l0_upstream_dependency.kickoff_job is True
+    assert l0_upstream_dependency.trigger_job is True
     assert l0_upstream_dependency.dependency_query_time_range == []
 
     assert leapseconds_upstream_dependency.source == "leapseconds"
     assert leapseconds_upstream_dependency.data_type == "spice"
     assert leapseconds_upstream_dependency.descriptor == "historical"
     assert leapseconds_upstream_dependency.required is True
-    assert leapseconds_upstream_dependency.kickoff_job is False
+    assert leapseconds_upstream_dependency.trigger_job is False
     assert leapseconds_upstream_dependency.dependency_query_time_range == []
 
     assert spacecraft_clock_upstream_dependency.source == "spacecraft_clock"
     assert spacecraft_clock_upstream_dependency.data_type == "spice"
     assert spacecraft_clock_upstream_dependency.descriptor == "historical"
     assert spacecraft_clock_upstream_dependency.required is True
-    assert spacecraft_clock_upstream_dependency.kickoff_job is False
+    assert spacecraft_clock_upstream_dependency.trigger_job is False
     assert spacecraft_clock_upstream_dependency.dependency_query_time_range == []

--- a/tests/lambda_endpoints/test_types.py
+++ b/tests/lambda_endpoints/test_types.py
@@ -8,7 +8,6 @@ from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.dependency_refactorin
     DependencyNode,
     ProcessingJobNode,
     TimeRange,
-    format_upstream_node_input,
     get_cadence_duration,
 )
 
@@ -63,7 +62,7 @@ def test_node_invalid_raises():
 def test_dependency_node_defaults():
     node = DependencyNode(source="mag", data_type="l1b", descriptor="norm")
     assert node.required is True
-    assert node.kickoff_job is True
+    assert node.trigger_job is True
     assert node.dependency_query_time_range == []
 
 
@@ -74,7 +73,7 @@ def test_dependency_node_non_boolean_required_raises():
 
 def test_dependency_node_non_boolean_kickoff_raises():
     with pytest.raises(ValueError, match="must be boolean"):
-        DependencyNode(source="swe", data_type="l1a", descriptor="sci", kickoff_job=1)
+        DependencyNode(source="swe", data_type="l1a", descriptor="sci", trigger_job=1)
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +148,7 @@ def test_dependency_node_serialize_roundtrip():
         data_type="l1b",
         descriptor="norm",
         required=False,
-        kickoff_job=True,
+        trigger_job=True,
         dependency_query_time_range=["-2d", "2d"],
     )
     serialized = node.serialize()
@@ -188,39 +187,6 @@ def test_processing_job_node_inherits_node_validation():
             descriptor="hist",
             time_span=TimeRange.from_string("20240101", "20240101"),
         )
-
-
-def test_format_upstream_node_input_basic():
-    result = format_upstream_node_input(
-        {
-            "upstream_source": "swe",
-            "upstream_data_type": "l0",
-            "upstream_descriptor": "raw",
-        }
-    )
-    assert isinstance(result, DependencyNode)
-    assert result.source == "swe"
-    assert result.data_type == "l0"
-    assert result.descriptor == "raw"
-    assert result.required is True
-    assert result.kickoff_job is True
-    assert result.dependency_query_time_range == []
-
-
-def test_format_upstream_node_input_optional_fields():
-    result = format_upstream_node_input(
-        {
-            "upstream_source": "mag",
-            "upstream_data_type": "l1a",
-            "upstream_descriptor": "norm",
-            "required": False,
-            "kickoff_job": False,
-            "date_range": ["-2d", "2d"],
-        }
-    )
-    assert result.required is False
-    assert result.kickoff_job is False
-    assert result.dependency_query_time_range == ["-2d", "2d"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Change Summary
closes #1360 

## Overview

<!--Add a list or paragraph giving an overview of your changes-->
This change was last minute decision. This is needed for long-term benefits. This change will improve and generalize dependency read in and connection in dagster so much easier. The `upstream_inputs` will become assets that will trigger potential job key in the yaml files. `job_ouputs` list is checking for any output files that can come from a job. 

In general, any batch job in SDC can produce 1-1 file per job or 1-many files per job.

If job is 1-1 file per job, dagster can continue materialize waiting asset when batch job succeed.

If job is 1-many files per job, we can set automation rule to be waiting for all expected output files or wait for any files from that job to kickoff next job. **Right now, we are using `outputs` for double checking if file was expected and log messages as needed for debugging.**

## Future Improvement

_Eg. **(l1a, all)** can produce one or more files based on what apid exists in L0 file, we can add required flag to `outputs` and set required flag to false which will tell dagster to not wait for all files to continue on next job. It will kickoff based on what files become available from that job. Now at higher data level, that may not be true. We may expect to get all files from certain job. That's when we can set required to true and it will tell dagster to look for all files before we can continue on next job._

We will add flag in the future if needed. In the future, if it becomes a need, `job_output` can become an asset in dagster which listens on dagster event to decide if dependency are met or not and job can be trigger.

This is high level summary of my understanding. @bryan-harter will be able to help with more details!

## File changes

<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- removed `upstream_` prefix. It worked nicely with DependencyNode.
- added `inputs` and `outputs`. inputs are upstream dependency needed for the job. outputs are files produced from the job.
- renamed `kickoff_job` to `trigger_job` line up with comments on documentation PR

## Testing

<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
I will update test later. Wanted to use this as platform to gather info.