### PR TITLE
Removing ancillary deps for SWAPI L3

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_swapi_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_swapi_dependencies.yaml
@@ -130,22 +130,7 @@ l3a_spice_common: &l3a_spice_common
       trigger_job: false
     - source: swapi
       data_type: ancillary
-      descriptor: clock-angle-and-flow-deflection-lut
-      trigger_job: false
-    - source: swapi
-      data_type: ancillary
-      descriptor: proton-density-temperature-lut
-      trigger_job: false
-    - source: swapi
-      data_type: ancillary
-      descriptor: alpha-density-temperature-lut
-    - source: swapi
-      data_type: ancillary
       descriptor: energy-gf-pui-lut
-      trigger_job: false
-    - source: swapi
-      data_type: ancillary
-      descriptor: instrument-response-lut
       trigger_job: false
     - source: swapi
       data_type: ancillary
@@ -177,21 +162,7 @@ l3a_spice_common: &l3a_spice_common
       descriptor: sci
     - source: swapi
       data_type: ancillary
-      descriptor: clock-angle-and-flow-deflection-lut
-    - source: swapi
-      data_type: ancillary
-      descriptor: proton-density-temperature-lut
-    - source: swapi
-      data_type: ancillary
-      descriptor: alpha-density-temperature-lut
-      trigger_job: false
-    - source: swapi
-      data_type: ancillary
       descriptor: energy-gf-pui-lut
-      trigger_job: false
-    - source: swapi
-      data_type: ancillary
-      descriptor: instrument-response-lut
       trigger_job: false
     - source: swapi
       data_type: ancillary
@@ -223,21 +194,7 @@ l3a_spice_common: &l3a_spice_common
       descriptor: sci
     - source: swapi
       data_type: ancillary
-      descriptor: clock-angle-and-flow-deflection-lut
-    - source: swapi
-      data_type: ancillary
-      descriptor: proton-density-temperature-lut
-      trigger_job: false
-    - source: swapi
-      data_type: ancillary
-      descriptor: alpha-density-temperature-lut
-      trigger_job: false
-    - source: swapi
-      data_type: ancillary
       descriptor: energy-gf-pui-lut
-    - source: swapi
-      data_type: ancillary
-      descriptor: instrument-response-lut
     - source: swapi
       data_type: ancillary
       descriptor: density-of-neutral-helium-lut


### PR DESCRIPTION
# Change Summary

## Overview
SWAPI no longer needs some ancillary files for L3, per Menlo. This is a refactor of the PR here: https://github.com/IMAP-Science-Operations-Center/sds-data-manager/pull/1320, since that one was slightly out of date. 


## File changes
sds_data_manager/orchestration/dependencies/imap_swapi_dependencies.yaml

Removed some of the ancillary file dependencies 


## Testing
Unit tests pass
