### PR TITLE
ENH: adding support for mission-wide data release reprocessing trigger

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -238,10 +238,8 @@ def get_latest_ancillary_files(
         ),
     )
 
-    # Combine
-    combined = union_all(with_end_date_query, no_end_date_query).order_by(
-        text("file_path")
-    )
+    # Combine — ORDER BY positional index works across all DB backends for UNION ALL
+    combined = union_all(with_end_date_query, no_end_date_query).order_by(text("1"))
 
     latest_ancillary_files = [row[0] for row in session.execute(combined).fetchall()]
 

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -106,98 +106,29 @@ def validate_query_params(event):
 
 
 def query_latest_science_files(
-    session, instrument, start_date, end_date, science_files_to_exclude=None
+    session,
+    instrument,
+    start_date,
+    end_date,
+    release_number,
+    science_files_to_exclude=None,
 ):
     """Query for the latest-version science file paths matching given criteria."""
     science_table = models.ScienceFiles
 
-    # Check if any file in the range has a non-null repointing
-    has_repointing = (
-        session.query(science_table)
-        .filter(
-            science_table.instrument == instrument,
-            science_table.start_date >= start_date,
-            science_table.start_date <= end_date,
-            science_table.repointing.isnot(None),
-        )
-        .first()
-        is not None
+    # query for release number for the given instrument and date range
+    latest_science_files = session.query(science_table).filter(
+        science_table.instrument == instrument,
+        science_table.start_date >= start_date,
+        science_table.start_date <= end_date,
+        science_table.release_number == release_number,
     )
 
-    if has_repointing:
-        max_ver_subq = (
-            session.query(
-                science_table.instrument,
-                science_table.data_level,
-                science_table.descriptor,
-                science_table.start_date,
-                science_table.repointing,
-                func.max(science_table.version).label("max_version"),
-            )
-            .group_by(
-                science_table.instrument,
-                science_table.data_level,
-                science_table.descriptor,
-                science_table.start_date,
-                science_table.repointing,
-            )
-            .subquery()
-        )
-        latest_science_files = (
-            session.query(science_table)
-            .join(
-                max_ver_subq,
-                (science_table.instrument == max_ver_subq.c.instrument)
-                & (science_table.data_level == max_ver_subq.c.data_level)
-                & (science_table.descriptor == max_ver_subq.c.descriptor)
-                & (science_table.start_date == max_ver_subq.c.start_date)
-                & (science_table.repointing == max_ver_subq.c.repointing)
-                & (science_table.version == max_ver_subq.c.max_version),
-            )
-            .filter(
-                science_table.instrument == instrument,
-                science_table.start_date >= start_date,
-                science_table.start_date <= end_date,
-            )
-        )
-    else:
-        max_ver_subq = (
-            session.query(
-                science_table.instrument,
-                science_table.data_level,
-                science_table.descriptor,
-                science_table.start_date,
-                func.max(science_table.version).label("max_version"),
-            )
-            .group_by(
-                science_table.instrument,
-                science_table.data_level,
-                science_table.descriptor,
-                science_table.start_date,
-            )
-            .subquery()
-        )
-        latest_science_files = (
-            session.query(science_table)
-            .join(
-                max_ver_subq,
-                (science_table.instrument == max_ver_subq.c.instrument)
-                & (science_table.data_level == max_ver_subq.c.data_level)
-                & (science_table.descriptor == max_ver_subq.c.descriptor)
-                & (science_table.start_date == max_ver_subq.c.start_date)
-                & (science_table.version == max_ver_subq.c.max_version),
-            )
-            .filter(
-                science_table.instrument == instrument,
-                science_table.start_date >= start_date,
-                science_table.start_date <= end_date,
-            )
-        )
     if science_files_to_exclude:
         latest_science_files = latest_science_files.filter(
             ~science_table.file_path.in_(science_files_to_exclude)
         )
-    results = list(latest_science_files)
+    results = list(latest_science_files.all())
     logger.info(f"Found {len(results)} science file(s) for instrument={instrument}")
     return results
 
@@ -312,18 +243,21 @@ def get_latest_ancillary_files(
         text("file_path")
     )
 
+    latest_ancillary_files = [row[0] for row in session.execute(combined).fetchall()]
+
     # Now exclude any files in the exclude list
     if ancillary_files_to_exclude:
-        combined = combined.where(~combined.c.file_path.in_(ancillary_files_to_exclude))
+        latest_ancillary_files = [
+            p for p in latest_ancillary_files if p not in ancillary_files_to_exclude
+        ]
 
-    ancillary_file_paths = [row[0] for row in session.execute(combined).fetchall()]
-    if not ancillary_file_paths:
+    if not latest_ancillary_files:
         logger.info(f"Found 0 ancillary file(s) for instrument={instrument}")
         return []
 
     results = list(
         session.query(models.AncillaryFiles).filter(
-            models.AncillaryFiles.file_path.in_(ancillary_file_paths)
+            models.AncillaryFiles.file_path.in_(latest_ancillary_files)
         )
     )
     logger.info(f"Found {len(results)} ancillary file(s) for instrument={instrument}")
@@ -381,9 +315,10 @@ def release_type_handler(query_params):
     start_date = datetime.datetime.strptime(query_params["start_date"], "%Y%m%d")
     end_date = datetime.datetime.strptime(query_params["end_date"], "%Y%m%d")
     exclude_file = query_params.get("exclude_file", None)
+    release_number = int(query_params["release_number"])
+    instrument = query_params["instrument"]
 
     with db.Session() as session:
-        # Query for withhold files to exclude from release.
         science_files_to_exclude = []
         ancillary_files_to_exclude = []
 
@@ -394,26 +329,47 @@ def release_type_handler(query_params):
 
         science_files_to_update = query_latest_science_files(
             session,
-            query_params["instrument"],
+            instrument,
             start_date,
             end_date,
+            release_number,
             science_files_to_exclude=science_files_to_exclude,
         )
 
         ancillary_files_to_update = get_latest_ancillary_files(
             session,
-            query_params["instrument"],
+            instrument,
             start_date,
             end_date,
             ancillary_files_to_exclude=ancillary_files_to_exclude,
         )
 
-        # Directly update ORM objects
+        if not science_files_to_update and not ancillary_files_to_update:
+            return {
+                "statusCode": 400,
+                "body": json.dumps(
+                    "No files to release for the specified "
+                    f"{instrument}, {start_date} to {end_date}, and "
+                    f"{release_number}."
+                ),
+            }
+
         for obj in science_files_to_update:
             obj.released = True
+
         for obj in ancillary_files_to_update:
             obj.released = True
+
         session.commit()
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                f"Successfully released "
+                f"{len(science_files_to_update)} science files and "
+                f"{len(ancillary_files_to_update)} ancillary files."
+            ),
+        }
 
 
 def early_release_type_handler(query_params):
@@ -421,6 +377,12 @@ def early_release_type_handler(query_params):
     manifest_file = query_params["manifest_file"]
 
     science_files, ancillary_files = download_read_file(manifest_file)
+
+    if not science_files and not ancillary_files:
+        return {
+            "statusCode": 400,
+            "body": json.dumps("No files found in the manifest file."),
+        }
 
     with db.Session() as session:
         if science_files:
@@ -442,8 +404,7 @@ def early_release_type_handler(query_params):
         session.commit()
 
     logger.info(
-        f"Early released "
-        f"{len(science_files)} science files and "
+        f"Early released {len(science_files)} science files and "
         f"{len(ancillary_files)} ancillary files."
     )
 
@@ -462,6 +423,14 @@ def unrelease_type_handler(query_params):
     manifest_file = query_params["manifest_file"]
 
     science_files, ancillary_files = download_read_file(manifest_file)
+
+    if not science_files and not ancillary_files:
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                "The manifest file does not contain any science or ancillary files."
+            ),
+        }
 
     with db.Session() as session:
         if science_files:
@@ -483,8 +452,7 @@ def unrelease_type_handler(query_params):
         session.commit()
 
     logger.info(
-        f"Unreleased "
-        f"{len(science_files)} science files and "
+        f"Unreleased {len(science_files)} science files and "
         f"{len(ancillary_files)} ancillary files."
     )
 
@@ -496,6 +464,68 @@ def unrelease_type_handler(query_params):
             f"{len(ancillary_files)} ancillary files."
         ),
     }
+
+
+def reprocess_type_handler(query_params):
+    """Update global release table with the new release number.
+
+    This table update is monitored by Dagster sensor. When this table is
+    updated, it will trigger reprocessing for the new release number.
+    """
+    release_number = int(query_params["release_number"])
+
+    with db.Session() as session:
+        # First check that there is no existing DB record with
+        # release number.
+        existing_record = (
+            session.query(models.GlobalRelease)
+            .filter(models.GlobalRelease.release_number == release_number)
+            .first()
+        )
+
+        if existing_record:
+            return {
+                "statusCode": 400,
+                "body": json.dumps(
+                    f"Release number {release_number} already exists. "
+                    "Please choose a release number that has not been used before."
+                ),
+            }
+
+        # If new release number is not increment by 1 from the latest release number.
+        latest_release = (
+            session.query(models.GlobalRelease)
+            .order_by(models.GlobalRelease.release_number.desc())
+            .first()
+        )
+
+        if latest_release and release_number != latest_release.release_number + 1:
+            return {
+                "statusCode": 400,
+                "body": json.dumps(
+                    f"Release number {release_number} is not the next increment "
+                    f"from the latest release number "
+                    f"{latest_release.release_number}. "
+                    "Please choose the next sequential release number."
+                ),
+            }
+
+        # Add to table with the new release number and update the timestamp.
+        new_release = models.GlobalRelease(
+            release_number=release_number,
+            updated_date=datetime.datetime.utcnow(),
+        )
+
+        session.add(new_release)
+        session.commit()
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                f"Successfully created release number {release_number}. "
+                "Dagster reprocessing will be triggered automatically."
+            ),
+        }
 
 
 def lambda_handler(event, context):
@@ -537,14 +567,19 @@ def lambda_handler(event, context):
     release_type = query_validation["data"]["release_type"]
     query_params = query_validation["data"]["query_params"]
 
-    if release_type == "release":
-        release_type_handler(query_params)
-    elif release_type == "early-release":
-        early_release_type_handler(query_params)
-    elif release_type == "unrelease":
-        unrelease_type_handler(query_params)
-
-    return {
-        "statusCode": 200,
-        "body": json.dumps(f"Successful {release_type} "),
+    handler_map = {
+        "release": release_type_handler,
+        "early-release": early_release_type_handler,
+        "unrelease": unrelease_type_handler,
+        "reprocess": reprocess_type_handler,
     }
+
+    handler = handler_map.get(release_type)
+
+    if handler is None:
+        return {
+            "statusCode": 400,
+            "body": json.dumps(f"Invalid release type: {release_type}"),
+        }
+
+    return handler(query_params)

--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/release_api.py
@@ -105,7 +105,7 @@ def validate_query_params(event):
     }
 
 
-def query_latest_science_files(
+def query_releasable_science_files(
     session,
     instrument,
     start_date,
@@ -113,7 +113,20 @@ def query_latest_science_files(
     release_number,
     science_files_to_exclude=None,
 ):
-    """Query for the latest-version science file paths matching given criteria."""
+    """Query releaseable science files for given release number.
+
+    At every mission wide release, all data that will be released
+    to public should have vRRR.000. Eg. If release 1, all data
+    since launch will now have v001.000. If release 2,
+    all data will have v002.000 and so on.
+
+    In between public release version, version MMM will be used to
+    track updates to intermediate data. eg. After public
+    release 1, data can have v001.001 or v001.012 and so on
+    indicating that data was reprocessed 1 or 12 times respectively
+    since release 1, due to updates, such as input data changed
+    or processing code changed.
+    """
     science_table = models.ScienceFiles
 
     # query for release number for the given instrument and date range
@@ -122,6 +135,7 @@ def query_latest_science_files(
         science_table.start_date >= start_date,
         science_table.start_date <= end_date,
         science_table.release_number == release_number,
+        science_table.data_version == 0,
     )
 
     if science_files_to_exclude:
@@ -325,7 +339,7 @@ def release_type_handler(query_params):
                 exclude_file
             )
 
-        science_files_to_update = query_latest_science_files(
+        science_files_to_update = query_releasable_science_files(
             session,
             instrument,
             start_date,

--- a/tests/lambda_endpoints/test_release_api.py
+++ b/tests/lambda_endpoints/test_release_api.py
@@ -1,18 +1,7 @@
-"""Integration tests for the Release API.
-
-These tests verify the six core release behaviors against a live in-memory DB:
-
-Test Case 1  release (no descriptor)  — all matching instrument+date files released
-Test Case 2  early-release
-Test Case 3  unrelease
-Test Case 4  repoint files for a single day
-Test Case 5  ancillary files query
-"""
+"""Integration tests for the Release API."""
 
 import datetime
 from unittest.mock import patch
-
-import pytest
 
 from sds_data_manager.lambda_code.SDSCode.api_lambdas import release_api
 from sds_data_manager.lambda_code.SDSCode.database import models
@@ -42,6 +31,7 @@ def _science(
     descriptor="hk",
     start_date="20250115",
     released=False,
+    release_number=0,
 ):
     session.add(
         models.ScienceFiles(
@@ -50,7 +40,8 @@ def _science(
             data_level="l0",
             descriptor=descriptor,
             start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
-            version="v001",
+            data_version=1,
+            release_number=release_number,
             extension="pkts",
             released=released,
             ingestion_date=datetime.datetime(
@@ -61,12 +52,45 @@ def _science(
     session.commit()
 
 
+def _ancillary(
+    session,
+    *,
+    file_path,
+    instrument="swe",
+    descriptor="l1b-in-flight-cal",
+    start_date="20260413",
+    end_date=None,
+    version="v001",
+    released=False,
+):
+    """Insert a single AncillaryFiles row and commit."""
+    session.add(
+        models.AncillaryFiles(
+            file_path=file_path,
+            instrument=instrument,
+            descriptor=descriptor,
+            start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
+            end_date=(
+                datetime.datetime.strptime(end_date, "%Y%m%d") if end_date else None
+            ),
+            version=version,
+            extension="csv",
+            released=released,
+            ingestion_date=datetime.datetime(2026, 4, 14, 0, 0, 0),
+        )
+    )
+    session.commit()
+
+
 # ---------------------------------------------------------------------------
-# Test Case 1  release — all files for instrument + date range
+#   release — all files for instrument + date range + release number
 # ---------------------------------------------------------------------------
 
 
-def test_release_all_files_in_date_range(session):
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.api_lambdas.release_api.download_read_file"
+)
+def test_release_all_files_in_date_range(mock_download_read_file, session):
     """release_type=release with no descriptor releases every matching file.
 
     Two files for the target instrument within the date range and one file
@@ -74,25 +98,35 @@ def test_release_all_files_in_date_range(session):
     """
     _science(
         session,
-        file_path="imap/hit/l0/imap_hit_l0_hk_20250110_v001.pkts",
+        file_path="imap/hit/l0/imap_hit_l0_hk_20250110_v001.001.pkts",
         instrument="hit",
         descriptor="hk",
         start_date="20250110",
+        release_number=1,
     )
     _science(
         session,
-        file_path="imap/hit/l0/imap_hit_l0_sci_20250120_v001.pkts",
+        file_path="imap/hit/l0/imap_hit_l0_sci_20250120_v001.001.pkts",
         instrument="hit",
         descriptor="sci",
         start_date="20250120",
+        release_number=1,
     )
     _science(
         session,
-        file_path="imap/hit/l0/imap_hit_l0_hk_20250201_v001.pkts",
+        file_path="imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts",
         instrument="hit",
         descriptor="hk",
         start_date="20250201",
+        release_number=0,
     )  # outside range
+
+    # Provide the manifest file with the two in-range files
+    science_files = [
+        "imap/hit/l0/imap_hit_l0_hk_20250110_v001.001.pkts",
+    ]
+    ancillary_files = []
+    mock_download_read_file.return_value = (science_files, ancillary_files)
 
     params = {
         "instrument": "hit",
@@ -100,6 +134,7 @@ def test_release_all_files_in_date_range(session):
         "end_date": "20250131",
         "release_type": "release",
         "release_number": "1",
+        "exclude_file": "some_file.txt",
     }
     result = release_api.lambda_handler(
         event=_build_event(params),
@@ -109,189 +144,37 @@ def test_release_all_files_in_date_range(session):
     assert result["statusCode"] == 200
 
     rows = {r.file_path: r.released for r in session.query(models.ScienceFiles).all()}
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.pkts"] is True, (
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.001.pkts"] is False, (
+        "Excluded in-range file should not be released"
+    )
+    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.001.pkts"] is True, (
+        "Non-excluded in-range file should be released"
+    )
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts"] is False, (
+        "Out-of-range file must stay unreleased"
+    )
+
+    # Now test without exclude file.
+    params.pop("exclude_file")
+    result = release_api.lambda_handler(
+        event=_build_event(params),
+        context={},
+    )
+    assert result["statusCode"] == 200
+    rows = {r.file_path: r.released for r in session.query(models.ScienceFiles).all()}
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.001.pkts"] is True, (
         "In-range file should be released"
     )
-    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.pkts"] is True, (
+    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.001.pkts"] is True, (
         "In-range file should be released"
     )
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v001.pkts"] is False, (
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts"] is False, (
         "Out-of-range file must stay unreleased"
     )
 
 
 # ---------------------------------------------------------------------------
-# Test Case 2  early-release
-# ---------------------------------------------------------------------------
-
-
-@patch(
-    "sds_data_manager.lambda_code.SDSCode.api_lambdas.release_api.download_read_file"
-)
-def test_early_release(mock_download_read_file, session):
-    # Provide the manifest file with the two in-range files
-    science_files = [
-        "imap/hit/l0/imap_hit_l0_hk_20250110_v001.pkts",
-        "imap/hit/l0/imap_hit_l0_sci_20250120_v001.pkts",
-    ]
-    ancillary_files = []
-    mock_download_read_file.return_value = (science_files, ancillary_files)
-
-    _science(
-        session,
-        file_path="imap/hit/l0/imap_hit_l0_hk_20250110_v001.pkts",
-        instrument="hit",
-        descriptor="hk",
-        start_date="20250110",
-    )
-    _science(
-        session,
-        file_path="imap/hit/l0/imap_hit_l0_sci_20250120_v001.pkts",
-        instrument="hit",
-        descriptor="sci",
-        start_date="20250120",
-    )
-    _science(
-        session,
-        file_path="imap/hit/l0/imap_hit_l0_hk_20250201_v001.pkts",
-        instrument="hit",
-        descriptor="hk",
-        start_date="20250201",
-    )
-
-    manifest_file = "s3://dummy-bucket/manifest.txt"
-    result = release_api.lambda_handler(
-        event=_build_event(
-            {
-                "release_type": "early-release",
-                "manifest_file": manifest_file,
-            }
-        ),
-        context={},
-    )
-
-    assert result["statusCode"] == 200
-
-    rows = {r.file_path: r.released for r in session.query(models.ScienceFiles).all()}
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.pkts"] is True
-    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.pkts"] is True
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v001.pkts"] is False
-
-
-# ---------------------------------------------------------------------------
-# Test Case 3  unrelease
-# ---------------------------------------------------------------------------
-
-
-@patch(
-    "sds_data_manager.lambda_code.SDSCode.api_lambdas.release_api.download_read_file"
-)
-def test_unrelease_all_files_in_date_range(mock_download_read_file, session):
-    # Provide the manifest file with the two in-range files
-    science_files = [
-        "imap/hit/l0/imap_hit_l0_hk_20250110_v001.pkts",
-        "imap/hit/l0/imap_hit_l0_sci_20250120_v001.pkts",
-    ]
-    ancillary_files = []
-    mock_download_read_file.return_value = (science_files, ancillary_files)
-
-    _science(
-        session,
-        file_path="imap/hit/l0/imap_hit_l0_hk_20250110_v001.pkts",
-        instrument="hit",
-        descriptor="hk",
-        start_date="20250110",
-        released=True,
-    )
-    _science(
-        session,
-        file_path="imap/hit/l0/imap_hit_l0_sci_20250120_v001.pkts",
-        instrument="hit",
-        descriptor="sci",
-        start_date="20250120",
-        released=True,
-    )
-    _science(
-        session,
-        file_path="imap/hit/l0/imap_hit_l0_hk_20250201_v001.pkts",
-        instrument="hit",
-        descriptor="hk",
-        start_date="20250201",
-        released=True,
-    )  # outside range
-
-    manifest_file = "s3://dummy-bucket/manifest.txt"
-    result = release_api.lambda_handler(
-        event=_build_event(
-            {
-                "release_type": "unrelease",
-                "manifest_file": manifest_file,
-            }
-        ),
-        context={},
-    )
-
-    assert result["statusCode"] == 200
-
-    rows = {r.file_path: r.released for r in session.query(models.ScienceFiles).all()}
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.pkts"] is False, (
-        "In-range file must be unreleased"
-    )
-    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.pkts"] is False, (
-        "In-range file must be unreleased"
-    )
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v001.pkts"] is True, (
-        "Out-of-range file must remain released"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test Case 4  repoint files for a single day
-# ---------------------------------------------------------------------------
-
-
-def test_release_repoint_files_date_range(session):
-    """Test multiple repoint files for a single day."""
-    # April 7th, Hi has three repoint files with different repointing and version
-    files = [
-        ("imap_hi_l1a_45sensor-hk_20260407-repoint00209_v001.cdf", 209, "v001"),
-        ("imap_hi_l1a_45sensor-hk_20260407-repoint00210_v002.cdf", 210, "v002"),
-        ("imap_hi_l1a_45sensor-hk_20260407-repoint00211_v003.cdf", 211, "v003"),
-    ]
-    for file_path, repointing, version in files:
-        session.add(
-            models.ScienceFiles(
-                file_path=file_path,
-                instrument="hi",
-                data_level="l1a",
-                descriptor="45sensor-hk",
-                start_date=datetime.datetime.strptime("20260407", "%Y%m%d"),
-                repointing=repointing,
-                version=version,
-                extension="cdf",
-                released=False,
-                ingestion_date=datetime.datetime(2026, 4, 8, 0, 0, 0),
-            )
-        )
-    session.commit()
-
-    # Query for all files on this date
-    results = release_api.query_latest_science_files(
-        session,
-        instrument="hi",
-        start_date=datetime.datetime.strptime("20260407", "%Y%m%d"),
-        end_date=datetime.datetime.strptime("20260407", "%Y%m%d"),
-    )
-    file_paths = sorted([obj.file_path for obj in results])
-    assert file_paths == [
-        "imap_hi_l1a_45sensor-hk_20260407-repoint00209_v001.cdf",
-        "imap_hi_l1a_45sensor-hk_20260407-repoint00210_v002.cdf",
-        "imap_hi_l1a_45sensor-hk_20260407-repoint00211_v003.cdf",
-    ], f"Expected all repoint files, got: {file_paths}"
-
-
-# ---------------------------------------------------------------------------
-# Test Case 5  ancillary files released from manifest
+#  ancillary files release
 # ---------------------------------------------------------------------------
 def test_release_ancillary_files_in_date_range(session):
     """Ancillary files in manifest are released properly."""
@@ -325,6 +208,19 @@ def test_release_ancillary_files_in_date_range(session):
     # Add an out-of-range ancillary file (should not be released)
     session.add(
         models.AncillaryFiles(
+            file_path="imap/ancillary/codice/imap_codice_l1a-sci-lut_20260403_v001.json",
+            instrument="codice",
+            descriptor="l1a-sci-lut",
+            start_date=datetime.datetime.strptime("20260403", "%Y%m%d"),
+            end_date=None,
+            version="v001",
+            extension="json",
+            released=False,
+            ingestion_date=datetime.datetime(2026, 1, 2, 0, 0, 0),
+        )
+    )
+    session.add(
+        models.AncillaryFiles(
             file_path="imap/ancillary/codice/imap_codice_l1a-sci-lut_20260403_v002.json",
             instrument="codice",
             descriptor="l1a-sci-lut",
@@ -355,4 +251,329 @@ def test_release_ancillary_files_in_date_range(session):
     )
 
 
-pytestmark = pytest.mark.skip(reason="Needs update for ticket #1400")
+# ---------------------------------------------------------------------------
+# ancillary release with exclude file
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.api_lambdas.release_api.download_read_file"
+)
+def test_ancillary_release_with_exclude_file(mock_download_read_file, session):
+    """release_type=release excludes specified ancillary files.
+
+    Three ancillary files for swe/l1b-in-flight-cal:
+      - v001 (older version, same descriptor+date) — should stay unreleased because
+        v002 is the latest.
+      - v002 (latest version, in range) — should be released because it is the
+        latest and is NOT in the exclude list.
+      - v001 with a different start_date inside range, but listed in the exclude
+        file — must remain unreleased.
+    """
+    # Older version — superseded by v002, same start_date
+    _ancillary(
+        session,
+        file_path="imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260413_v001.csv",
+        version="v001",
+        start_date="20260413",
+    )
+    # Latest version — should be released
+    _ancillary(
+        session,
+        file_path="imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260413_v002.csv",
+        version="v002",
+        start_date="20260413",
+    )
+    # In-range file that is the only version for its date but is in the exclude list
+    _ancillary(
+        session,
+        file_path="imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260420_v001.csv",
+        version="v001",
+        start_date="20260420",
+    )
+    _ancillary(
+        session,
+        file_path="imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260420_v002.csv",
+        version="v002",
+        start_date="20260420",
+    )
+
+    # Exclude list contains the April 20 file
+    mock_download_read_file.return_value = (
+        [],  # no science files excluded
+        ["imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260420_v002.csv"],
+    )
+
+    params = {
+        "instrument": "swe",
+        "start_date": "20260401",
+        "end_date": "20260430",
+        "release_type": "release",
+        "release_number": "1",
+        "exclude_file": "s3://dummy-bucket/exclude.txt",
+    }
+    result = release_api.lambda_handler(event=_build_event(params), context={})
+
+    assert result["statusCode"] == 200
+
+    rows = {r.file_path: r.released for r in session.query(models.AncillaryFiles).all()}
+    # Older version: not selected as latest → stays unreleased
+    assert (
+        rows["imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260413_v001.csv"] is False
+    ), "Older version should not be released"
+    # Latest version, not excluded → should be released
+    assert (
+        rows["imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260413_v002.csv"] is True
+    ), "Latest version should be released"
+    # In-range but explicitly excluded → must stay unreleased
+    assert (
+        rows["imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260420_v001.csv"] is False
+    ), "Excluded file should not be released"
+    # Latest version for April 20 -> must stay unreleased
+    assert (
+        rows["imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260420_v002.csv"] is False
+    ), "Latest version for April 20 should not be released"
+
+
+# ---------------------------------------------------------------------------
+#  ancillary release without exclude file — only latest version released
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.api_lambdas.release_api.download_read_file"
+)
+def test_ancillary_release_without_exclude_file_latest_version_only(
+    mock_download_read_file, session
+):
+    """release_type=release with no exclude file releases only the latest version.
+
+    Two versions of the same descriptor+start_date exist. Only the highest
+    version (v002) should be released; v001 must remain unreleased.
+    An out-of-range file must also remain unreleased.
+    """
+    # v001 — older version for April 13
+    _ancillary(
+        session,
+        file_path="imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260413_v001.csv",
+        version="v001",
+        start_date="20260413",
+    )
+    # v002 — latest version for April 13
+    _ancillary(
+        session,
+        file_path="imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260413_v002.csv",
+        version="v002",
+        start_date="20260413",
+    )
+    # Out-of-range: May 5 — outside the query window
+    _ancillary(
+        session,
+        file_path="imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260505_v001.csv",
+        version="v001",
+        start_date="20260505",
+    )
+
+    # No exclude file provided
+    params = {
+        "instrument": "swe",
+        "start_date": "20260401",
+        "end_date": "20260430",
+        "release_type": "release",
+        "release_number": "1",
+    }
+    result = release_api.lambda_handler(event=_build_event(params), context={})
+
+    assert result["statusCode"] == 200
+
+    rows = {r.file_path: r.released for r in session.query(models.AncillaryFiles).all()}
+    # Older version should remain unreleased
+    assert (
+        rows["imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260413_v001.csv"] is False
+    ), "Older version must not be released"
+    # Latest version should be released
+    assert (
+        rows["imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260413_v002.csv"] is True
+    ), "Latest version should be released"
+    # Out-of-range file must stay unreleased
+    assert (
+        rows["imap/ancillary/swe/imap_swe_l1b-in-flight-cal_20260505_v001.csv"] is False
+    ), "Out-of-range file must not be released"
+
+
+# ---------------------------------------------------------------------------
+#   early-release
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.api_lambdas.release_api.download_read_file"
+)
+def test_early_release(mock_download_read_file, session):
+    # Provide the manifest file with the two in-range files
+    science_files = [
+        "imap/hit/l0/imap_hit_l0_hk_20250110_v000.001.pkts",
+        "imap/hit/l0/imap_hit_l0_sci_20250120_v000.001.pkts",
+    ]
+    ancillary_files = []
+    mock_download_read_file.return_value = (science_files, ancillary_files)
+
+    _science(
+        session,
+        file_path="imap/hit/l0/imap_hit_l0_hk_20250110_v000.001.pkts",
+        instrument="hit",
+        descriptor="hk",
+        start_date="20250110",
+        release_number=0,
+    )
+    _science(
+        session,
+        file_path="imap/hit/l0/imap_hit_l0_sci_20250120_v000.001.pkts",
+        instrument="hit",
+        descriptor="sci",
+        start_date="20250120",
+        release_number=0,
+    )
+    _science(
+        session,
+        file_path="imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts",
+        instrument="hit",
+        descriptor="hk",
+        start_date="20250201",
+        release_number=0,
+    )
+
+    manifest_file = "s3://dummy-bucket/manifest.txt"
+    result = release_api.lambda_handler(
+        event=_build_event(
+            {
+                "release_type": "early-release",
+                "manifest_file": manifest_file,
+            }
+        ),
+        context={},
+    )
+
+    assert result["statusCode"] == 200
+
+    rows = {r.file_path: r.released for r in session.query(models.ScienceFiles).all()}
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v000.001.pkts"] is True
+    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v000.001.pkts"] is True
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts"] is False
+
+
+# ---------------------------------------------------------------------------
+#   unrelease
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "sds_data_manager.lambda_code.SDSCode.api_lambdas.release_api.download_read_file"
+)
+def test_unrelease_all_files_in_date_range(mock_download_read_file, session):
+    # Provide the manifest file with the two in-range files
+    science_files = [
+        "imap/hit/l0/imap_hit_l0_hk_20250110_v000.001.pkts",
+        "imap/hit/l0/imap_hit_l0_sci_20250120_v000.001.pkts",
+    ]
+    ancillary_files = []
+    mock_download_read_file.return_value = (science_files, ancillary_files)
+
+    _science(
+        session,
+        file_path="imap/hit/l0/imap_hit_l0_hk_20250110_v000.001.pkts",
+        instrument="hit",
+        descriptor="hk",
+        start_date="20250110",
+        released=True,
+        release_number=0,
+    )
+    _science(
+        session,
+        file_path="imap/hit/l0/imap_hit_l0_sci_20250120_v000.001.pkts",
+        instrument="hit",
+        descriptor="sci",
+        start_date="20250120",
+        released=True,
+        release_number=0,
+    )
+    _science(
+        session,
+        file_path="imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts",
+        instrument="hit",
+        descriptor="hk",
+        start_date="20250201",
+        released=True,
+        release_number=0,
+    )  # outside range
+
+    manifest_file = "s3://dummy-bucket/manifest.txt"
+    result = release_api.lambda_handler(
+        event=_build_event(
+            {
+                "release_type": "unrelease",
+                "manifest_file": manifest_file,
+            }
+        ),
+        context={},
+    )
+
+    assert result["statusCode"] == 200
+
+    rows = {r.file_path: r.released for r in session.query(models.ScienceFiles).all()}
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v000.001.pkts"] is False, (
+        "In-range file must be unreleased"
+    )
+    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v000.001.pkts"] is False, (
+        "In-range file must be unreleased"
+    )
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts"] is True, (
+        "Out-of-range file must remain released"
+    )
+
+
+# ---------------------------------------------------------------------------
+#  repoint files for a single day
+# ---------------------------------------------------------------------------
+
+
+def test_release_repoint_files_date_range(session):
+    """Test multiple repoint files for a single day."""
+    # April 7th, Hi has three repoint files with different repointing and data_version
+    files = [
+        ("imap_hi_l1a_45sensor-hk_20260407-repoint00209_v001.001.cdf", 209, 1),
+        ("imap_hi_l1a_45sensor-hk_20260407-repoint00210_v001.002.cdf", 210, 2),
+        ("imap_hi_l1a_45sensor-hk_20260407-repoint00211_v001.003.cdf", 211, 3),
+    ]
+    for file_path, repointing, version in files:
+        session.add(
+            models.ScienceFiles(
+                file_path=file_path,
+                instrument="hi",
+                data_level="l1a",
+                descriptor="45sensor-hk",
+                start_date=datetime.datetime.strptime("20260407", "%Y%m%d"),
+                repointing=repointing,
+                data_version=version,
+                release_number=1,
+                extension="cdf",
+                released=False,
+                ingestion_date=datetime.datetime(2026, 4, 8, 0, 0, 0),
+            )
+        )
+    session.commit()
+
+    # Query for all files on this date
+    results = release_api.query_latest_science_files(
+        session,
+        instrument="hi",
+        start_date=datetime.datetime.strptime("20260407", "%Y%m%d"),
+        end_date=datetime.datetime.strptime("20260407", "%Y%m%d"),
+        release_number=1,
+    )
+    file_paths = sorted([obj.file_path for obj in results])
+    assert file_paths == [
+        "imap_hi_l1a_45sensor-hk_20260407-repoint00209_v001.001.cdf",
+        "imap_hi_l1a_45sensor-hk_20260407-repoint00210_v001.002.cdf",
+        "imap_hi_l1a_45sensor-hk_20260407-repoint00211_v001.003.cdf",
+    ], f"Expected all repoint files, got: {file_paths}"

--- a/tests/lambda_endpoints/test_release_api.py
+++ b/tests/lambda_endpoints/test_release_api.py
@@ -32,6 +32,7 @@ def _science(
     start_date="20250115",
     released=False,
     release_number=0,
+    data_version=1,
 ):
     session.add(
         models.ScienceFiles(
@@ -40,7 +41,7 @@ def _science(
             data_level="l0",
             descriptor=descriptor,
             start_date=datetime.datetime.strptime(start_date, "%Y%m%d"),
-            data_version=1,
+            data_version=data_version,
             release_number=release_number,
             extension="pkts",
             released=released,
@@ -98,32 +99,35 @@ def test_release_all_files_in_date_range(mock_download_read_file, session):
     """
     _science(
         session,
-        file_path="imap/hit/l0/imap_hit_l0_hk_20250110_v001.001.pkts",
+        file_path="imap/hit/l0/imap_hit_l0_hk_20250110_v001.000.pkts",
         instrument="hit",
         descriptor="hk",
         start_date="20250110",
         release_number=1,
+        data_version=0,
     )
     _science(
         session,
-        file_path="imap/hit/l0/imap_hit_l0_sci_20250120_v001.001.pkts",
+        file_path="imap/hit/l0/imap_hit_l0_sci_20250120_v001.000.pkts",
         instrument="hit",
         descriptor="sci",
         start_date="20250120",
         release_number=1,
+        data_version=0,
     )
     _science(
         session,
-        file_path="imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts",
+        file_path="imap/hit/l0/imap_hit_l0_hk_20250201_v001.000.pkts",
         instrument="hit",
         descriptor="hk",
         start_date="20250201",
-        release_number=0,
+        release_number=1,
+        data_version=0,
     )  # outside range
 
     # Provide the manifest file with the two in-range files
     science_files = [
-        "imap/hit/l0/imap_hit_l0_hk_20250110_v001.001.pkts",
+        "imap/hit/l0/imap_hit_l0_hk_20250110_v001.000.pkts",
     ]
     ancillary_files = []
     mock_download_read_file.return_value = (science_files, ancillary_files)
@@ -144,13 +148,13 @@ def test_release_all_files_in_date_range(mock_download_read_file, session):
     assert result["statusCode"] == 200
 
     rows = {r.file_path: r.released for r in session.query(models.ScienceFiles).all()}
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.001.pkts"] is False, (
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.000.pkts"] is False, (
         "Excluded in-range file should not be released"
     )
-    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.001.pkts"] is True, (
+    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.000.pkts"] is True, (
         "Non-excluded in-range file should be released"
     )
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts"] is False, (
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v001.000.pkts"] is False, (
         "Out-of-range file must stay unreleased"
     )
 
@@ -162,13 +166,13 @@ def test_release_all_files_in_date_range(mock_download_read_file, session):
     )
     assert result["statusCode"] == 200
     rows = {r.file_path: r.released for r in session.query(models.ScienceFiles).all()}
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.001.pkts"] is True, (
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250110_v001.000.pkts"] is True, (
         "In-range file should be released"
     )
-    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.001.pkts"] is True, (
+    assert rows["imap/hit/l0/imap_hit_l0_sci_20250120_v001.000.pkts"] is True, (
         "In-range file should be released"
     )
-    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v000.001.pkts"] is False, (
+    assert rows["imap/hit/l0/imap_hit_l0_hk_20250201_v001.000.pkts"] is False, (
         "Out-of-range file must stay unreleased"
     )
 
@@ -541,9 +545,9 @@ def test_release_repoint_files_date_range(session):
     """Test multiple repoint files for a single day."""
     # April 7th, Hi has three repoint files with different repointing and data_version
     files = [
-        ("imap_hi_l1a_45sensor-hk_20260407-repoint00209_v001.001.cdf", 209, 1),
-        ("imap_hi_l1a_45sensor-hk_20260407-repoint00210_v001.002.cdf", 210, 2),
-        ("imap_hi_l1a_45sensor-hk_20260407-repoint00211_v001.003.cdf", 211, 3),
+        ("imap_hi_l1a_45sensor-hk_20260407-repoint00209_v001.000.cdf", 209, 0),
+        ("imap_hi_l1a_45sensor-hk_20260407-repoint00210_v001.000.cdf", 210, 0),
+        ("imap_hi_l1a_45sensor-hk_20260407-repoint00211_v001.000.cdf", 211, 0),
     ]
     for file_path, repointing, version in files:
         session.add(
@@ -564,7 +568,7 @@ def test_release_repoint_files_date_range(session):
     session.commit()
 
     # Query for all files on this date
-    results = release_api.query_latest_science_files(
+    results = release_api.query_releasable_science_files(
         session,
         instrument="hi",
         start_date=datetime.datetime.strptime("20260407", "%Y%m%d"),
@@ -573,7 +577,7 @@ def test_release_repoint_files_date_range(session):
     )
     file_paths = sorted([obj.file_path for obj in results])
     assert file_paths == [
-        "imap_hi_l1a_45sensor-hk_20260407-repoint00209_v001.001.cdf",
-        "imap_hi_l1a_45sensor-hk_20260407-repoint00210_v001.002.cdf",
-        "imap_hi_l1a_45sensor-hk_20260407-repoint00211_v001.003.cdf",
+        "imap_hi_l1a_45sensor-hk_20260407-repoint00209_v001.000.cdf",
+        "imap_hi_l1a_45sensor-hk_20260407-repoint00210_v001.000.cdf",
+        "imap_hi_l1a_45sensor-hk_20260407-repoint00211_v001.000.cdf",
     ], f"Expected all repoint files, got: {file_paths}"


### PR DESCRIPTION
# Change Summary
closes #1412 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
`/release` API takes in mission wide reprocessing and updates global release table. Update science query logic to use new release_number update in science table.

## File changes
<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- added reprocessing `release-type` handler
- Update science table query logic to query by release number now.
- minor refactor

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
- update tests