### PR TITLE
Update query API to handle new major/minor versions, while preserving…

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/query_api.py
@@ -5,7 +5,7 @@ import json
 import logging
 from collections import namedtuple
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 
 from ..api_lambdas.utils import is_authenticated_user
 from ..database import database as db
@@ -14,6 +14,197 @@ from ..database import models
 # Logger setup
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+# Columns that, together with repointing, identify a unique science file
+# "series" when resolving the latest version.
+_VERSION_GROUPING_COLUMNS = (
+    "instrument",
+    "data_level",
+    "descriptor",
+    "start_date",
+)
+
+# The two ways a science query resolves "latest". NEWEST keeps only the single
+# newest file per series (latest major, then latest minor); LATEST_MAJOR keeps
+# every minor version of the latest major.
+LatestVersionMode = namedtuple("LatestVersionMode", ["newest", "latest_major"])
+LATEST_VERSION_MODE = LatestVersionMode(newest="newest", latest_major="latest_major")
+
+
+def _parse_version_alias(value):
+    """Translate a legacy ``version`` string into ``(major, minor)`` integers.
+
+    The ``version`` query parameter is kept for backwards compatibility after
+    the science ``version`` column was split into ``major_version`` and
+    ``minor_version``. Accepts the full ``vMMM.mmmm`` form or the deprecated
+    minor-only ``vXXX`` form.
+
+    Parameters
+    ----------
+    value : str
+        The ``version`` query parameter value.
+
+    Returns
+    -------
+    tuple
+        ``(major, minor)`` where ``major`` is ``None`` for the minor-only form.
+
+    """
+    digits = value.lstrip("vV")
+    if "." in digits:
+        major_str, minor_str = digits.split(".", 1)
+        return int(major_str), int(minor_str)
+    return None, int(digits)
+
+
+def _resolve_science_version_mode(query_params):
+    """Resolve science version params in place and return the latest mode.
+
+    Applies the backwards-compatible ``version`` alias and reads the ``latest``
+    flag, mutating ``query_params`` so the generic query loop only sees real
+    columns.
+
+    Parameters
+    ----------
+    query_params : dict
+        The (mutable) query parameters; updated in place.
+
+    Returns
+    -------
+    str or None
+        A ``LATEST_VERSION_MODE`` value, or None when a concrete major_version
+        was requested (no latest restriction applied).
+
+    Raises
+    ------
+    ValueError
+        If the ``version`` alias value cannot be parsed.
+
+    """
+    # Backwards-compatible `version` alias -> minor_version (and major_version
+    # when the full vMMM.mmmm form is provided).
+    if "version" in query_params:
+        major, minor = _parse_version_alias(query_params.pop("version"))
+        if major is not None:
+            query_params["major_version"] = major
+        query_params["minor_version"] = minor
+
+    # `latest=true` -> the single newest file (latest major + latest minor).
+    latest_flag = str(query_params.pop("latest", "")).lower() == "true"
+
+    # Precedence: a concrete major_version wins (None -> no latest restriction),
+    # then latest=true, then the default (omitting major_version -> latest
+    # major, all minor versions).
+    if "major_version" in query_params:
+        return None
+    if latest_flag:
+        return LATEST_VERSION_MODE.newest
+    return LATEST_VERSION_MODE.latest_major
+
+
+def _latest_version_filters(model, mode, released_only):
+    """Build WHERE clauses restricting science results to the latest version.
+
+    "Latest" is resolved with correlated subqueries: for each candidate result
+    row, a subquery computes the maximum version within that row's file
+    "series" (same instrument / data_level / descriptor / start_date /
+    repointing) and the row is kept only if it matches that maximum.
+
+    Parameters
+    ----------
+    model
+        The science table model.
+    mode : str
+        One of ``LATEST_VERSION_MODE``. ``latest_major`` keeps the latest major
+        version with ALL of its minor versions; ``newest`` keeps only the single
+        newest file (latest major and, within it, latest minor).
+    released_only : bool
+        When True, only released files count toward "latest". This is applied
+        *inside* the max subqueries (not as a plain filter on the outer query)
+        so that an unreleased newer version cannot hide the latest released
+        version from unauthenticated users.
+
+    Returns
+    -------
+    list
+        SQLAlchemy boolean clauses to AND into the query.
+
+    """
+    outer = model.__table__
+
+    def same_series_as_outer(inner):
+        """Conditions correlating an inner alias to the outer row's series."""
+        # Equality on every grouping column that defines one file series.
+        conditions = [
+            getattr(inner.c, column) == getattr(outer.c, column)
+            for column in _VERSION_GROUPING_COLUMNS
+        ]
+        # repointing is nullable, so NULL-safe equality keeps NULL-repointing
+        # rows grouped together instead of dropping them from the correlation.
+        conditions.append(
+            or_(
+                inner.c.repointing == outer.c.repointing,
+                and_(inner.c.repointing.is_(None), outer.c.repointing.is_(None)),
+            )
+        )
+        # Only released files participate in the max when released_only is set.
+        if released_only:
+            conditions.append(inner.c.released.is_(True))
+        return conditions
+
+    # Keep rows whose major_version is the max major within their series.
+    # Each max subquery re-scans the science table, so it needs its own aliased
+    # reference to that table (a self-join): the alias is the inner scan, while
+    # the un-aliased `outer` is the row being tested, which the subquery
+    # correlates back to via same_series_as_outer().
+    major_inner = outer.alias("latest_major_inner")
+    max_major = (
+        select(func.max(major_inner.c.major_version))
+        .where(*same_series_as_outer(major_inner))
+        .scalar_subquery()
+    )
+    filters = [outer.c.major_version == max_major]
+
+    # For "newest", additionally keep only the max minor within that major.
+    if mode == LATEST_VERSION_MODE.newest:
+        # A second, independent self-join alias for the minor-version scan.
+        minor_inner = outer.alias("latest_minor_inner")
+        max_minor = (
+            select(func.max(minor_inner.c.minor_version))
+            .where(
+                *same_series_as_outer(minor_inner),
+                minor_inner.c.major_version == outer.c.major_version,
+            )
+            .scalar_subquery()
+        )
+        filters.append(outer.c.minor_version == max_minor)
+    return filters
+
+
+def _format_search_results(search_results):
+    """Stringify datetime fields in query results for the JSON response.
+
+    Parameters
+    ----------
+    search_results : list
+        List of result dicts; mutated in place.
+
+    Returns
+    -------
+    list
+        The same list with date fields formatted as strings.
+
+    """
+    for result in search_results:
+        result["start_date"] = result["start_date"].strftime("%Y%m%d")
+        if result.get("end_date"):
+            result["end_date"] = result["end_date"].strftime("%Y%m%d")
+        ingestion = result["ingestion_date"]
+        if ingestion.tzinfo is not None:
+            # Convert to UTC and drop the timezone.
+            ingestion = ingestion.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        result["ingestion_date"] = ingestion.strftime("%Y%m%d %H:%M:%S")
+    return search_results
 
 
 def lambda_handler(event, context):  # noqa: PLR0912
@@ -47,7 +238,8 @@ def lambda_handler(event, context):  # noqa: PLR0912
     )
 
     # add session, pick model like in indexer and add query to filter_as
-    query_params = event["queryStringParameters"]
+    # Make a mutable copy so we can pre-process science version parameters.
+    query_params = dict(event["queryStringParameters"])
     # get desired table for query
     query_table = query_params.get("table", "science")
 
@@ -55,9 +247,25 @@ def lambda_handler(event, context):  # noqa: PLR0912
     model = getattr(table_models, query_table)
 
     # select the given table for the query
+    authenticated = is_authenticated_user(event)
     query = select(model.__table__)
-    if not is_authenticated_user(event):
+    if not authenticated:
         query = query.filter(model.released)
+
+    # Science-only version handling: a backwards-compatible `version` alias plus
+    # server-side resolution of "latest". Other tables keep `version` as a real
+    # column and are left untouched.
+    version_mode = None
+    if query_table == "science":
+        try:
+            version_mode = _resolve_science_version_mode(query_params)
+        except ValueError:
+            return {
+                "statusCode": 400,
+                "body": json.dumps(
+                    "Invalid 'version' value. Use format 'vMMM.mmmm' or 'vXXX'."
+                ),
+            }
 
     # get a list of all valid search parameters
     valid_parameters = [
@@ -119,6 +327,13 @@ def lambda_handler(event, context):  # noqa: PLR0912
         else:
             query = query.where(getattr(model, param) == value)
 
+    # Restrict science results to the latest version when no concrete
+    # major_version was requested. NEWEST keeps a single file per series;
+    # LATEST_MAJOR keeps all minor versions of the latest major.
+    if version_mode is not None:
+        for clause in _latest_version_filters(model, version_mode, not authenticated):
+            query = query.where(clause)
+
     # We want to order the query returns by the filename
     # This will implicitly sort by: instrument, data level, descriptor, start_date, ...
     # Default for the table is by the ascending id so by insertion order
@@ -128,20 +343,10 @@ def lambda_handler(event, context):  # noqa: PLR0912
     with db.Session() as session:
         search_results = session.execute(query).all()
 
-        # Convert the search results (list of tuples) to a list of dicts
+        # Convert the search results (list of tuples) to a list of dicts and
+        # stringify their datetime fields for the JSON response.
         search_results = [result._asdict() for result in search_results]
-
-        # Convert datetimes to string values of format 'YYYYMMDD'
-        # Also remove values that are not needed by users
-        for result in search_results:
-            result["start_date"] = result["start_date"].strftime("%Y%m%d")
-            if result.get("end_date"):
-                result["end_date"] = result["end_date"].strftime("%Y%m%d")
-            d = result["ingestion_date"]
-            if d.tzinfo is not None:
-                # Convert it to UTC and remove the timezone
-                d = d.astimezone(datetime.timezone.utc).replace(tzinfo=None)
-            result["ingestion_date"] = d.strftime("%Y%m%d %H:%M:%S")
+        search_results = _format_search_results(search_results)
 
         logger.info(
             "Found [%s] Query Search Results: %s",

--- a/tests/lambda_endpoints/test_query_api.py
+++ b/tests/lambda_endpoints/test_query_api.py
@@ -25,7 +25,8 @@ def _populate_test_data(session):
         "data_level": "l0",
         "descriptor": "raw",
         "start_date": datetime.datetime.strptime("20251107", "%Y%m%d"),
-        "version": "v001",
+        "major_version": 1,
+        "minor_version": 1,
         "extension": "pkts",
         "ingestion_date": datetime.datetime.strptime(
             "2025-11-07 10:13:12+00:00", "%Y-%m-%d %H:%M:%S%z"
@@ -50,7 +51,8 @@ def expected_response():
                 "descriptor": "raw",
                 "start_date": "20251107",
                 "repointing": None,
-                "version": "v001",
+                "major_version": 1,
+                "minor_version": 1,
                 "extension": "pkts",
                 "ingestion_date": "20251107 10:13:12",
                 "cr": None,
@@ -350,4 +352,184 @@ def test_invalid_param_ancillary_query(session):
     )
 
 
-pytestmark = pytest.mark.skip(reason="Needs update for ticket #1400")
+def _populate_versioned_science_data(session):
+    """Populate one science series with several major/minor versions.
+
+    All rows share the same instrument/level/descriptor/start_date series so
+    that version resolution collapses them. Versions added (major, minor):
+    (1, 1), (1, 2), (2, 1), (2, 3).
+    """
+    versions = [(1, 1), (1, 2), (2, 1), (2, 3)]
+    for major, minor in versions:
+        filepath = (
+            f"test/file/path/imap_hit_l1a_count_20251107_v{major:03d}.{minor:04d}.cdf"
+        )
+        session.add(
+            models.ScienceFiles(
+                file_path=filepath,
+                instrument="hit",
+                data_level="l1a",
+                descriptor="count",
+                start_date=datetime.datetime.strptime("20251107", "%Y%m%d"),
+                major_version=major,
+                minor_version=minor,
+                extension="cdf",
+                ingestion_date=datetime.datetime.strptime(
+                    "2025-11-07 10:13:12+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+                released=True,
+            )
+        )
+    session.commit()
+
+
+def _returned_versions(returned_query):
+    """Return the set of (major_version, minor_version) tuples in a response."""
+    return {
+        (item["major_version"], item["minor_version"])
+        for item in json.loads(returned_query["body"])
+    }
+
+
+def test_default_returns_latest_major_all_minors(session):
+    """Omitting version params returns the latest major with all its minors."""
+    _populate_versioned_science_data(session)
+    event = {"queryStringParameters": {"instrument": "hit"}}
+
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    # Latest major is 2; both minor versions of major 2 are returned.
+    assert _returned_versions(returned_query) == {(2, 1), (2, 3)}
+
+
+def test_latest_true_returns_single_newest_file(session):
+    """latest=true returns only the single newest file (latest major+minor)."""
+    _populate_versioned_science_data(session)
+    event = {"queryStringParameters": {"instrument": "hit", "latest": "true"}}
+
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert _returned_versions(returned_query) == {(2, 3)}
+
+
+def test_concrete_major_version_filter(session):
+    """A concrete major_version returns all minors of that major only."""
+    _populate_versioned_science_data(session)
+    event = {"queryStringParameters": {"instrument": "hit", "major_version": "1"}}
+
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert _returned_versions(returned_query) == {(1, 1), (1, 2)}
+
+
+def test_version_alias_minor_only(session):
+    """Legacy `version=vXXX` maps to a minor_version filter within latest major."""
+    _populate_versioned_science_data(session)
+    event = {"queryStringParameters": {"instrument": "hit", "version": "v001"}}
+
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    # minor_version=1 within the latest major (2).
+    assert _returned_versions(returned_query) == {(2, 1)}
+
+
+def test_version_alias_full_form(session):
+    """Legacy `version=vMMM.mmmm` maps to both major and minor filters."""
+    _populate_versioned_science_data(session)
+    event = {"queryStringParameters": {"instrument": "hit", "version": "v001.0002"}}
+
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    assert _returned_versions(returned_query) == {(1, 2)}
+
+
+def _populate_old_filename_science_data(session):
+    """Populate science files that use the legacy vXXX filename convention.
+
+    Files produced before the major/minor version split used filenames like
+    ``imap_hit_l1a_count_20251107_v002.cdf`` and are stored with the default
+    major_version of 1 and the legacy number as the minor_version.
+    """
+    for minor in (1, 2):
+        filepath = f"test/file/path/imap_hit_l1a_count_20251107_v{minor:03d}.cdf"
+        session.add(
+            models.ScienceFiles(
+                file_path=filepath,
+                instrument="hit",
+                data_level="l1a",
+                descriptor="count",
+                start_date=datetime.datetime.strptime("20251107", "%Y%m%d"),
+                major_version=1,
+                minor_version=minor,
+                extension="cdf",
+                ingestion_date=datetime.datetime.strptime(
+                    "2025-11-07 10:13:12+00:00", "%Y-%m-%d %H:%M:%S%z"
+                ),
+                released=True,
+            )
+        )
+    session.commit()
+
+
+def test_query_with_old_filename_format(session):
+    """Files from legacy vXXX filenames stay queryable, including via `version`."""
+    _populate_old_filename_science_data(session)
+
+    # A plain query returns the files (the default latest-major path still works;
+    # the legacy files all share major_version 1).
+    event = {"queryStringParameters": {"instrument": "hit"}}
+    returned_query = query_api.lambda_handler(event=event, context={})
+    assert returned_query["statusCode"] == 200
+    assert _returned_versions(returned_query) == {(1, 1), (1, 2)}
+
+    # The legacy `version=vXXX` parameter still resolves to a specific file.
+    event = {"queryStringParameters": {"instrument": "hit", "version": "v002"}}
+    returned_query = query_api.lambda_handler(event=event, context={})
+    assert returned_query["statusCode"] == 200
+    assert _returned_versions(returned_query) == {(1, 2)}
+
+
+def test_latest_default_excludes_unreleased_for_unauthenticated(session):
+    """Unauthenticated latest resolution ignores unreleased newer versions."""
+    _populate_versioned_science_data(session)
+    # Add an unreleased newer major that an unauthenticated user must not see,
+    # and which must not suppress the latest released version.
+    session.add(
+        models.ScienceFiles(
+            file_path="test/file/path/imap_hit_l1a_count_20251107_v003.0001.cdf",
+            instrument="hit",
+            data_level="l1a",
+            descriptor="count",
+            start_date=datetime.datetime.strptime("20251107", "%Y%m%d"),
+            major_version=3,
+            minor_version=1,
+            extension="cdf",
+            ingestion_date=datetime.datetime.strptime(
+                "2025-11-07 10:13:12+00:00", "%Y-%m-%d %H:%M:%S%z"
+            ),
+            released=False,
+        )
+    )
+    session.commit()
+
+    event = {"queryStringParameters": {"instrument": "hit"}}
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 200
+    # Latest *released* major is still 2, with both of its minors.
+    assert _returned_versions(returned_query) == {(2, 1), (2, 3)}
+
+
+def test_invalid_version_alias_returns_400(session):
+    """A malformed `version` value returns a 400."""
+    _populate_versioned_science_data(session)
+    event = {"queryStringParameters": {"instrument": "hit", "version": "vABC"}}
+
+    returned_query = query_api.lambda_handler(event=event, context={})
+
+    assert returned_query["statusCode"] == 400


### PR DESCRIPTION
## Summary

Adds major-version querying to the science query API and moves "latest" resolution server-side, following the science version-scheme rework that split `version` into integer `major_version` / `minor_version` columns.

Science queries now default to the latest major version when no major version is specified — a behavior change from the previous "return all versions unless filtered" default.

## Changes

- **`version` backwards-compatibility alias**: the science `version` query param is still accepted and maps to the new columns. `v001` -> `minor_version` (deprecated minor-only form); `v001.0002` -> `major_version` + `minor_version` (full `vMMM.mmmm` form). Malformed values return 400.
- **Server-side "latest"** (science only):
  - No `major_version` supplied (the new default) -> latest major version with  ALL of its minor versions, per file series.
  - `latest=true` -> the single newest file (latest major, then latest minor) per series, mirroring the existing `/spice-query` `latest=true` convention.
  - A concrete `major_version` disables the latest restriction and filters to that major. Precedence: concrete major_version > latest=true > default.
- **Released-aware latest**: for unauthenticated requests, the max-version computation runs inside the correlated subqueries with a `released` filter, so an unreleased newer version cannot hide the latest *released* version.
- A "file series" is grouped by instrument / data_level / descriptor / start_date / repointing (NULL-safe on repointing).
- Other tables (ancillary, spice) and the quicklook table are unchanged.
- Refactored the handler into helpers (`_parse_version_alias`, `_resolve_science_version_mode`, `_latest_version_filters`, `_format_search_results`) to keep it readable and within lint limits.

## Testing

- `tests/lambda_endpoints/test_query_api.py`: un-skipped, fixtures updated to the new integer version columns, and new cases added for the latest-major default, `latest=true`, concrete major, the `version` alias (both forms), unreleased-version exclusion for unauthenticated users, legacy `vXXX` filenames, and invalid-version 400s.

## Notes
- Response keys are now `major_version` / `minor_version` (no combined `version` key). 
- Depends on the DB migration that introduced `major_version` / `minor_version` (already on the branch).

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)
