### PR TITLE
1444 bug   pointing attitude job is not being run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ repository = "https://github.com/IMAP-Science-Operations-Center/sds-data-manager
 testpaths = [
   "tests",
 ]
-addopts = "-ra"
+addopts = "-ra -p no:anyio"
 markers = [
     "network: Test that requires network access",
 ]

--- a/sds_data_manager/orchestration/custom_partitions.py
+++ b/sds_data_manager/orchestration/custom_partitions.py
@@ -242,9 +242,128 @@ def add_idex_30_day_partitions(context: SensorEvaluationContext):
     )
 
 
+##### THIS TELLS DAGSTER ABOUT SPACECRAFT POINTING-ATTITUDE PROCESSING WINDOWS
+# One partition per attitude_history SPICE kernel, keyed by pointing times.
+# Partition start = pointing_start_utc of the first pointing with any overlap
+# with the ah kernel. Partition end = pointing_end_utc of the last pointing
+# completely covered by the ah kernel.
+# Prefix is "pointingattitude" (no underscores) so parse_dates_from_partition_key can
+# split on the first "_" to isolate the date range.
+pointing_attitude_partitions = DynamicPartitionsDefinition(
+    name="pointing_attitude_partitions"
+)
+
+
+@sensor(minimum_interval_seconds=600)
+def add_pointing_attitude_partitions(context: SensorEvaluationContext):
+    """Alert Dagster when new spacecraft pointing partitions should be made.
+
+    One partition is maintained per ah kernel cycle. When a new ah kernel
+    extends or replaces earlier coverage, any existing partitions whose full
+    range is subsumed by the new partition are deleted first. This handles
+    both the normal growing-append case (same start, later end) and the
+    retroactive combined-file case (one large file that subsumes many small
+    early-mission daily partitions).
+    """
+    with db.Session() as session:
+        attitude_kernels = (
+            session.query(models.SPICEFiles)
+            .filter(models.SPICEFiles.kernel_type == "attitude_history")
+            .all()
+        )
+
+        if not attitude_kernels:
+            return SensorResult()
+
+        existing_partitions = context.instance.get_dynamic_partitions(
+            "pointing_attitude_partitions"
+        )
+
+        # Parse existing partitions into (start_str, end_str, key) for subsumption
+        # checks. %Y-%m-%dT%H:%M:%S is fixed-width and zero-padded, so
+        # lexicographic string comparison is equivalent to chronological order.
+        existing_parsed = []
+        for key in existing_partitions:
+            date_range = key.split("_", 1)[1]
+            if "_to_" in date_range:
+                start_str, end_str = date_range.split("_to_")
+                existing_parsed.append((start_str, end_str, key))
+
+        partitions_to_add = []
+        partitions_to_delete = []
+
+        for kernel in attitude_kernels:
+            if not kernel.min_date_datetime or not kernel.max_date_datetime:
+                continue
+            ah_min = kernel.min_date_datetime
+            ah_max = kernel.max_date_datetime
+
+            # First pointing with any overlap with the ah kernel coverage
+            first_overlapping = (
+                session.query(models.PointingTable)
+                .filter(
+                    models.PointingTable.pointing_start_utc < ah_max,
+                    models.PointingTable.repoint_start_utc > ah_min,
+                )
+                .order_by(models.PointingTable.pointing_start_utc)
+                .first()
+            )
+
+            # Last pointing completely contained within the ah kernel coverage
+            last_covered = (
+                session.query(models.PointingTable)
+                .filter(
+                    models.PointingTable.pointing_start_utc >= ah_min,
+                    models.PointingTable.repoint_start_utc <= ah_max,
+                )
+                .order_by(models.PointingTable.pointing_end_utc.desc())
+                .first()
+            )
+
+            # Skip if no pointings are completely covered yet
+            if not first_overlapping or not last_covered:
+                continue
+
+            new_start_str = first_overlapping.pointing_start_utc.strftime(
+                "%Y-%m-%dT%H:%M:%S"
+            )
+            new_end_str = last_covered.pointing_end_utc.strftime("%Y-%m-%dT%H:%M:%S")
+            new_partition_name = f"pointingattitude_{new_start_str}_to_{new_end_str}"
+
+            if new_partition_name in existing_partitions:
+                continue  # Already up to date
+
+            # Delete any existing partition whose range is fully contained within
+            # the new range. Covers both the growing-append case (same start,
+            # smaller end) and the retroactive combined-file case (many small
+            # early-mission partitions all subsumed by one large new partition).
+            subsumed = [
+                key
+                for start_str, end_str, key in existing_parsed
+                if start_str >= new_start_str and end_str <= new_end_str
+            ]
+            partitions_to_delete.extend(subsumed)
+            partitions_to_add.append(new_partition_name)
+
+        partition_requests = []
+        if partitions_to_delete:
+            partition_requests.append(
+                pointing_attitude_partitions.build_delete_request(partitions_to_delete)
+            )
+            context.log.info(f"Deleting subsumed partitions: {partitions_to_delete}")
+        if partitions_to_add:
+            partition_requests.append(
+                pointing_attitude_partitions.build_add_request(partitions_to_add)
+            )
+            context.log.info(f"Registered new partitions: {partitions_to_add}")
+
+    return SensorResult(dynamic_partitions_requests=partition_requests)
+
+
 sensors = [
     add_repoint_partitions,
     add_daily_partitions,
     add_idex_10_day_partitions,
     add_idex_30_day_partitions,
+    add_pointing_attitude_partitions,
 ]

--- a/sds_data_manager/orchestration/dependencies/imap_spacecraft_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_spacecraft_dependencies.yaml
@@ -5,7 +5,7 @@
 # and how to properly configure them for your pipeline lambdas.
 
 (l1a, pointing-attitude):
-  partition: repoint
+  partition: pointing_attitude
   inputs:
     - source: repoint
       data_type: repoint

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -88,6 +88,7 @@ priority_levels = {
 partition_map = {
     "daily": custom_partitions.daily_partitions,
     "repoint": custom_partitions.repoint_partitions,
+    "pointing_attitude": custom_partitions.pointing_attitude_partitions,
     "10d": custom_partitions.idex10_partitions,
     # NOTE: Right now, IDEX is the only instrument who uses 1mo cadence job that
     # maps to exactly 30 days. If this changes, this logic will need update.
@@ -519,6 +520,16 @@ class IMAPJobHandler:
                         models.AncillaryFiles.instrument,
                         models.AncillaryFiles.descriptor,
                     )
+                elif dependency.data_type == "repoint":
+                    # New repoint inputs — RepointFiles only has end_date, no start_date
+                    target_partitions = self.trigger_from_new_non_science_inputs(
+                        context,
+                        dependency,
+                        new_cursors,
+                        models.RepointFiles,
+                        datetime_start_column="end_date",
+                        datetime_end_column="end_date",
+                    )
                 # Now we loop through each partition that we received new data for, and
                 # determine if we need to start it again.
                 for target_partition in target_partitions:
@@ -839,8 +850,8 @@ class IMAPJobHandler:
                     processing_input.ScienceInput(*list(set(science_files)))
                 )
 
-        if not science_processing_inputs:
-            # Return right away if we have zero science files.
+        if not science_processing_inputs and self.job_config.science_inputs:
+            # Science inputs were configured but none were found.
             raise MissingDependenciesError(
                 "No science files were discovered. "
                 "All jobs require at least one science file."


### PR DESCRIPTION
# ## Fix and enable spacecraft `pointing-attitude` processing job
                                                                                                                                                                                                                                         
  ### Background
  
  The `spacecraft/l1a/pointing-attitude` job produces a SPICE kernel encoding
  despun spacecraft attitude for each pointing period. Its inputs are an
  `attitude_history` (ah) SPICE kernel and a `repoint` file; it has no science
  data inputs.
  
  The ah kernel has an unusual delivery pattern. Each new delivery *appends*
  coverage to the previous file, growing the covered time range up to
  approximately three months before resetting. Early in the mission, before the
  appending scheme was adopted, ah files covered approximately one day each. When
  conops changed, the team retroactively produced a single combined file covering
  the first ~three months.

  Because one run of the pointing-attitude job corresponds to the full coverage of
  one ah kernel cycle — not a calendar day — the partition and sensor logic require
  special handling compared to other processing jobs.

  ---

  ### Changes

  #### Bug fixes in `imap_job.py`
  
  **1. Science-input guard was unconditional**

  `get_science_files_inputs` raised
  `MissingDependenciesError("All jobs require at least one science file.")` whenever
  the collected science inputs were empty — even when the job was not configured
  with any science inputs at all. The pointing-attitude job has only SPICE and
  repoint inputs, so it hit this guard on every run. Fixed by adding
  `and self.job_config.science_inputs` to the condition, so the error is only
  raised when science inputs were *expected* but not found.

  **2. Sensor had no handler for `repoint` dependency type**

  The `build_sensor` loop dispatches on `dependency.data_type` to determine which
  table to query for new files. The supported types were `VALID_DATALEVELS`,                                                                                                                                                             
  `spice`, `spin`, and `ancillary`. There was no `repoint` case, so new repoint
  files never produced any `target_partitions` and never triggered the
  pointing-attitude job. Added an `elif dependency.data_type == "repoint":` branch
  calling `trigger_from_new_non_science_inputs` with `models.RepointFiles`.

  **3. `RepointFiles` has no `start_date` column**

  `trigger_from_new_non_science_inputs` defaults to reading `start_date` and
  `end_date` from each file record. `RepointFiles` only has `end_date`. Without
  explicit column overrides, this would raise `AttributeError` on the second sensor
  run (after the cursor advances past `MISSION_START_TIME`). The repoint branch                                                                                                                                                          
  passes `datetime_start_column="end_date"` and `datetime_end_column="end_date"`
  to avoid this.
  
  ---

  #### New custom partition: `pointing_attitude` (`custom_partitions.py`)

  `daily` partitions were previously configured for this job, meaning the sensor
  would attempt to run once per calendar day. This was wrong: the output of each
  job run covers the full time range of the ah kernel (potentially months), not a
  single day. One run corresponds to one ah kernel cycle.

  The new `pointing_attitude_partitions` (`DynamicPartitionsDefinition`) creates
  one partition per ah kernel, with the key encoding the *pointing* times covered —
  not the raw kernel timestamps:

  - **Start**: `pointing_start_utc` of the first pointing with any overlap with the ah kernel's coverage
  - **End**: `pointing_end_utc` of the last pointing *completely* contained within the ah kernel's coverage
  
  Using pointing times (rather than kernel timestamps) aligns the partition
  boundaries exactly with the science data being processed and ensures no
  partially-covered pointing is claimed as complete.
  
  **Partition lifecycle — subsumption-based deletion**

  The `add_pointing_attitude_partitions` sensor handles two update scenarios by
  deleting any existing partition whose full range is contained within the new
  partition's range before adding the new one:

  - *Growing-append case*: a new ah delivery extends the end date of an existing
    cycle. The old partition (same start, earlier end) is subsumed and replaced.
  - *Retroactive combined-file case*: a single large file covers a span previously
    represented by many small daily partitions. All of the older smaller partitions
    are subsumed and deleted in one sensor run, replaced by the single combined
    partition.

  The trigger for the job remains the `repoint` file (not `attitude_history`
  directly), because the repoint file is delivered to the SDC after the updated ah
  kernel, making it the reliable signal that all inputs are ready.                                                                                                                                                                       

  **Partition key prefix**

  The prefix `pointingattitude` (no underscores) is required because
  `parse_dates_from_partition_key` splits on the first `_` to isolate the date                                                                                                                                                           
  range portion of the key. A multi-word prefix with underscores would leave part
  of the prefix attached to the start datetime string, causing `strptime` to fail.

  ---

  #### Tests (`tests/orchestration/test_custom_partitions.py`)

  Seven unit tests covering:

  - No attitude history kernels in the database (no-op)
  - No pointings overlapping the ah kernel coverage
  - Partial coverage only — `first_overlapping` exists but `last_covered` is `None`
  - New partition created on first run
  - Already up to date — exact partition key already registered (no-op)
  - Growing-append case — old partition replaced when end date extends
  - Retroactive combined-file case — multiple daily partitions subsumed and replaced

  ---

  #### `pyproject.toml`

  Added `-p no:anyio` to `addopts`. Installing the `cdk-install` dependency group
  (which includes `dagster`) also pulls in `anyio`, which registers a pytest plugin
  requiring pytest ≥7. The project uses pytest 6.2.5. Disabling the plugin via
  `-p no:anyio` restores normal test collection without requiring a pytest upgrade.
