### PR TITLE
Scheduled job permissions

### DIFF
--- a/sds_data_manager/constructs/scheduled_job_lambda.py
+++ b/sds_data_manager/constructs/scheduled_job_lambda.py
@@ -91,7 +91,12 @@ class ScheduledJobLambda(Construct):
         # and submit batch job
         lambda_policy = iam.PolicyStatement(
             effect=iam.Effect.ALLOW,
-            actions=["events:PutEvents", "batch:SubmitJob"],
+            actions=[
+                "events:PutEvents",
+                "batch:SubmitJob",
+                "batch:DescribeJobDefinitions",
+                "ecr:DescribeImages",
+            ],
             resources=[
                 "*",
             ],

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_glows_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_glows_dependencies.yaml
@@ -106,7 +106,7 @@ hist_spice: &hist_spice
     upstream_descriptor: hist
   - upstream_source: glows
     upstream_data_type: ancillary
-    upstream_descriptor: calibration-data
+    upstream_descriptor: l2-calibration
   - upstream_source: glows
     upstream_data_type: ancillary
     upstream_descriptor: l3-time-dep-bckgrd


### PR DESCRIPTION
# Change Summary

## Overview

* Updated ScheduledJobLambda to have the same permissions as the BatchStarterLambda so that GLOWS and Maps jobs can run
 
## File changes
* scheduled_job_lambda.py
