### PR TITLE
Fix idex l0 assets

### DIFF
--- a/sds_data_manager/orchestration/idex.py
+++ b/sds_data_manager/orchestration/idex.py
@@ -1,4 +1,6 @@
 import datetime
+import os
+
 import pandas as pd
 from dagster import (
     SensorResult,
@@ -110,13 +112,15 @@ def idex_l0_raw(context: AssetExecutionContext):
             # Dedup: keep highest version per file base path (strip version suffix)
             best: dict[str, models.IDEXL0Files] = {}
             for rec in records:
+                # Get the basename from the filepath
+                filename = os.path.basename(rec.file_path)
+                base = filename.rsplit("_", 1)[0]  # strip "_v001.pkts"
                 # "imap_idex_l0_raw_20260408_v001.pkts" -> "imap_idex_l0_raw_20260408"
-                base = rec.file_path.rsplit("_", 1)[0]  # strip "_v001.pkts"
                 if base not in best or rec.version > best[base].version:
                     best[base] = rec
 
             for rec in records:
-                files.append(rec.file_path)
+                files.append(filename)
                 versions.append(int(rec.version[1:]))
 
             materialization = get_materialization_result(context,


### PR DESCRIPTION
# Change Summary

## Overview
I noticed the idex l1a jobs were failing with a file not found error. 

e.g.

`FileNotFoundError: [Errno 2] No such file or directory: '/app/data/imap/idex/l0/2026/04/imap/idex/l0/2026/04/imap_idex_l0_raw_20260430_v001.pkts'`


## File changes
The fix was to only materialize the filenames and not the filepaths. This follows other instruments. 

