### PR TITLE
dependencies for lo/l1b/goodtimes

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -843,6 +843,8 @@ spacecraft_clock, spice, historical, lo, l1b, prostar, HARD_NO_TRIGGER, DOWNSTRE
 leapseconds, spice, historical, lo, l1b, prostar, HARD_NO_TRIGGER, DOWNSTREAM
 
 lo, l1b, histrates, lo, l1b, goodtimes, HARD, DOWNSTREAM
+lo, l1b, de, lo, l1b, goodtimes, HARD, DOWNSTREAM
+lo, l1b, nhk, lo, l1b, goodtimes, HARD, DOWNSTREAM
 leapseconds, spice, historical, lo, l1b, goodtimes, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1b, goodtimes, HARD_NO_TRIGGER, DOWNSTREAM
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
@@ -183,6 +183,17 @@ lo_esa_fit_factors: &lo_esa_fit_factors
     upstream_data_type: l1b
     upstream_descriptor: nhk
 
+(l1b, goodtimes):
+  - *spice_basic
+  - upstream_source: lo
+    upstream_data_type: l1b
+    upstream_descriptor: histrates
+  - upstream_source: lo
+    upstream_data_type: l1b
+    upstream_descriptor: de
+  - upstream_source: lo
+    upstream_data_type: l1b
+    upstream_descriptor: nhk
 # ======== Level L1C ========
 (l1c, pset):
   - *spice_common


### PR DESCRIPTION
# Change Summary

Closes #1374 

## Overview

The modified `lo/l1b/goodtimes` (already merged into `imap_processing`) depends on `lo/l1b/de` as well as `lo/l1b/nhk`.

Modified the corresponding `.yaml` as well.
