### PR TITLE
updated dependencies for lo/l1b/goodtimes (& bgrates)

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -845,6 +845,7 @@ leapseconds, spice, historical, lo, l1b, prostar, HARD_NO_TRIGGER, DOWNSTREAM
 lo, l1b, histrates, lo, l1b, goodtimes, HARD, DOWNSTREAM
 lo, l1b, de, lo, l1b, goodtimes, HARD, DOWNSTREAM
 lo, l1b, nhk, lo, l1b, goodtimes, HARD, DOWNSTREAM
+lo, ancillary, bg-rates-anti-ram-overrides, lo, l1b, goodtimes, SOFT_NO_TRIGGER, DOWNSTREAM
 repoint, repoint, historical, lo, l1b, goodtimes, HARD, DOWNSTREAM
 leapseconds, spice, historical, lo, l1b, goodtimes, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1b, goodtimes, HARD_NO_TRIGGER, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -849,11 +849,6 @@ repoint, repoint, historical, lo, l1b, goodtimes, HARD, DOWNSTREAM
 leapseconds, spice, historical, lo, l1b, goodtimes, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1b, goodtimes, HARD_NO_TRIGGER, DOWNSTREAM
 
-lo, l1b, histrates, lo, l1b, bgrates, HARD, DOWNSTREAM
-repoint, repoint, historical, lo, l1b, bgrates, HARD, DOWNSTREAM
-leapseconds, spice, historical, lo, l1b, bgrates, HARD_NO_TRIGGER, DOWNSTREAM
-spacecraft_clock, spice, historical, lo, l1b, bgrates, HARD_NO_TRIGGER, DOWNSTREAM
-
 lo, l1b, de, lo, l1c, pset, HARD, DOWNSTREAM
 lo, l1b, goodtimes, lo, l1c, pset, HARD, DOWNSTREAM
 lo, l1b, bgrates, lo, l1c, pset, HARD, DOWNSTREAM

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_config.csv
@@ -845,10 +845,12 @@ leapseconds, spice, historical, lo, l1b, prostar, HARD_NO_TRIGGER, DOWNSTREAM
 lo, l1b, histrates, lo, l1b, goodtimes, HARD, DOWNSTREAM
 lo, l1b, de, lo, l1b, goodtimes, HARD, DOWNSTREAM
 lo, l1b, nhk, lo, l1b, goodtimes, HARD, DOWNSTREAM
+repoint, repoint, historical, lo, l1b, goodtimes, HARD, DOWNSTREAM
 leapseconds, spice, historical, lo, l1b, goodtimes, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1b, goodtimes, HARD_NO_TRIGGER, DOWNSTREAM
 
 lo, l1b, histrates, lo, l1b, bgrates, HARD, DOWNSTREAM
+repoint, repoint, historical, lo, l1b, bgrates, HARD, DOWNSTREAM
 leapseconds, spice, historical, lo, l1b, bgrates, HARD_NO_TRIGGER, DOWNSTREAM
 spacecraft_clock, spice, historical, lo, l1b, bgrates, HARD_NO_TRIGGER, DOWNSTREAM
 

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
@@ -197,6 +197,9 @@ lo_esa_fit_factors: &lo_esa_fit_factors
   - upstream_source: repoint
     upstream_data_type: repoint
     upstream_descriptor: historical
+  - upstream_source: lo
+    upstream_data_type: ancillary
+    upstream_descriptor: bg-rates-anti-ram-overrides
 
 # ======== Level L1C ========
 (l1c, pset):

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
@@ -194,6 +194,18 @@ lo_esa_fit_factors: &lo_esa_fit_factors
   - upstream_source: lo
     upstream_data_type: l1b
     upstream_descriptor: nhk
+  - upstream_source: repoint
+    upstream_data_type: repoint
+    upstream_descriptor: historical
+
+(l1b, bgrates):
+  - *spice_basic
+  - upstream_source: lo
+    upstream_data_type: l1b
+    upstream_descriptor: histrates
+  - upstream_source: repoint
+    upstream_data_type: repoint
+    upstream_descriptor: historical
 # ======== Level L1C ========
 (l1c, pset):
   - *spice_common

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/dependency_refactoring/dependencies/imap_lo_dependencies.yaml
@@ -198,14 +198,6 @@ lo_esa_fit_factors: &lo_esa_fit_factors
     upstream_data_type: repoint
     upstream_descriptor: historical
 
-(l1b, bgrates):
-  - *spice_basic
-  - upstream_source: lo
-    upstream_data_type: l1b
-    upstream_descriptor: histrates
-  - upstream_source: repoint
-    upstream_data_type: repoint
-    upstream_descriptor: historical
 # ======== Level L1C ========
 (l1c, pset):
   - *spice_common


### PR DESCRIPTION
Closes #1379 

The `yaml` was missing one product entirely. Added it to make it consistent with the `.csv`.