### PR TITLE
I-ALiRT - Prepare SDS Account for NOAA VPC Peering

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,12 @@ if account_name == "backup":
     build_backup(app, env=env, source_account=source_account)
 else:
     # Deploy SDS resources. This is the default with no CLI context variables set.
-    build_sds(app, env=env, account_config=account_config)
+    smce_account_id = app.node.get_context("smce")["account"]
+    build_sds(
+        app,
+        env=env,
+        account_config=account_config,
+        smce_account_id=smce_account_id,
+    )
 
 app.synth()

--- a/cdk.json
+++ b/cdk.json
@@ -20,6 +20,10 @@
       "account": "012345678901",
       "source_account": "dev"
     },
+    "smce": {
+      "account": "301233867300",
+      "region": "us-west-2"
+    },
     "dev": {
       "account": "449431850278",
       "domain_name": "dev.imap-mission.com",

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -16,6 +16,8 @@ from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_secretsmanager as secretsmanager
 from constructs import Construct
 
+SMCE_VPC_CIDR = "10.0.0.0/8"
+
 
 class IalirtProcessing(Construct):
     """A processing system for I-ALiRT."""
@@ -94,6 +96,7 @@ class IalirtProcessing(Construct):
             ],  # LASP (used for testing only)
             "198.118.1.14/32": [7526],  # BlueNet (tlm relay)
             "193.174.22.3/32": [7564],  # Kiel
+            SMCE_VPC_CIDR: [7565],  # SMCE VPC — NOAA telemetry via VPC peering
             "185.83.168.248/32": [7566, 7567],  # UKSA
             "41.74.156.19/32": [7568],  # SANSA
             "41.74.156.20/32": [7568],  # SANSA

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -16,7 +16,7 @@ from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_secretsmanager as secretsmanager
 from constructs import Construct
 
-SMCE_VPC_CIDR = "10.0.0.0/8"
+SMCE_VPC_CIDR = "10.1.0.0/16"
 
 
 class IalirtProcessing(Construct):

--- a/sds_data_manager/utils/stackbuilder.py
+++ b/sds_data_manager/utils/stackbuilder.py
@@ -6,6 +6,7 @@ import imap_data_access
 from aws_cdk import App, Environment, Stack
 from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_rds as rds
 
@@ -46,6 +47,7 @@ def build_sds(
     scope: App,
     env: Environment,
     account_config: dict,
+    smce_account_id: str,
 ):
     """Build the entire SDS.
 
@@ -57,6 +59,8 @@ def build_sds(
         Account and region
     account_config : dict
         Account configuration (domain_name and other account specific configurations)
+    smce_account_id : str
+        AWS account ID of the SMCE account, read from cdk.json smce context.
 
     """
     networking_stack = Stack(scope, "NetworkingStack", env=env)
@@ -329,6 +333,19 @@ def build_sds(
 
     # I-ALiRT Stack
     ialirt_stack = Stack(scope, "IalirtStack", cross_region_references=True, env=env)
+
+    accepter_role = iam.Role(
+        ialirt_stack,
+        "SmcePeeringAccepterRole",
+        role_name="SmcePeeringAccepterRole",
+        assumed_by=iam.AccountPrincipal(smce_account_id),
+    )
+    accepter_role.add_to_policy(
+        iam.PolicyStatement(
+            actions=["ec2:AcceptVpcPeeringConnection"],
+            resources=["*"],
+        )
+    )
 
     ialirt_spice_lambda_layer = lambda_layer_construct.IMAPLambdaLayer(
         scope=ialirt_stack,


### PR DESCRIPTION
**Background**

  I-ALiRT needs to receive real-time NOAA telemetry from NOAA's N-Wave network. The architecture routes traffic through NASA's Science Mission Cloud Environment (SMCE) account:

  NOAA → IPSec VPN → SMCE VPC → VPC Peering → SDS VPC → I-ALiRT ECS

  This PR makes the SDS (dev) account ready to accept the VPC peering connection from the SMCE account. The SMCE stack itself (VPN + peering constructs) lives on the relay_test branch and will be
   deployed separately.

  **Changes**

  - stackbuilder.py — Adds SmcePeeringAccepterRole to IalirtStack. CloudFormation in the SMCE account will assume this role to auto-accept the VPC peering connection without manual intervention.
  - ialirt_processing_construct.py — Opens the I-ALiRT ECS security group to accept NOAA telemetry from the SMCE VPC (10.1.0.0/16) on TCP port 7565.
  - app.py — Reads the SMCE account ID from cdk.json smce context and passes it to build_sds to configure the accepter role's trust policy.
  - cdk.json — Adds the smce context block (account, region) consistent with existing dev/prod/backup structure.