### PR TITLE
l3 cron jobs unique constraint fix

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/__init__.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/__init__.py
@@ -9,3 +9,46 @@ NON_DAILY_INSTRUMENTS = ["idex"]
 FIRST_MAP_START_DATE = datetime.datetime(2026, 1, 17, tzinfo=datetime.timezone.utc)
 
 LAUNCH_DATE = datetime.datetime(2025, 9, 24, tzinfo=datetime.timezone.utc)
+
+L3_CRON_JOBS = [
+    (
+        "glows",
+        "l3b",
+        "ion-rate-profile",
+    ),
+    (
+        "lo",
+        "l3",
+        "all-maps",
+    ),
+    (
+        "hi",
+        "l3",
+        "sp-maps",
+    ),
+    (
+        "hi",
+        "l3",
+        "hic-maps",
+    ),
+    (
+        "ultra",
+        "l3",
+        "u45-maps",
+    ),
+    (
+        "ultra",
+        "l3",
+        "u90-maps",
+    ),
+    (
+        "ultra",
+        "l3",
+        "ulc-sp-maps",
+    ),
+    (
+        "ultra",
+        "l3",
+        "ulc-nsp-maps",
+    ),
+]

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -28,6 +28,7 @@ from ..database import database as db
 from ..database import models
 from . import (
     FIRST_MAP_START_DATE,
+    L3_CRON_JOBS,
     LAUNCH_DATE,
     REPOINT_DEPENDENT_INSTRUMENTS,
     VALID_CADENCE_STRS,
@@ -56,49 +57,6 @@ BATCH_JOB_RETRY_STRATEGY = {
 }
 # Create an sqs client
 SQS_CLIENT = boto3.client("sqs", region_name="us-west-2")
-
-L3_CRON_JOBS = [
-    (
-        "glows",
-        "l3b",
-        "ion-rate-profile",
-    ),
-    (
-        "lo",
-        "l3",
-        "all-maps",
-    ),
-    (
-        "hi",
-        "l3",
-        "sp-maps",
-    ),
-    (
-        "hi",
-        "l3",
-        "hic-maps",
-    ),
-    (
-        "ultra",
-        "l3",
-        "u45-maps",
-    ),
-    (
-        "ultra",
-        "l3",
-        "u90-maps",
-    ),
-    (
-        "ultra",
-        "l3",
-        "ulc-sp-maps",
-    ),
-    (
-        "ultra",
-        "l3",
-        "ulc-nsp-maps",
-    ),
-]
 
 
 def get_container_image_digest(job_definition: str):

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
@@ -57,6 +57,49 @@ BATCH_JOB_RETRY_STRATEGY = {
 # Create an sqs client
 SQS_CLIENT = boto3.client("sqs", region_name="us-west-2")
 
+L3_CRON_JOBS = [
+    (
+        "glows",
+        "l3b",
+        "ion-rate-profile",
+    ),
+    (
+        "lo",
+        "l3",
+        "all-maps",
+    ),
+    (
+        "hi",
+        "l3",
+        "sp-maps",
+    ),
+    (
+        "hi",
+        "l3",
+        "hic-maps",
+    ),
+    (
+        "ultra",
+        "l3",
+        "u45-maps",
+    ),
+    (
+        "ultra",
+        "l3",
+        "u90-maps",
+    ),
+    (
+        "ultra",
+        "l3",
+        "ulc-sp-maps",
+    ),
+    (
+        "ultra",
+        "l3",
+        "ulc-nsp-maps",
+    ),
+]
+
 
 def get_container_image_digest(job_definition: str):
     """Get the container image digest.
@@ -484,6 +527,15 @@ def try_to_submit_job(
     # information here and not in indexer.py to avoid race conditions where the image
     # could change during job execution.
     container_image_digest = get_container_image_digest(job_definition)
+
+    # Certain l3 jobs do not run through the batch starter but call
+    # try_to_submit_job directly from the Schedule Jobs lambda. These jobs gather the
+    # dependencies within the jobs themselves so the dependency hash does not encompass
+    # the true dependencies for the job. For these jobs, do not add the dependency
+    # hash to the processing job table because it could undesirably cause a job to
+    # be considered a duplicate even though it may not be.
+    if (instrument, data_level, descriptor) in L3_CRON_JOBS:
+        dep_hash = None
 
     # All of our upstream requirements have been met.
     # Try to insert a record into the Processing Jobs table

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -2705,3 +2705,28 @@ def test_get_container_image_job_deff_not_found():
                 batch_starter.get_container_image_digest("ProcessingJob-swe")
         job_definition = "ProcessingJob-swe"
         batch_starter.get_container_image_digest(job_definition)
+
+
+def test_try_to_submit_job_l3_cron_job(session, batch_client, ecr_client):
+    """Test that the L3 cron job is submitted with the correct parameters."""
+    # Call the function to submit the L3 cron job
+    batch_starter.try_to_submit_job(
+        session,
+        job_info={
+            "data_source": "glows",
+            "data_type": "l3b",
+            "descriptor": "ion-rate-profile",
+        },
+        start_date="20240101",
+        version="v001",
+        serialized_dependencies="testing123",
+    )
+    # Verify there is a new processing job record
+    processing_job_record = session.query(models.ProcessingJob).first()
+    assert processing_job_record.instrument == "glows"
+    assert processing_job_record.data_level == "l3b"
+    # The dependency hash should be None for l3 cron jobs to allow for multiple runs
+    # with the same dependencies. The schedule lambda cron jobs gathers the
+    # dependencies within the job itself so we dont know at submission time whether the
+    # Job is a duplicate or not.
+    assert processing_job_record.dependency_hash is None

--- a/tests/lambda_endpoints/test_batch_starter.py
+++ b/tests/lambda_endpoints/test_batch_starter.py
@@ -2726,7 +2726,7 @@ def test_try_to_submit_job_l3_cron_job(session, batch_client, ecr_client):
     assert processing_job_record.instrument == "glows"
     assert processing_job_record.data_level == "l3b"
     # The dependency hash should be None for l3 cron jobs to allow for multiple runs
-    # with the same dependencies. The schedule lambda cron jobs gathers the
-    # dependencies within the job itself so we dont know at submission time whether the
-    # Job is a duplicate or not.
+    # with the same dependencies. The schedule lambda cron jobs gather the
+    # dependencies within the job itself so we don't know at submission time whether the
+    # job is a duplicate or not.
     assert processing_job_record.dependency_hash is None


### PR DESCRIPTION
# Change Summary

## Overview

Fix the unique constraint in the processing job table for l3 cron jobs. 

## File changes
sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/batch_starter.py
- Null out any dependency hash for cron jobs. 

