### PR TITLE
Stopping jobs from kicking off with no SPICE files.

### DIFF
--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -781,9 +781,9 @@ class IMAPJobHandler:
         )
         if not spice_files and self.job_config.spice_inputs:
             # If no SPICE files are returned, but there are SPICE inputs, raise failure
-            raise MissingDependenciesError(f"""Missing SPICE files between 
+            raise MissingDependenciesError(f"""Missing SPICE files between
                                            {target_start} and {target_end}""")
-            
+
         return spice_files
 
     def get_science_files_inputs(self, context, target_start, target_end):

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -779,6 +779,11 @@ class IMAPJobHandler:
         spice_files = spice.get_upstream_dependency_inputs_spice(
             self.job_config.spice_types, target_start, target_end
         )
+        if not spice_files and self.job_config.spice_inputs:
+            # If no SPICE files are returned, but there are SPICE inputs, raise failure
+            raise MissingDependenciesError(f"""Missing SPICE files between 
+                                           {target_start} and {target_end}""")
+            
         return spice_files
 
     def get_science_files_inputs(self, context, target_start, target_end):


### PR DESCRIPTION
# Change Summary

## Overview
Adds a change to have the code raise an error if no SPICE files were found. 

## File changes
- sds_data_manager/orchestration/imap_job.py 
Added a check to raise an error if SPICE output was None, and there were SPICE files required. 

## Testing
- Working on testing suite in another ticket 