### PR TITLE
Add major version and output products to dependency hash

### DIFF
--- a/sds_data_manager/orchestration/custom_behavior/idex.py
+++ b/sds_data_manager/orchestration/custom_behavior/idex.py
@@ -14,6 +14,7 @@ from dagster import (
     asset,
     sensor,
 )
+from imap_data_access.file_validation import Version
 from sqlalchemy import select
 
 from sds_data_manager.lambda_code.SDSCode.database import database as db
@@ -72,20 +73,23 @@ class IDEXL0FileHandler(imap_file.IMAPScienceFileHandler):
                         base = filename.rsplit("_", 1)[0]  # strip "_v001.pkts"
                         # "imap_idex_l0_raw_20260408_v001.pkts" ->
                         # "imap_idex_l0_raw_20260408"
-                        if base not in best or rec.version > best[base].version:
+                        current_version = Version(rec.major_version, rec.minor_version)
+                        if base not in best or current_version > Version(
+                            best[base].major_version, best[base].minor_version
+                        ):
                             best[base] = rec
 
                     for rec in best.values():
                         filename = os.path.basename(rec.file_path)
                         files.append(filename)
-                        versions.append(int(rec.version[1:]))
+                        versions.append(Version(rec.major_version, rec.minor_version))
 
                     materialization = get_materialization_result(
                         context,
                         AssetKey("idex_l0_raw"),
                         current_partition,
                         files,
-                        str(max(versions)),
+                        max(versions),
                         "science",
                     )
                     if materialization:

--- a/sds_data_manager/orchestration/custom_behavior/l3_jobs.py
+++ b/sds_data_manager/orchestration/custom_behavior/l3_jobs.py
@@ -74,7 +74,9 @@ class L3CronHandler(imap_job.IMAPJobHandler):
         )
         return file
 
-    def _dependency_hash(self, serialized_dependencies: str):
+    def _dependency_hash(
+        self, serialized_dependencies: str, output_versions: dict[str, dict[str, int]]
+    ) -> str:
         """Generate a hash for the serialized dependencies.
 
         We are overriding the behavior of IMAPJobHandler. Dependencies are largely
@@ -86,6 +88,8 @@ class L3CronHandler(imap_job.IMAPJobHandler):
         ----------
         serialized_dependencies : str
             The serialized dependencies string.
+        output_versions : dict[str, dict[str, int]]
+            The output versions dictionary.
 
         Returns
         -------

--- a/sds_data_manager/orchestration/dependencies/imap_mag_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_mag_dependencies.yaml
@@ -36,6 +36,11 @@
       data_type: l1a
       descriptor: burst-mago
       major_version: 1
+    - source: mag
+      data_type: l1a
+      descriptor: burst-raw
+      major_version: 1
+
 
 (l1b, burst-magi):
   partition: daily

--- a/sds_data_manager/orchestration/imap_file.py
+++ b/sds_data_manager/orchestration/imap_file.py
@@ -10,6 +10,7 @@ from dagster import (
     SensorResult,
     sensor,
 )
+from imap_data_access.file_validation import Version
 from sqlalchemy import select
 
 from sds_data_manager.lambda_code.SDSCode.database import database as db
@@ -72,7 +73,8 @@ class IMAPScienceFileHandler:
                 .order_by(
                     models.ScienceFiles.start_date,
                     models.ScienceFiles.repointing,
-                    models.ScienceFiles.version.desc(),
+                    models.ScienceFiles.major_version.desc(),
+                    models.ScienceFiles.minor_version.desc(),
                 )
             )
 
@@ -127,7 +129,7 @@ class IMAPScienceFileHandler:
                             self.job_config.to_dagster_asset(),
                             partition,
                             [os.path.basename(record.file_path)],
-                            str(int(record.version[1:])),
+                            Version(record.major_version, record.minor_version),
                             "science",
                         )
                         if materialization:

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -1070,7 +1070,7 @@ class IMAPJobHandler:
         dependency_strings.append(self._get_container_image_digest())
         # Append a string of each output descriptor and its major version, sorted
         # alphabetically by descriptor
-        # e.g. 'burst-magi:1,burst-mago:1,norm-magi:1,norm-mago:1'
+        # e.g. 'burst-magi:1,burst-mago:1,burst-raw:1,norm-magi:1,norm-mago:1'
         version_string = ",".join(
             sorted(
                 [

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -1213,7 +1213,7 @@ class IMAPJobHandler:
         # Add the dependency hash and version hash to the dependency file name to ensure
         # uniqueness. The dependency hash is based on the upstream dependencies and the
         # container image digest. The version hash is based on the output versions.
-        dep_hash = self._dependency_hash(serialized_dependencies)
+        dep_hash = self._dependency_hash(serialized_dependencies, output_versions)
         version_hash = self._get_sha256_descriptor(json.dumps(output_versions))
         dep_descriptor = f"{self.job_config.descriptor}-{dep_hash}-{version_hash}"
         dependency_file = DependencyFilePath.generate_from_inputs(

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -1031,21 +1031,29 @@ class IMAPJobHandler:
 
         return output_versions
 
-    def _dependency_hash(self, serialized_dependencies: str):
+    def _dependency_hash(
+        self, serialized_dependencies: str, output_versions: dict[str, dict[str, int]]
+    ) -> str:
         """Generate a hash for the serialized dependencies.
 
         This is a unique ID for a particular run. Dagster will refuse to run a job with
-        the same dependency_hash.
+        the same dependency_hash. It is created from the upstream dependencies,
+        the container image hash, and the output products and their major version
+        numbers.
 
         Parameters
         ----------
         serialized_dependencies : str
             The serialized dependencies string.
+        output_versions : dict[str, dict[str, int]]
+            A dictionary of major and minor version numbers for each output descriptor.
 
         Returns
         -------
         str
-            The first 8 characters of the SHA-256 hash of the serialized dependencies.
+            The first 8 characters of the SHA-256 hash of the serialized dependencies,
+            container image digest, and output products and their major versions
+             numbers
         """
         # We need to pull out the individual files and put them in alphabetical order
         dependencies = json.loads(serialized_dependencies)
@@ -1058,9 +1066,21 @@ class IMAPJobHandler:
                     # difference to processing.
                     non_sclk_deps.append(file)
         # Append the image_digest
-        sorted_files = sorted(list(set(non_sclk_deps)))
-        sorted_files.append(self._get_container_image_digest())
-        joined_string = "|".join(sorted_files)
+        dependency_strings = sorted(list(set(non_sclk_deps)))
+        dependency_strings.append(self._get_container_image_digest())
+        # Append a string of each output descriptor and its major version, sorted
+        # alphabetically by descriptor
+        # e.g. 'burst-magi:1,burst-mago:1,norm-magi:1,norm-mago:1'
+        version_string = ",".join(
+            sorted(
+                [
+                    f"{desc}:{val['major_version']}"
+                    for desc, val in output_versions.items()
+                ]
+            )
+        )
+        dependency_strings.append(version_string)
+        joined_string = "|".join(dependency_strings)
 
         return self._get_sha256_descriptor(joined_string)
 

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -1036,10 +1036,13 @@ class IMAPJobHandler:
     ) -> str:
         """Generate a hash for the serialized dependencies.
 
-        This is a unique ID for a particular run. Dagster will refuse to run a job with
-        the same dependency_hash. It is created from the upstream dependencies,
-        the container image hash, and the output products and their major version
-        numbers.
+        This is a unique ID for a particular run. This is a unique ID for a particular
+        run. Dagster will refuse to run a job with the same dependency_hash. It is
+        derived from the upstream dependencies, the container image hash, and the
+        output products' major version numbers. Minor versions are excluded because
+        they only change with a dependency update, major version bump, or code change —
+        whereas major versions can change independent of those, so excluding minor lets
+        us reprocess when only the major version has been bumped.
 
         Parameters
         ----------


### PR DESCRIPTION
# Change Summary

closes #1462 
## Overview

We need to add the output products and major versions to the dependency hash. This will give us the ability to reprocess files when the dependencies have not changed but we have bumped a major version number. The minor version should NOT be included in the dependency hash because the minor version should only get updated when we have a dependency update, a major version bump, or a code change. The major can change when there hasnt been a code change or a dependency update.

This PR also adds some small fixes I found during testing today. 

## File changes
- sds_data_manager/orchestration/custom_behavior/idex.py
   - in the idex.py code, we were deduping files to only materialize the latest ones. I updated this code to use the new version format
- sds_data_manager/orchestration/dependencies/imap_mag_dependencies.yaml
   - During one of my first tests, the mag l1a job failed because the version dict was missing the output for burst-raw. ***NOTE*** we should double check that all outputs are being accounted for because it will error out if they are not in the dependency yaml. This is new behavior after Vineets PR. 
   - sds_data_manager/orchestration/imap_job.py
      - dependency hash updates. 