### PR TITLE
Adding Lo L1c Quickmap job/data product

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
@@ -278,12 +278,39 @@ lo_esa_fit_factors: &lo_esa_fit_factors
     - source: lo
       data_type: l1b
       descriptor: bgrates
-
-# ======== Level L2 ========
   outputs:
     - source: lo
       data_type: l1c
       descriptor: pset
+
+(l1c, quickmap):
+  partition: repoint
+  inputs:
+    - *spice_basic
+    - source: lo
+      data_type: l1b
+      descriptor: de
+    - source: lo
+      data_type: l1b
+      descriptor: goodtimes
+    - source: lo
+      data_type: l1b
+      descriptor: bgrates
+    - source: lo
+      data_type: l1b
+      descriptor: nhk
+    - source: lo
+      data_type: l1b
+      descriptor: histrates
+    - source: spacecraft
+      data_type: l1a
+      descriptor: quaternions
+  outputs:
+    - source: lo
+      data_type: l1c
+      descriptor: quickmap
+
+# ======== Level L2 ========
 
 (l2, l090-ena-h-hf-nsp-ram-hae-6deg-1yr):
   partition: 1yr


### PR DESCRIPTION
# Change Summary

## Overview
Adding a new Lo L1c Quickmap Job/Product. This is a re-do of this PR: https://github.com/IMAP-Science-Operations-Center/sds-data-manager/pull/1325 but using the new YAML files instead of the old CSV. 

## File changes
imap_lo_dependencies.yaml updated 

## Testing
No testing needed, other than unit tests passing
