### PR TITLE
imap processing release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1636,19 +1636,19 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "imap-processing"
-version = "1.0.32"
+version = "1.0.34"
 description = "IMAP Science Operations Center Processing"
 optional = false
 python-versions = "<3.13,>=3.10"
 groups = ["layer-idex-processing", "layer-processing"]
 files = [
-    {file = "imap_processing-1.0.32-py3-none-any.whl", hash = "sha256:d53ca85c1ca111354074949e479fd082e518416194817bd094513ca048bdf17b"},
-    {file = "imap_processing-1.0.32.tar.gz", hash = "sha256:c6dc7e945d8118e2ad5b48cc2ba98aadfe80c4b26d641b8255172aaebf28b77b"},
+    {file = "imap_processing-1.0.34-py3-none-any.whl", hash = "sha256:ad2a2c4c2f0a868afb9bdf41c74d54ec0b8bdfb2828b7fb97c564ef8db73b3dd"},
+    {file = "imap_processing-1.0.34.tar.gz", hash = "sha256:d47baf8e1debb562cd62214b16b5163f8c232be271c9b0b459e74fefd1d92ad1"},
 ]
 
 [package.dependencies]
 astropy-healpix = ">=1.0"
-cdflib = ">=1.3.6"
+cdflib = ">=1.3.11"
 imap-data-access = ">=0.37.0"
 numpy = ">=2,<3"
 sammi-cdf = ">=1.0,<2"
@@ -4650,4 +4650,4 @@ tool = ["alembic"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "13767a152b2146a46f463fa18e7a2ddeafdb89c5e54fc970925d274b716369b6"
+content-hash = "7a723f6eba8150f4763fe7d74e59204e80ddaddc5e63ceb0ddb24e267123a528"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,12 +82,12 @@ requests = "^2.28.2"
 spiceypy = "^6.0.0"
 
 [tool.poetry.group.layer-processing.dependencies]
-imap-processing = "1.0.32"
+imap-processing = "1.0.34"
 pandas = ">=3.0.3,<4.0.0"
 
 
 [tool.poetry.group.layer-idex-processing.dependencies]
-imap-processing = "^1.0.30"
+imap-processing = "^1.0.34"
 spiceypy = "^6.0.0"
 sqlalchemy = "^2.0.49"
 psycopg2-binary = "^2.9.12"

--- a/sds_data_manager/lambda_code/idex_processing/requirements.txt
+++ b/sds_data_manager/lambda_code/idex_processing/requirements.txt
@@ -261,9 +261,9 @@ idna==3.18 ; python_version >= "3.11" and python_version < "3.13" \
 imap-data-access==0.41.0 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:88c550e41c8e9fcb881787e6911bd21a5b4253be3e5ba7176a51151324588169 \
     --hash=sha256:927966c3d0b16d9a1f8be23abdc34cff28afdec377a6e72ade7ae27496108557
-imap-processing==1.0.32 ; python_version >= "3.11" and python_version < "3.13" \
-    --hash=sha256:c6dc7e945d8118e2ad5b48cc2ba98aadfe80c4b26d641b8255172aaebf28b77b \
-    --hash=sha256:d53ca85c1ca111354074949e479fd082e518416194817bd094513ca048bdf17b
+imap-processing==1.0.34 ; python_version >= "3.11" and python_version < "3.13" \
+    --hash=sha256:ad2a2c4c2f0a868afb9bdf41c74d54ec0b8bdfb2828b7fb97c564ef8db73b3dd \
+    --hash=sha256:d47baf8e1debb562cd62214b16b5163f8c232be271c9b0b459e74fefd1d92ad1
 jmespath==1.1.0 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -261,9 +261,9 @@ idna==3.18 ; python_version >= "3.11" and python_version < "3.13" \
 imap-data-access==0.41.0 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:88c550e41c8e9fcb881787e6911bd21a5b4253be3e5ba7176a51151324588169 \
     --hash=sha256:927966c3d0b16d9a1f8be23abdc34cff28afdec377a6e72ade7ae27496108557
-imap-processing==1.0.32 ; python_version >= "3.11" and python_version < "3.13" \
-    --hash=sha256:c6dc7e945d8118e2ad5b48cc2ba98aadfe80c4b26d641b8255172aaebf28b77b \
-    --hash=sha256:d53ca85c1ca111354074949e479fd082e518416194817bd094513ca048bdf17b
+imap-processing==1.0.34 ; python_version >= "3.11" and python_version < "3.13" \
+    --hash=sha256:ad2a2c4c2f0a868afb9bdf41c74d54ec0b8bdfb2828b7fb97c564ef8db73b3dd \
+    --hash=sha256:d47baf8e1debb562cd62214b16b5163f8c232be271c9b0b459e74fefd1d92ad1
 jmespath==1.1.0 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64


### PR DESCRIPTION
This pull request updates the `imap-processing` dependency to version 1.0.34 across multiple files and dependency groups to ensure consistency and compatibility throughout the project.

Dependency updates:

* Updated the `imap-processing` package to version 1.0.34 in the `[tool.poetry.group.layer-processing.dependencies]` and `[tool.poetry.group.layer-idex-processing.dependencies]` sections of `pyproject.toml`.
* Updated the `imap-processing` requirement to version 1.0.34 (including hash values) in both `sds_data_manager/lambda_code/processing/requirements.txt` and `sds_data_manager/lambda_code/idex_processing/requirements.txt`. [[1]](diffhunk://#diff-cc8a15ab762756551934f3e9553c78546a09ffc638b7d179341292aed7c83c89L264-R266) [[2]](diffhunk://#diff-a088692813760de750f037cf6654ccd8c32dcb3bdf99b6e7f80e4651f6dc3cf8L264-R266)
