### PR TITLE
Modifying how pointing_attitude is kicked off

### DIFF
--- a/sds_data_manager/orchestration/custom_behavior/spacecraft.py
+++ b/sds_data_manager/orchestration/custom_behavior/spacecraft.py
@@ -1,6 +1,17 @@
 """Override behavior for Spacecraft processing."""
 
-from sds_data_manager.orchestration import imap_job
+import datetime
+import json
+
+from dagster import (
+    RunRequest,
+    SensorEvaluationContext,
+    sensor,
+)
+
+from sds_data_manager.orchestration import (
+    imap_job,
+)
 from sds_data_manager.orchestration.job_handler_registry import JobBuilderRegistry
 
 
@@ -11,3 +22,53 @@ class SpacecraftPointingAttitudeJob(imap_job.IMAPJobHandler):
     def get_science_files_inputs(self, context, target_start, target_end):
         """Override default behavior to return nothing."""
         return []
+
+    def build_sensor(self):
+        """Return a Dagster sensor monitoring for new dependencies.
+
+        By running on each new repoint partition, rather than new repoint files,
+        we ensure that dagster has been given enough time to actually create the
+        new custom partitions.
+
+        """
+        sensor_name = f"{self.job_config.to_dagster_name()}_kickoff_sensor"
+
+        @sensor(
+            name=sensor_name,
+            job=self.dagster_job,
+            minimum_interval_seconds=self.sensor_run_frequency,
+        )
+        def _sensor(context: SensorEvaluationContext):
+
+            # Create a unique suffix for this sensor trigger
+            job_suffix = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+            cursor_str = context.cursor or "[]"
+            processed_partitions = set(json.loads(cursor_str))
+
+            # Query the instance for the current state of the dynamic partitions
+            current_partitions = set(
+                context.instance.get_dynamic_partitions(self.partitions_def.name)
+            )
+            # Determine the delta
+            new_partitions = current_partitions - processed_partitions
+
+            # Yield a RunRequest for each new partition
+            for partition_key in new_partitions:
+                run_key = "_".join(
+                    [
+                        self.job_config.to_dagster_name(),
+                        partition_key,
+                        job_suffix,
+                    ]
+                )
+                yield RunRequest(
+                    run_key=run_key,
+                    partition_key=partition_key,
+                )
+
+            # Update the cursor so we don't process these again
+            # We store the full current set so the next tick has the latest baseline
+            context.update_cursor(json.dumps(list(current_partitions)))
+
+        return _sensor

--- a/sds_data_manager/orchestration/dependencies/imap_spacecraft_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_spacecraft_dependencies.yaml
@@ -5,7 +5,7 @@
 # and how to properly configure them for your pipeline lambdas.
 
 (l1a, pointing-attitude):
-  partition: daily
+  partition: repoint
   inputs:
     - source: repoint
       data_type: repoint

--- a/tests/orchestration/test_spacecraft.py
+++ b/tests/orchestration/test_spacecraft.py
@@ -70,7 +70,7 @@ def test_spacecraft_l1a_sensor(mock_db_session, ephemeral_instance):
     run_requests = list(sensor_result)
 
     # Verify things were kicked off
-    assert len(run_requests) > 270, "Expected numerous kickoffs to be attempted."
+    assert len(run_requests) == 10, "Expected a run for each repoint partition."
 
 
 def test_spacecraft_l1a_no_repoint(


### PR DESCRIPTION
# Change Summary

## Overview
Pointing attitude was kicked off daily with the most recent changes. However, it makes more sense to kick it off for every new repoint. 

In addition, I made a change to the sensor so that things are kicked off on every new repoint partition that has been added. I think this makes a little more sense than triggering on a new repoint file itself, since it ensures that we've had time for the actual partition to get created. 

## File changes
sds_data_manager/orchestration/custom_behavior/spacecraft.py
- The sensor will trigger on new repoint partitions. The previous behavior was that it would trigger every day. 

sds_data_manager/orchestration/dependencies/imap_spacecraft_dependencies.yaml
- Set to be repoint partitions instead of daily. This is only partially accurate, since technically it creates a file that could span many repoints. However, we don't currently keep track of the output of this job in Dagster, and "repoint" reflects the frequency that we want to kick off this job. Tim's PR is working on adding a new custom partition to handle the output, if we decide we want to keep track of the output.  

## Testing
tests/orchestration/test_spacecraft.py
- Change to reflect the new sensor output. We'd get a run for each repoint, rather than each day, and the test only adds 10 repoints. 
