### PR TITLE
CoDICE-Lo: Add l3-lo-efficiency ancillary file to be used by L3 products

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_codice_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_codice_dependencies.yaml
@@ -28,7 +28,7 @@ lo_l3a_dist_common: &lo_l3a_dist_common
     descriptor: lo-energy-per-charge
   - source: codice
     data_type: ancillary
-    descriptor: l2-lo-efficiency
+    descriptor: l3-lo-efficiency
 
 # ====== Specific Product Dependencies ======
 (l1a, all):


### PR DESCRIPTION
# Change Summary

## Overview
Creating l3-specific ancillary file for CoDICE-Lo efficiency

## File changes
1 character change, changing l2-lo-efficiency descriptor to l3

## Testing
No relevant test changes
