### PR TITLE
Version migration from vXXX -> vMMM.mmmm

### DIFF
--- a/scripts/migrate/README.md
+++ b/scripts/migrate/README.md
@@ -1,0 +1,133 @@
+# Science-file S3/DB migration
+
+One-off tooling to re-version IMAP science files: it rewrites each file's
+name (and the embedded CDF metadata) to the new versioning scheme and updates
+the matching `science_files` rows in the RDS database.
+
+The heavy lifting runs on a short-lived EC2 instance so it has in-region, egress-free
+access to the S3 bucket and the RDS instance. The `run` script provisions that
+instance, ships the migration code to it, executes it, and tears everything down.
+
+```
+run (your laptop)
+ ├─ ensures IAM role + instance profile + key pair exist
+ ├─ launches (or reuses) a t3.large EC2 instance
+ ├─ opens the RDS security group to that instance's IP
+ ├─ scp run_remote.sh + migrate.py to the instance
+ └─ ssh: run_remote.sh
+         ├─ installs uv + Python deps
+         └─ python migrate.py   <- the actual S3 / DB migration
+```
+
+On exit (success, failure, or Ctrl-C) the instance is terminated and the
+security-group rule is revoked automatically.
+
+---
+
+## Prerequisites
+
+On the **local** machine that runs `run`:
+
+- AWS CLI v2, authenticated for the target account. `run` uses
+  `AWS_PROFILE=imap-dev` — set up that profile (`aws configure --profile imap-dev`)
+  or edit the variable at the top of `run`.
+- Permission to manage IAM roles/instance profiles, EC2 key pairs and
+  instances, and to modify the RDS security group.
+- `ssh`, `scp`, `openssl`, `envsubst` on `PATH`.
+
+Run `bash run` to test out the setup. This won't actually run the migration, simply
+print out the old name -> new name mapping.
+
+---
+
+## Configuration
+
+Configure the run by editing the variables near the top of `run`, then execute it.
+
+| Variable | Default | Meaning                                                    |
+|----------|---------|------------------------------------------------------------|
+| `COPY_FILES` | `0`     | `1` = copy/rewrite files in S3 (stage 1).                  |
+| `MODIFY_ROWS` | `0`     | `1` = update `file_path` in the database (stage 2).         |
+| `OVERWRITE` | `0`     | `1` = re-copy destination files even if they already exist. |
+| `MAX_FILES` | `1000`  | Max CDF/PKTS files to process this run (`0` = all).        |
+
+> **`COPY_FILES` and `MODIFY_ROWS` are mutually exclusive.** `migrate.py`
+> asserts you never enable both in the same run — do it in stages (below).
+
+---
+
+## Workflow
+
+### Incremental file copying (stage 1)
+
+```bash
+COPY_FILES=1
+MODIFY_ROWS=0
+```
+
+Reads each source object under `imap/`, rewrites the CDF metadata
+(`Data_version`, `Logical_file_id`, `Parents`) and writes it to the new name
+under the `renamed/` prefix. PKTS files are copied as-is to the new name.
+Existing objects under `renamed/` are skipped, so this stage is resumable and
+can be run in batches (see below).
+
+`MAX_FILES` limits how many CDF/PKTS files a single run processes. Because
+stage 1 **skips destinations that already exist** under `renamed/`, repeated
+runs with the same `MAX_FILES` walk through the whole set a batch at a time:
+
+```bash
+# in run: COPY_FILES=1, MODIFY_ROWS=0, OVERWRITE=0, MAX_FILES=1000
+bash run   # copies the first 1000 not-yet-copied files
+bash run   # copies the next 1000
+bash run   # ... repeat until everything is under renamed/
+```
+
+Set `MAX_FILES=0` to process everything in one run. *Not recommended.* except for
+testing. `prod` has ~281k files. Probably try 1000 first to see how long it takes.
+
+To **regenerate** files you have already copied (e.g. after fixing the metadata
+logic), set `OVERWRITE=1`. This disables the skip-if-exists behavior and
+re-copies the selected files in place.
+
+Copying runs across multiple CPU cores automatically (one worker per core).
+`run` uses `t3.large` (2 vCPUs), so two files are rewritten in parallel;
+use a larger instance type if you want more throughput. `t3.xlarge` has 4 vCPUs.
+`t3.2xlarge` has 8 vCPUs.
+
+
+### Manual step - promote the renamed files
+
+After verifying `renamed/`, back up the existing `imap/` tree and then bulk-move
+objects from `renamed/..` to their final `imap/..` paths. `run` does not do this move
+for you.
+
+You will want to keep the `ancillary/`, `dependency/` and `spice/` trees in `imap/`
+intact, since these do not have rows in the science_files table and are not affected by
+the renaming.
+
+### Update the database (stage 2)
+
+```bash
+COPY_FILES=0
+MODIFY_ROWS=1
+```
+
+Updates each `science_files.file_path` from the old name to the new one.
+
+Then run it:
+
+```bash
+bash run        # or ./run
+```
+
+#### Tips
+
+- Inspect s3 bucket in a separate terminal to monitor file copy progress.
+
+  ```bash
+  aws s3 ls s3://sds-data-449431850278/renamed/ --recursive --summarize --human-readable
+  ```
+
+- Set `INTERACTIVE=1` to provision the instance and drop into an SSH shell
+instead of running the migration. The instance is still torn down when you exit
+the shell.

--- a/scripts/migrate/ec2-perms.json
+++ b/scripts/migrate/ec2-perms.json
@@ -1,0 +1,27 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::${AWS_BUCKET}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::${AWS_BUCKET}/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": "arn:aws:secretsmanager:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT}:secret:sdp-database-cred*"
+    }
+  ]
+}

--- a/scripts/migrate/ec2-trust.json
+++ b/scripts/migrate/ec2-trust.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/scripts/migrate/migrate.py
+++ b/scripts/migrate/migrate.py
@@ -1,0 +1,220 @@
+"""Migration script for renaming science files in S3/DB."""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import boto3
+import imap_data_access
+from imap_data_access.file_validation import ScienceFilePath, Version
+from imap_processing.cdf.utils import load_cdf
+from imap_processing.cdf.utils import write_cdf as _write_cdf
+
+from sds_data_manager.lambda_code.SDSCode.database import database as db
+from sds_data_manager.lambda_code.SDSCode.database import models
+
+# Destination prefix for copied files
+DEST_PREFIX: str = "renamed/"
+# Maximum number of CDFs/PKTs to process; None for all (for testing on dev)
+MAX_CDFS_PKTS: int | None = None
+# Reverse the sense of `old` vs `new` paths? (for testing on dev)
+REVERSE: bool = False
+# Write a dummy CDF instead of a real one to make the script go fast (for testing)
+DUMMY_CDF: bool = False
+
+
+def write_cdf(dataset, **kwargs):
+    """Write a CDF, or a dummy placeholder file if ``DUMMY_CDF`` is set."""
+    if DUMMY_CDF:
+        with tempfile.NamedTemporaryFile(suffix=".cdf", delete=False) as tmp:
+            tmp.write(b"dummy cdf")
+            return tmp.name
+    return _write_cdf(dataset, **kwargs)
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
+
+
+def remap_parents(dataset, basename_map: dict[str, str]):
+    """Update the ``Parents`` attribute to reflect the CDF renaming.
+
+    ``Parents`` is a list of dependency file *basenames* (see imap_processing
+    ``cli.py``: ``[p.name for p in dependencies.get_file_paths()]``). Many of
+    those parents are themselves science files being renamed by this migration,
+    so each basename is remapped via ``basename_map``. Parents not in the map
+    (e.g. SPICE/ancillary files) are left unchanged. ``load_cdf`` collapses a
+    single-element ``Parents`` to a scalar string.
+    """
+    parents = dataset.attrs.get("Parents")
+    if parents is None:
+        return
+    if isinstance(parents, str):
+        parents = [parents]
+    dataset.attrs["Parents"] = [basename_map.get(p, p) for p in list(parents)]
+
+
+def upload_cdf(
+    client,
+    bucket: str,
+    src_key: str,
+    dst_key: str,
+    dst_version: str,
+    basename_map: dict[str, str],
+):
+    """Download/modify/upload a pkts/cdf file on S3."""
+    if src_key.endswith("pkts"):
+        client.copy_object(
+            Bucket=bucket,
+            CopySource={"Bucket": bucket, "Key": src_key},
+            Key=dst_key,
+        )
+        logger.info(f"Copied PKTS {src_key} -> s3://{bucket}/{dst_key}")
+        return
+
+    with tempfile.NamedTemporaryFile(suffix=".cdf") as tmp:
+        client.download_fileobj(bucket, src_key, tmp)
+        tmp.flush()
+        dataset = load_cdf(tmp.name)
+
+    # From @tech3371 - `Data_version` is sans `v`
+    dataset.attrs["Data_version"] = dst_version.lstrip("v")
+
+    # Parent filenames embed the old version format and may themselves be
+    # renamed science files, so remap them to match the new CDF names.
+    remap_parents(dataset, basename_map)
+
+    # Making guarantees about spdf conformance on existing files is out of scope
+    written = Path(write_cdf(dataset, istp=True, terminate_on_warning=False))
+    try:
+        client.upload_file(str(written), bucket, dst_key)
+    finally:
+        written.unlink(missing_ok=True)
+    logger.info(f"Copied CDF {src_key} -> s3://{bucket}/{dst_key}")
+
+
+def get_s3_keys(bucket, prefix="imap/"):
+    """Return the set of all object keys in ``bucket`` under ``prefix``."""
+    client = boto3.client("s3")
+    paginator = client.get_paginator("list_objects_v2")
+    keys = set()
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        keys.update(obj["Key"] for obj in page.get("Contents", []))
+    return keys
+
+
+def migrate(copy_files: bool = False, modify_rows: bool = False):  # noqa: PLR0912, PLR0915
+    """Migrate science files in S3 or update the database."""
+    assert not all([copy_files, modify_rows]), "Please do this in stages!"
+
+    data_dir = imap_data_access.config["DATA_DIR"]
+
+    bucket = os.getenv("S3_BUCKET")
+    if not bucket:
+        raise ValueError("S3_BUCKET environment variable is not set")
+    logger.info(f"Listing objects in s3://{bucket}/imap/ ...")
+    s3_keys = get_s3_keys(bucket)
+    logger.info(f"Found {len(s3_keys)} objects in the bucket")
+
+    n_cdfs_pkts = 0
+
+    with db.Session() as session:
+        count = session.query(models.ScienceFiles).count()
+        logger.info(f"Verifying file_path mapping for {count} records")
+
+        # (current_path, current_version_str) => (new_path, new_version_str)
+        path_mapping: dict[tuple[str, str], tuple[str, str]] = {}
+
+        # old_basename => new_basename, covering ALL rows (not just the ones
+        # copied this run) so the `Parents` attribute can be fully remapped.
+        basename_map: dict[str, str] = {}
+
+        for row in session.query(models.ScienceFiles):
+            old_version = str(Version(None, row.minor_version))
+            new_version = str(Version(row.major_version, row.minor_version))
+
+            old_suffix = f"_{old_version}.{row.extension}"
+            new_suffix = f"_{new_version}.{row.extension}"
+
+            # Construct the new filename from scratch using the table columns.
+            new_file = ScienceFilePath.generate_from_inputs(
+                instrument=row.instrument,
+                data_level=row.data_level,
+                descriptor=row.descriptor,
+                start_time=row.start_date.strftime("%Y%m%d"),
+                major_version=row.major_version,
+                minor_version=row.minor_version,
+                extension=row.extension,
+                repointing=row.repointing,
+                cr=row.cr,
+            )
+
+            # construct_path() prepends DATA_DIR; strip it
+            new_file_path = str(new_file.construct_path().relative_to(data_dir))
+            old_file_path = new_file_path[: -len(new_suffix)] + old_suffix
+
+            basename_map[os.path.basename(old_file_path)] = os.path.basename(
+                new_file_path
+            )
+
+            if new_file_path.endswith(".cdf") or new_file_path.endswith(".pkts"):
+                n_cdfs_pkts += 1
+                if MAX_CDFS_PKTS is None or n_cdfs_pkts <= MAX_CDFS_PKTS:
+                    path_mapping[(old_file_path, old_version)] = (
+                        new_file_path,
+                        new_version,
+                    )
+
+        if REVERSE:
+            rename_map = {v: k for k, v in path_mapping.items()}
+            basename_map = {v: k for k, v in basename_map.items()}
+        else:
+            rename_map = dict(path_mapping)
+
+        for (src_path, _), (dst_path, _) in rename_map.items():
+            logger.info(f"Mapping {src_path} -> {dst_path}")
+
+        dst_paths = list(rename_map.values())
+        assert len(set(dst_paths)) == len(dst_paths), "Duplicates in dst_paths!"
+
+        if copy_files:
+            client = boto3.client("s3")
+            for (src_path, _), (dst_path, dst_version) in rename_map.items():
+                if src_path == dst_path:
+                    logger.info(f"Identical src/dst: {src_path}")
+                    continue
+                if src_path not in s3_keys:
+                    logger.info(f"Cannot read missing object: {src_path}")
+                    continue
+
+                dst_key = f"{DEST_PREFIX}{dst_path}"
+                try:
+                    upload_cdf(
+                        client, bucket, src_path, dst_key, dst_version, basename_map
+                    )
+                except Exception as e:
+                    logger.info(f"Failed to copy {src_path} -> {dst_key} - {e}")
+                    continue
+            logger.info("All destination files written")
+
+        # Updating rows does not use `dst_key` at all. It is assumed that after making
+        # a backup of the `imap/` path in the S3 bucket, files will be moved from
+        # DEST_PREFIX to the original path in bulk, and then this block will be run.
+        if modify_rows:
+            for (src_path, _), (dst_path, _) in rename_map.items():
+                session.query(models.ScienceFiles).filter(
+                    models.ScienceFiles.file_path == src_path
+                ).update(
+                    {models.ScienceFiles.file_path: dst_path},
+                    synchronize_session=False,
+                )
+            session.commit()
+            logger.info(f"Updated file_path for {len(rename_map)} records")
+
+
+if __name__ == "__main__":
+    copy_files = os.getenv("COPY_FILES", "0") == "1"
+    modify_rows = os.getenv("MODIFY_ROWS", "0") == "1"
+    migrate(copy_files=copy_files, modify_rows=modify_rows)

--- a/scripts/migrate/migrate.py
+++ b/scripts/migrate/migrate.py
@@ -1,8 +1,10 @@
 """Migration script for renaming science files in S3/DB."""
 
 import logging
+import multiprocessing as mp
 import os
 import tempfile
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import boto3
@@ -16,8 +18,6 @@ from sds_data_manager.lambda_code.SDSCode.database import models
 
 # Destination prefix for copied files
 DEST_PREFIX: str = "renamed/"
-# Maximum number of CDFs/PKTs to process; None for all (for testing on dev)
-MAX_CDFS_PKTS: int | None = None
 # Reverse the sense of `old` vs `new` paths? (for testing on dev)
 REVERSE: bool = False
 # Write a dummy CDF instead of a real one to make the script go fast (for testing)
@@ -53,7 +53,16 @@ def remap_parents(dataset, basename_map: dict[str, str]):
         return
     if isinstance(parents, str):
         parents = [parents]
-    dataset.attrs["Parents"] = [basename_map.get(p, p) for p in list(parents)]
+
+    # verbose, but we need the logging
+    new_parents = []
+    for p in parents:
+        if p in basename_map:
+            logger.info(f"Remapping parent {p} to {basename_map[p]}")
+            new_parents.append(basename_map[p])
+        else:
+            new_parents.append(p)
+    dataset.attrs["Parents"] = new_parents
 
 
 def upload_cdf(
@@ -63,15 +72,17 @@ def upload_cdf(
     dst_key: str,
     dst_version: str,
     basename_map: dict[str, str],
+    overwrite: bool = False,
 ):
     """Download/modify/upload a pkts/cdf file on S3."""
-    try:
-        client.head_object(Bucket=bucket, Key=dst_key)
-    except client.exceptions.ClientError:
-        pass
-    else:
-        logger.info(f"Target exists, leaving untouched: s3://{bucket}/{dst_key}")
-        return
+    if not overwrite:
+        try:
+            client.head_object(Bucket=bucket, Key=dst_key)
+        except client.exceptions.ClientError:
+            pass
+        else:
+            logger.info(f"Target exists, leaving untouched: s3://{bucket}/{dst_key}")
+            return
 
     if src_key.endswith("pkts"):
         client.copy_object(
@@ -90,6 +101,10 @@ def upload_cdf(
     # From @tech3371 - `Data_version` is sans `v`
     dataset.attrs["Data_version"] = dst_version.lstrip("v")
 
+    # `Logical_file_id` must match the renamed filename, sans extension.
+    dataset.attrs["Logical_file_id"] = Path(dst_key).stem
+    logger.info(f"Logical_file_id = {dataset.attrs['Logical_file_id']}")
+
     # Parent filenames embed the old version format and may themselves be
     # renamed science files, so remap them to match the new CDF names.
     remap_parents(dataset, basename_map)
@@ -103,6 +118,39 @@ def upload_cdf(
     logger.info(f"Copied CDF {src_key} -> s3://{bucket}/{dst_key}")
 
 
+# --- Parallel copy workers -------------------------------------------------
+# Each pool worker holds its own boto3 client (clients must not be shared
+# across processes) plus the read-only state every copy needs. Populated once
+# per process by the pool initializer, then reused for every task.
+_WORKER: dict = {}
+
+
+def _init_worker(bucket: str, basename_map: dict[str, str], overwrite: bool):
+    """Set up per-process state for the copy pool."""
+    _WORKER["client"] = boto3.client("s3")
+    _WORKER["bucket"] = bucket
+    _WORKER["basename_map"] = basename_map
+    _WORKER["overwrite"] = overwrite
+
+
+def _copy_one(task: tuple[str, str, str]) -> tuple[str, str, str | None]:
+    """Copy one file in a worker; return ``(src, dst, error_or_None)``."""
+    src_path, dst_key, dst_version = task
+    try:
+        upload_cdf(
+            _WORKER["client"],
+            _WORKER["bucket"],
+            src_path,
+            dst_key,
+            dst_version,
+            _WORKER["basename_map"],
+            overwrite=_WORKER["overwrite"],
+        )
+        return src_path, dst_key, None
+    except Exception as e:
+        return src_path, dst_key, str(e)
+
+
 def get_s3_keys(bucket, prefix="imap/"):
     """Return the set of all object keys in ``bucket`` under ``prefix``."""
     client = boto3.client("s3")
@@ -113,7 +161,45 @@ def get_s3_keys(bucket, prefix="imap/"):
     return keys
 
 
-def migrate(copy_files: bool = False, modify_rows: bool = False):  # noqa: PLR0912, PLR0915
+def compute_paths(row, data_dir):
+    """Return ``(old_path, old_version, new_path, new_version)`` for a DB row.
+
+    Paths are relative to ``data_dir``. The new filename is constructed from
+    the table columns; the old path differs only in the version suffix (the
+    old names lacked the major version).
+    """
+    old_version = str(Version(None, row.minor_version))
+    new_version = str(Version(row.major_version, row.minor_version))
+
+    old_suffix = f"_{old_version}.{row.extension}"
+    new_suffix = f"_{new_version}.{row.extension}"
+
+    # Construct the new filename from scratch using the table columns.
+    new_file = ScienceFilePath.generate_from_inputs(
+        instrument=row.instrument,
+        data_level=row.data_level,
+        descriptor=row.descriptor,
+        start_time=row.start_date.strftime("%Y%m%d"),
+        major_version=row.major_version,
+        minor_version=row.minor_version,
+        extension=row.extension,
+        repointing=row.repointing,
+        cr=row.cr,
+    )
+
+    # construct_path() prepends DATA_DIR; strip it
+    new_file_path = str(new_file.construct_path().relative_to(data_dir))
+    old_file_path = new_file_path[: -len(new_suffix)] + old_suffix
+    return old_file_path, old_version, new_file_path, new_version
+
+
+def migrate(  # noqa: PLR0912, PLR0915
+    copy_files: bool = False,
+    modify_rows: bool = False,
+    overwrite: bool = False,
+    max_files: int = 0,
+    max_workers: int = 0,
+):
     """Migrate science files in S3 or update the database."""
     assert not all([copy_files, modify_rows]), "Please do this in stages!"
 
@@ -126,54 +212,51 @@ def migrate(copy_files: bool = False, modify_rows: bool = False):  # noqa: PLR09
     s3_keys = get_s3_keys(bucket)
     logger.info(f"Found {len(s3_keys)} objects in the bucket")
 
-    n_cdfs_pkts = 0
-
     with db.Session() as session:
         count = session.query(models.ScienceFiles).count()
         logger.info(f"Verifying file_path mapping for {count} records")
 
-        # (current_path, current_version_str) => (new_path, new_version_str)
-        path_mapping: dict[tuple[str, str], tuple[str, str]] = {}
-
         # old_basename => new_basename, covering ALL rows (not just the ones
         # copied this run) so the `Parents` attribute can be fully remapped.
         basename_map: dict[str, str] = {}
-
         for row in session.query(models.ScienceFiles):
-            old_version = str(Version(None, row.minor_version))
-            new_version = str(Version(row.major_version, row.minor_version))
-
-            old_suffix = f"_{old_version}.{row.extension}"
-            new_suffix = f"_{new_version}.{row.extension}"
-
-            # Construct the new filename from scratch using the table columns.
-            new_file = ScienceFilePath.generate_from_inputs(
-                instrument=row.instrument,
-                data_level=row.data_level,
-                descriptor=row.descriptor,
-                start_time=row.start_date.strftime("%Y%m%d"),
-                major_version=row.major_version,
-                minor_version=row.minor_version,
-                extension=row.extension,
-                repointing=row.repointing,
-                cr=row.cr,
-            )
-
-            # construct_path() prepends DATA_DIR; strip it
-            new_file_path = str(new_file.construct_path().relative_to(data_dir))
-            old_file_path = new_file_path[: -len(new_suffix)] + old_suffix
-
+            old_file_path, _, new_file_path, _ = compute_paths(row, data_dir)
             basename_map[os.path.basename(old_file_path)] = os.path.basename(
                 new_file_path
             )
 
-            if new_file_path.endswith(".cdf") or new_file_path.endswith(".pkts"):
-                n_cdfs_pkts += 1
-                if MAX_CDFS_PKTS is None or n_cdfs_pkts <= MAX_CDFS_PKTS:
-                    path_mapping[(old_file_path, old_version)] = (
-                        new_file_path,
-                        new_version,
-                    )
+        # Destinations already copied under DEST_PREFIX. Skipping these lets
+        # repeated copy runs advance through the full set, max_files at a time,
+        # instead of re-copying the same first N. Only meaningful when copying
+        # and not force-overwriting (overwrite deliberately re-copies existing).
+        existing_dsts: set[str] = set()
+        if copy_files and not overwrite:
+            existing_dsts = get_s3_keys(bucket, prefix=DEST_PREFIX)
+            logger.info(f"Found {len(existing_dsts)} objects under {DEST_PREFIX}")
+
+        # Candidate CDF/PKTS rows, deterministically ordered so the "next N not
+        # yet copied" is well-defined and reproducible across runs.
+        candidates = (
+            session.query(models.ScienceFiles)
+            .filter(models.ScienceFiles.extension.in_(["cdf", "pkts"]))
+            .order_by(models.ScienceFiles.file_path)
+        )
+
+        # (current_path, current_version_str) => (new_path, new_version_str),
+        # skipping files already present under DEST_PREFIX and capping the
+        # selection at max_files rows (0 => no cap).
+        path_mapping: dict[tuple[str, str], tuple[str, str]] = {}
+        for row in candidates:
+            old_file_path, old_version, new_file_path, new_version = compute_paths(
+                row, data_dir
+            )
+            # Path actually written under DEST_PREFIX (old vs new per REVERSE).
+            dst_path = old_file_path if REVERSE else new_file_path
+            if f"{DEST_PREFIX}{dst_path}" in existing_dsts:
+                continue
+            path_mapping[(old_file_path, old_version)] = (new_file_path, new_version)
+            if max_files != 0 and len(path_mapping) >= max_files:
+                break
 
         if REVERSE:
             rename_map = {v: k for k, v in path_mapping.items()}
@@ -188,7 +271,9 @@ def migrate(copy_files: bool = False, modify_rows: bool = False):  # noqa: PLR09
         assert len(set(dst_paths)) == len(dst_paths), "Duplicates in dst_paths!"
 
         if copy_files:
-            client = boto3.client("s3")
+            # Build the task list first (cheap, serial), skipping no-ops so the
+            # workers only ever do real copies.
+            tasks: list[tuple[str, str, str]] = []
             for (src_path, _), (dst_path, dst_version) in rename_map.items():
                 if src_path == dst_path:
                     logger.info(f"Identical src/dst: {src_path}")
@@ -196,15 +281,27 @@ def migrate(copy_files: bool = False, modify_rows: bool = False):  # noqa: PLR09
                 if src_path not in s3_keys:
                     logger.info(f"Cannot read missing object: {src_path}")
                     continue
+                tasks.append((src_path, f"{DEST_PREFIX}{dst_path}", dst_version))
 
-                dst_key = f"{DEST_PREFIX}{dst_path}"
-                try:
-                    upload_cdf(
-                        client, bucket, src_path, dst_key, dst_version, basename_map
-                    )
-                except Exception as e:
-                    logger.info(f"Failed to copy {src_path} -> {dst_key} - {e}")
-                    continue
+            # Each copy downloads, rewrites and re-uploads a CDF (CPU + I/O
+            # heavy), so fan the work across processes to use all cores. A
+            # `spawn` context gives each worker a clean interpreter with no
+            # inherited boto3/DB sockets; workers never touch the DB.
+            if tasks:
+                workers = max_workers if max_workers > 0 else (os.cpu_count() or 1)
+                workers = max(1, min(workers, len(tasks)))
+                logger.info(f"Copying {len(tasks)} files across {workers} workers")
+                with ProcessPoolExecutor(
+                    max_workers=workers,
+                    mp_context=mp.get_context("spawn"),
+                    initializer=_init_worker,
+                    initargs=(bucket, basename_map, overwrite),
+                ) as executor:
+                    for src_path, dst_key, err in executor.map(_copy_one, tasks):
+                        if err:
+                            logger.info(
+                                f"Failed to copy {src_path} -> {dst_key} - {err}"
+                            )
             logger.info("All destination files written")
 
         # Updating rows does not use `dst_key` at all. It is assumed that after making
@@ -225,4 +322,13 @@ def migrate(copy_files: bool = False, modify_rows: bool = False):  # noqa: PLR09
 if __name__ == "__main__":
     copy_files = os.getenv("COPY_FILES", "0") == "1"
     modify_rows = os.getenv("MODIFY_ROWS", "0") == "1"
-    migrate(copy_files=copy_files, modify_rows=modify_rows)
+    overwrite = os.getenv("OVERWRITE", "0") == "1"
+    max_files = int(os.getenv("MAX_FILES", "0"))
+    max_workers = int(os.getenv("MAX_WORKERS", "0"))
+    migrate(
+        copy_files=copy_files,
+        modify_rows=modify_rows,
+        overwrite=overwrite,
+        max_files=max_files,
+        max_workers=max_workers,
+    )

--- a/scripts/migrate/migrate.py
+++ b/scripts/migrate/migrate.py
@@ -49,6 +49,7 @@ def remap_parents(dataset, basename_map: dict[str, str]):
     single-element ``Parents`` to a scalar string.
     """
     parents = dataset.attrs.get("Parents")
+    logger.info(f"Parents: {parents}")
     if parents is None:
         return
     if isinstance(parents, str):
@@ -78,8 +79,10 @@ def upload_cdf(
     if not overwrite:
         try:
             client.head_object(Bucket=bucket, Key=dst_key)
-        except client.exceptions.ClientError:
-            pass
+        except client.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code")
+            if code not in ("404", "NoSuchKey", "NotFound"):
+                raise
         else:
             logger.info(f"Target exists, leaving untouched: s3://{bucket}/{dst_key}")
             return
@@ -208,9 +211,11 @@ def migrate(  # noqa: PLR0912, PLR0915
     bucket = os.getenv("S3_BUCKET")
     if not bucket:
         raise ValueError("S3_BUCKET environment variable is not set")
-    logger.info(f"Listing objects in s3://{bucket}/imap/ ...")
-    s3_keys = get_s3_keys(bucket)
-    logger.info(f"Found {len(s3_keys)} objects in the bucket")
+    s3_keys: set[str] = set()
+    if copy_files:
+        logger.info(f"Listing objects in s3://{bucket}/imap/ ...")
+        s3_keys = get_s3_keys(bucket)
+        logger.info(f"Found {len(s3_keys)} objects in the bucket")
 
     with db.Session() as session:
         count = session.query(models.ScienceFiles).count()
@@ -255,7 +260,7 @@ def migrate(  # noqa: PLR0912, PLR0915
             if f"{DEST_PREFIX}{dst_path}" in existing_dsts:
                 continue
             path_mapping[(old_file_path, old_version)] = (new_file_path, new_version)
-            if max_files != 0 and len(path_mapping) >= max_files:
+            if not modify_rows and max_files != 0 and len(path_mapping) >= max_files:
                 break
 
         if REVERSE:

--- a/scripts/migrate/migrate.py
+++ b/scripts/migrate/migrate.py
@@ -65,6 +65,14 @@ def upload_cdf(
     basename_map: dict[str, str],
 ):
     """Download/modify/upload a pkts/cdf file on S3."""
+    try:
+        client.head_object(Bucket=bucket, Key=dst_key)
+    except client.exceptions.ClientError:
+        pass
+    else:
+        logger.info(f"Target exists, leaving untouched: s3://{bucket}/{dst_key}")
+        return
+
     if src_key.endswith("pkts"):
         client.copy_object(
             Bucket=bucket,

--- a/scripts/migrate/run
+++ b/scripts/migrate/run
@@ -15,6 +15,10 @@ INTERACTIVE=0
 # modify the DB rows. Run in stages - do not enable both at once.
 COPY_FILES=0
 MODIFY_ROWS=0
+# Force overwriting of target cdf/pkts file(s) if they exist?
+OVERWRITE=0
+# Max cdf/pkts files to process in this batch (0 for all)
+MAX_FILES=1000
 
 ROLE_NAME=s3-transition-runner
 PROFILE_NAME=s3-transition-runner
@@ -55,13 +59,45 @@ if [ -z "$(aws iam get-instance-profile --instance-profile-name "$PROFILE_NAME" 
 fi
 
 # --- Key pair ---
-if ! aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
+# Create the AWS key pair and save the private key locally with tight perms.
+create_key_pair() {
   aws ec2 create-key-pair --key-name "$KEY_NAME" --query 'KeyMaterial' --output text > "$KEY_FILE"
   chmod 400 "$KEY_FILE"
-elif [ ! -f "$KEY_FILE" ]; then
-  echo "ERROR: key pair '$KEY_NAME' exists in AWS but local '$KEY_FILE' is missing." >&2
-  echo "       Delete the key pair (aws ec2 delete-key-pair --key-name $KEY_NAME) and re-run, or restore the .pem." >&2
-  exit 1
+}
+
+# The instance is ephemeral, but the AWS key pair and the local .pem persist
+# between runs. A fresh instance bakes in the AWS-stored public key, so the
+# local .pem must still be its matching private half. Reuse the pair only if
+# the fingerprints match; on any drift, regenerate - otherwise SSH fails on
+# every attempt, masked as an endless "Waiting for SSH ..." loop.
+if ! aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
+  echo "Key pair '$KEY_NAME' not found in AWS; creating it."
+  create_key_pair
+else
+  regenerate=0
+  if [ ! -f "$KEY_FILE" ]; then
+    echo "Key pair '$KEY_NAME' exists in AWS but local '$KEY_FILE' is missing; regenerating."
+    regenerate=1
+  else
+    aws_fp=$(aws ec2 describe-key-pairs --key-names "$KEY_NAME" \
+      --query 'KeyPairs[0].KeyFingerprint' --output text)
+    # EC2 CreateKeyPair fingerprint = SHA-1 of the DER (PKCS#8) private key.
+    local_fp=$(openssl pkcs8 -in "$KEY_FILE" -nocrypt -topk8 -outform DER 2>/dev/null \
+      | openssl sha1 -c 2>/dev/null | awk '{print $NF}')
+    if [ -z "$local_fp" ]; then
+      echo "WARNING: could not compute local fingerprint for '$KEY_FILE'; skipping match check." >&2
+    elif [ "$aws_fp" != "$local_fp" ]; then
+      echo "Local '$KEY_FILE' does not match AWS key pair '$KEY_NAME'; regenerating." >&2
+      echo "  AWS:   $aws_fp" >&2
+      echo "  local: $local_fp" >&2
+      regenerate=1
+    fi
+  fi
+  if [ "$regenerate" = 1 ]; then
+    aws ec2 delete-key-pair --key-name "$KEY_NAME"
+    rm -f "$KEY_FILE"
+    create_key_pair
+  fi
 fi
 # List keys
 aws ec2 describe-key-pairs --query 'KeyPairs[].KeyName' --output text
@@ -114,11 +150,25 @@ SSH_OPTS=(-i "$KEY_FILE"
   -o StrictHostKeyChecking=no
   -o UserKnownHostsFile=/dev/null)
 
-# SSH may not be ready the instant the instance is "running"; wait for it.
-until ssh "${SSH_OPTS[@]}" -o ConnectTimeout=5 ec2-user@"$EC2_IP" true 2>/dev/null; do
+# SSH may not be ready the instant the instance is "running"; wait for it, but
+# bound the wait so a real failure (e.g. a key mismatch) surfaces instead of
+# looping forever. On timeout, retry once WITHOUT hiding stderr so the actual
+# SSH error (e.g. "Permission denied (publickey)") is visible.
+ssh_ready=0
+for _ in $(seq 1 24); do
+  if ssh "${SSH_OPTS[@]}" -o ConnectTimeout=5 ec2-user@"$EC2_IP" true 2>/dev/null; then
+    ssh_ready=1
+    break
+  fi
   echo "Waiting for SSH on $EC2_IP ..."
   sleep 5
 done
+
+if [ "$ssh_ready" != 1 ]; then
+  echo "ERROR: SSH to $EC2_IP did not succeed after ~2 minutes. Last attempt:" >&2
+  ssh "${SSH_OPTS[@]}" -o ConnectTimeout=5 ec2-user@"$EC2_IP" true || true
+  exit 1
+fi
 
 # Copy the migration scripts up to the instance.
 scp "${SSH_OPTS[@]}" run_remote.sh migrate.py ec2-user@"$EC2_IP":~/
@@ -132,6 +182,6 @@ fi
 
 # Run the transition script on the instance.
 ssh "${SSH_OPTS[@]}" ec2-user@"$EC2_IP" \
-  "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION S3_BUCKET=$AWS_BUCKET SECRET_NAME=$SECRET_NAME COPY_FILES=$COPY_FILES MODIFY_ROWS=$MODIFY_ROWS bash ~/run_remote.sh"
+  "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION S3_BUCKET=$AWS_BUCKET SECRET_NAME=$SECRET_NAME COPY_FILES=$COPY_FILES MODIFY_ROWS=$MODIFY_ROWS OVERWRITE=$OVERWRITE MAX_FILES=$MAX_FILES bash ~/run_remote.sh"
 
 # Teardown happens in cleanup() via the EXIT trap.

--- a/scripts/migrate/run
+++ b/scripts/migrate/run
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -euo pipefail
+
+export AWS_PROFILE=imap-dev
+export AWS_DEFAULT_REGION=us-west-2
+export AWS_ACCOUNT=449431850278
+export AWS_BUCKET=sds-data-$AWS_ACCOUNT
+export SECRET_NAME=sdp-database-cred
+
+# Set to 1 to drop into an interactive SSH shell on the instance; set to 0
+# for fully-automated mode that runs the migration script remotely.
+INTERACTIVE=0
+
+# Passed through to migrate.py. Set to 1 to copy files on S3, and/or to 1 to
+# modify the DB rows. Run in stages - do not enable both at once.
+COPY_FILES=0
+MODIFY_ROWS=0
+
+ROLE_NAME=s3-transition-runner
+PROFILE_NAME=s3-transition-runner
+KEY_NAME=s3-transition-key
+KEY_FILE=s3-transition-key.pem
+INSTANCE_TAG=s3-transition
+
+# Function to tear down the instance (and the SG rule) on exit
+cleanup() {
+  if [ -n "${RDS_SG:-}" ] && [ -n "${EC2_IP:-}" ]; then
+    aws ec2 revoke-security-group-ingress --group-id "$RDS_SG" \
+      --protocol tcp --port 5432 --cidr "$EC2_IP/32" 2>/dev/null || true
+  fi
+  if [ -n "${IID:-}" ]; then
+    aws ec2 terminate-instances --instance-ids "$IID"
+  fi
+}
+
+# --- IAM role ---
+if ! aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
+  aws iam create-role --role-name "$ROLE_NAME" --assume-role-policy-document file://ec2-trust.json
+fi
+
+# Render the permissions policy template, substituting the account/bucket/region
+# from the variables above so they are not hardcoded in ec2-perms.json.
+PERMS_FILE=$(mktemp)
+envsubst '$AWS_BUCKET $AWS_ACCOUNT $AWS_DEFAULT_REGION' < ec2-perms.json > "$PERMS_FILE"
+aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name s3-transition-perms --policy-document "file://$PERMS_FILE"
+rm -f "$PERMS_FILE"
+
+if ! aws iam get-instance-profile --instance-profile-name "$PROFILE_NAME" >/dev/null 2>&1; then
+  aws iam create-instance-profile --instance-profile-name "$PROFILE_NAME"
+fi
+
+if [ -z "$(aws iam get-instance-profile --instance-profile-name "$PROFILE_NAME" \
+    --query "InstanceProfile.Roles[?RoleName=='$ROLE_NAME'].RoleName" --output text)" ]; then
+  aws iam add-role-to-instance-profile --instance-profile-name "$PROFILE_NAME" --role-name "$ROLE_NAME"
+fi
+
+# --- Key pair ---
+if ! aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
+  aws ec2 create-key-pair --key-name "$KEY_NAME" --query 'KeyMaterial' --output text > "$KEY_FILE"
+  chmod 400 "$KEY_FILE"
+elif [ ! -f "$KEY_FILE" ]; then
+  echo "ERROR: key pair '$KEY_NAME' exists in AWS but local '$KEY_FILE' is missing." >&2
+  echo "       Delete the key pair (aws ec2 delete-key-pair --key-name $KEY_NAME) and re-run, or restore the .pem." >&2
+  exit 1
+fi
+# List keys
+aws ec2 describe-key-pairs --query 'KeyPairs[].KeyName' --output text
+
+# --- EC2 instance (reuse an existing one if it is still up) ---
+IID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=$INSTANCE_TAG" "Name=instance-state-name,Values=pending,running" \
+  --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+if [ "$IID" = "None" ] || [ -z "$IID" ]; then
+  AMI=$(aws ssm get-parameter \
+    --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 \
+    --query Parameter.Value --output text)
+
+  IID=$(aws ec2 run-instances \
+    --image-id "$AMI" \
+    --instance-type t3.large \
+    --iam-instance-profile Name="$PROFILE_NAME" \
+    --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":10}}]' \
+    --associate-public-ip-address \
+    --key-name "$KEY_NAME" \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$INSTANCE_TAG}]" \
+    --query 'Instances[0].InstanceId' --output text)
+fi
+echo "Instance: $IID"
+
+# Ensure the instance is cleaned up on any exit.
+trap cleanup EXIT
+
+# Wait until the instance is running so it has a public IP.
+aws ec2 wait instance-running --instance-ids "$IID"
+
+# Grab the instance's Public IP
+EC2_IP=$(aws ec2 describe-instances --instance-ids "$IID" \
+  --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+echo "$EC2_IP"
+
+# Find the RDS security group id
+RDS_SG=$(aws ec2 describe-security-groups \
+    --filters Name=group-name,Values='SDCStack-RdsSecurityGroup*' \
+    --query 'SecurityGroups[0].GroupId' --output text)
+
+# Authorize ingress (ignore error if the rule already exists).
+aws ec2 authorize-security-group-ingress --group-id "$RDS_SG" \
+  --protocol tcp --port 5432 --cidr "$EC2_IP/32" 2>/dev/null || true
+
+# Ephemeral instances reuse public IPs, so skip host-key checking to avoid
+# "REMOTE HOST IDENTIFICATION HAS CHANGED" failures on re-runs.
+SSH_OPTS=(-i "$KEY_FILE"
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null)
+
+# SSH may not be ready the instant the instance is "running"; wait for it.
+until ssh "${SSH_OPTS[@]}" -o ConnectTimeout=5 ec2-user@"$EC2_IP" true 2>/dev/null; do
+  echo "Waiting for SSH on $EC2_IP ..."
+  sleep 5
+done
+
+# Copy the migration scripts up to the instance.
+scp "${SSH_OPTS[@]}" run_remote.sh migrate.py ec2-user@"$EC2_IP":~/
+
+if [ "${INTERACTIVE:-0}" = 1 ]; then
+  echo "Interactive mode: opening a shell on $EC2_IP (instance is torn down on exit)."
+  echo "  Run the migration manually with: bash ~/run_remote.sh"
+  ssh "${SSH_OPTS[@]}" ec2-user@"$EC2_IP"
+  exit 0
+fi
+
+# Run the transition script on the instance.
+ssh "${SSH_OPTS[@]}" ec2-user@"$EC2_IP" \
+  "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION S3_BUCKET=$AWS_BUCKET SECRET_NAME=$SECRET_NAME COPY_FILES=$COPY_FILES MODIFY_ROWS=$MODIFY_ROWS bash ~/run_remote.sh"
+
+# Teardown happens in cleanup() via the EXIT trap.

--- a/scripts/migrate/run_remote.sh
+++ b/scripts/migrate/run_remote.sh
@@ -12,6 +12,8 @@ export SECRET_NAME="${SECRET_NAME:-sdp-database-cred}"
 # Passed through to migrate.py.
 export COPY_FILES="${COPY_FILES:-0}"
 export MODIFY_ROWS="${MODIFY_ROWS:-0}"
+export OVERWRITE="${OVERWRITE:-0}"
+export MAX_FILES="${MAX_FILES:-0}"
 
 # t3 instances uses tmpdir as half of available RAM - not nearly enough for CDF files
 export TMPDIR="$HOME/tmp"

--- a/scripts/migrate/run_remote.sh
+++ b/scripts/migrate/run_remote.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Config (dev account 449431850278)
+# ---------------------------------------------------------------------------
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-west-2}"
+export S3_BUCKET="${S3_BUCKET:-sds-data-449431850278}"
+export SECRET_NAME="${SECRET_NAME:-sdp-database-cred}"
+
+# Passed through to migrate.py.
+export COPY_FILES="${COPY_FILES:-0}"
+export MODIFY_ROWS="${MODIFY_ROWS:-0}"
+
+# t3 instances uses tmpdir as half of available RAM - not nearly enough for CDF files
+export TMPDIR="$HOME/tmp"
+mkdir -p "$TMPDIR"
+
+
+# ---------------------------------------------------------------------------
+# uv
+# ---------------------------------------------------------------------------
+sudo dnf install -y git >/dev/null
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+uv venv --python 3.12 .venv
+source .venv/bin/activate
+
+# ---------------------------------------------------------------------------
+# deps
+# ---------------------------------------------------------------------------
+uv pip install \
+  "git+https://github.com/IMAP-Science-Operations-Center/sds-data-manager.git@release_version_work" \
+  "git+https://github.com/IMAP-Science-Operations-Center/imap_processing.git@new_version_work" \
+  "git+https://github.com/IMAP-Science-Operations-Center/imap-data-access.git" \
+  "SQLAlchemy<=3.0.0" \
+  "pandas>=3.0.3,<4.0.0" \
+  psycopg2-binary \
+  boto3
+
+uv run python migrate.py

--- a/sds_data_manager/lambda_code/SDSCode/database/s3_file_transition.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/s3_file_transition.py
@@ -2,32 +2,25 @@
 
 import logging
 import os
-import tempfile
-from pathlib import Path
 
 import boto3
 import imap_data_access
-from imap_data_access.file_validation import (
-    ScienceFilePath,
-    Version,
-    generate_imap_file_path,
-)
-from imap_processing.cdf.utils import load_cdf, write_cdf
+from imap_data_access.file_validation import ScienceFilePath, Version
 
 from . import database as db
 from . import models
 
 # Copy files from the old path to the new path?
-COPY_FILES: bool = True
+COPY_FILES: bool = False
 # Destination prefix for copied files
 DEST_PREFIX: str = "renamed/"
 # Update the file_path column in the database?
 # Do this once all files are moved from `DEST_PREFIX` to the canonical path on S3
 # bucket (after making a backup of the canonical path on the S3 bucket, of course).
-MODIFY_ROWS: bool = False
+MODIFY_ROWS: bool = True
 
-# Maximum number of CDFs to process; None for all (for testing on dev)
-MAX_CDFS: int | None = 3
+# Maximum number of CDFs/PKTs to process; None for all (for testing on dev)
+MAX_CDFS_PKTS: int | None = None
 # Reverse the sense of `old` vs `new` paths? (for testing on dev)
 REVERSE: bool = True
 
@@ -36,22 +29,13 @@ logger.setLevel(logging.DEBUG)
 
 
 def upload_cdf(client, bucket: str, src_key: str, dst_key: str, dst_version: str):
-    """Rewrite a CDF to add the new version attribute."""
-    with tempfile.NamedTemporaryFile(suffix=".cdf") as tmp:
-        client.download_fileobj(bucket, src_key, tmp)
-        tmp.flush()
-        dataset = load_cdf(tmp.name)
-
-    # From @tech3371 - `Data_version` is sans `v`
-    dataset.attrs["Data_version"] = dst_version.lstrip("v")
-
-    # Making guarantees about spdf conformance on existing files is out of scope
-    written = Path(write_cdf(dataset, istp=True, terminate_on_warning=False))
-    try:
-        client.upload_file(str(written), bucket, dst_key)
-    finally:
-        written.unlink(missing_ok=True)
-    logger.info(f"Wrote CDF {src_key} -> s3://{bucket}/{dst_key}")
+    """Upload a CDF file to S3."""
+    client.copy_object(
+        Bucket=bucket,
+        CopySource={"Bucket": bucket, "Key": src_key},
+        Key=dst_key,
+    )
+    logger.info(f"Copied CDF {src_key} -> s3://{bucket}/{dst_key}")
 
 
 def get_s3_keys(bucket, prefix="imap/"):
@@ -64,7 +48,7 @@ def get_s3_keys(bucket, prefix="imap/"):
     return keys
 
 
-def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
+def lambda_handler(event, context):  # noqa: PLR0912
     """Lambda handler for transitioning S3 files to new version.
 
     This lambda is used one-time to transition s3 files to new
@@ -85,7 +69,7 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     s3_keys = get_s3_keys(bucket)
     logger.info(f"Found {len(s3_keys)} objects in the bucket")
 
-    n_cdfs = 0
+    n_cdfs_pkts = 0
 
     with db.Session() as session:
         count = session.query(models.ScienceFiles).count()
@@ -95,56 +79,32 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
         path_mapping: dict[tuple[str, str], tuple[str, str]] = {}
 
         for row in session.query(models.ScienceFiles):
-            # Construct the new filename from scratch using the table columns. Use the
-            # class of the existing path so the directory prefix (science, dependency,
-            # etc.) is preserved.
-            imap_file = generate_imap_file_path(row.file_path)
-            file_cls = type(imap_file)
-            if not issubclass(file_cls, ScienceFilePath):
-                raise ValueError(f"Unexpected file type: {file_cls}")
-
-            old_version = f"v{row.minor_version:03}"  # no help from Version() here
-            old_file = file_cls.generate_from_inputs(
-                instrument=row.instrument,
-                data_level=row.data_level,
-                descriptor=row.descriptor,
-                start_time=row.start_date.strftime("%Y%m%d"),
-                version=old_version,
-                extension=row.extension,
-                repointing=row.repointing,
-                cr=row.cr,
-            )
-
+            old_version = str(Version(None, row.minor_version))
             new_version = str(Version(row.major_version, row.minor_version))
-            # identical to old_file, but with new version
-            new_file = file_cls.generate_from_inputs(
+
+            old_suffix = f"_{old_version}.{row.extension}"
+            new_suffix = f"_{new_version}.{row.extension}"
+
+            # Construct the new filename from scratch using the table columns.
+            new_file = ScienceFilePath.generate_from_inputs(
                 instrument=row.instrument,
                 data_level=row.data_level,
                 descriptor=row.descriptor,
                 start_time=row.start_date.strftime("%Y%m%d"),
-                version=new_version,
+                major_version=row.major_version,
+                minor_version=row.minor_version,
                 extension=row.extension,
                 repointing=row.repointing,
                 cr=row.cr,
             )
 
             # construct_path() prepends DATA_DIR; strip it
-            old_file_path = str(old_file.construct_path().relative_to(data_dir))
             new_file_path = str(new_file.construct_path().relative_to(data_dir))
+            old_file_path = new_file_path[: -len(new_suffix)] + old_suffix
 
-            # Sanity test - we should match naive str replacement
-            naive_file_path = old_file_path.replace(
-                f"_{old_version}.", f"_{new_version}.", 1
-            )
-            if naive_file_path != new_file_path:
-                raise ValueError(
-                    f"Mismatch for {old_file_path}: "
-                    f"naive={naive_file_path!r} vs from_scratch={new_file_path!r}"
-                )
-
-            if new_file_path.endswith(".cdf"):
-                n_cdfs += 1
-                if MAX_CDFS is None or n_cdfs <= MAX_CDFS:
+            if new_file_path.endswith(".cdf") or new_file_path.endswith(".pkts"):
+                n_cdfs_pkts += 1
+                if MAX_CDFS_PKTS is None or n_cdfs_pkts <= MAX_CDFS_PKTS:
                     path_mapping[(old_file_path, old_version)] = (
                         new_file_path,
                         new_version,
@@ -167,25 +127,18 @@ def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
                 if src_path == dst_path:
                     continue
                 if src_path not in s3_keys:
-                    raise ValueError(f"Cannot read missing object: {src_path}")
+                    logger.error(f"Cannot read missing object: {src_path}")
+                    continue
 
                 dst_key = f"{DEST_PREFIX}{dst_path}"
-                if dst_path.endswith(".cdf"):
-                    upload_cdf(client, bucket, src_path, dst_key, dst_version)
-                else:
-                    client.copy_object(
-                        Bucket=bucket,
-                        CopySource={"Bucket": bucket, "Key": src_path},
-                        Key=dst_key,
-                    )
-                    logger.info(f"Copied {src_path} -> {dst_key}")
+                upload_cdf(client, bucket, src_path, dst_key, dst_version)
             logger.info("All destination files written")
 
         # Updating rows does not use `dst_key` at all. It is assumed that after making
         # a backup of the `imap/` path in the S3 bucket, files will be moved from
         # DEST_PREFIX to the original path in bulk, and then this block will be run.
         if MODIFY_ROWS:
-            for src_path, dst_path in rename_map.items():
+            for (src_path, _), (dst_path, _) in rename_map.items():
                 session.query(models.ScienceFiles).filter(
                     models.ScienceFiles.file_path == src_path
                 ).update(

--- a/sds_data_manager/lambda_code/SDSCode/database/s3_file_transition.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/s3_file_transition.py
@@ -1,10 +1,70 @@
 """Lambda to transition S3 files to new version."""
 
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import boto3
+import imap_data_access
+from imap_data_access.file_validation import (
+    ScienceFilePath,
+    Version,
+    generate_imap_file_path,
+)
+from imap_processing.cdf.utils import load_cdf, write_cdf
+
 from . import database as db
 from . import models
 
+# Copy files from the old path to the new path?
+COPY_FILES: bool = True
+# Destination prefix for copied files
+DEST_PREFIX: str = "renamed/"
+# Update the file_path column in the database?
+# Do this once all files are moved from `DEST_PREFIX` to the canonical path on S3
+# bucket (after making a backup of the canonical path on the S3 bucket, of course).
+MODIFY_ROWS: bool = False
 
-def lambda_handler(event, context):
+# Maximum number of CDFs to process; None for all (for testing on dev)
+MAX_CDFS: int | None = 3
+# Reverse the sense of `old` vs `new` paths? (for testing on dev)
+REVERSE: bool = True
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+def upload_cdf(client, bucket: str, src_key: str, dst_key: str, dst_version: str):
+    """Rewrite a CDF to add the new version attribute."""
+    with tempfile.NamedTemporaryFile(suffix=".cdf") as tmp:
+        client.download_fileobj(bucket, src_key, tmp)
+        tmp.flush()
+        dataset = load_cdf(tmp.name)
+
+    # From @tech3371 - `Data_version` is sans `v`
+    dataset.attrs["Data_version"] = dst_version.lstrip("v")
+
+    # Making guarantees about spdf conformance on existing files is out of scope
+    written = Path(write_cdf(dataset, istp=True, terminate_on_warning=False))
+    try:
+        client.upload_file(str(written), bucket, dst_key)
+    finally:
+        written.unlink(missing_ok=True)
+    logger.info(f"Wrote CDF {src_key} -> s3://{bucket}/{dst_key}")
+
+
+def get_s3_keys(bucket, prefix="imap/"):
+    """Return the set of all object keys in ``bucket`` under ``prefix``."""
+    client = boto3.client("s3")
+    paginator = client.get_paginator("list_objects_v2")
+    keys = set()
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        keys.update(obj["Key"] for obj in page.get("Contents", []))
+    return keys
+
+
+def lambda_handler(event, context):  # noqa: PLR0912, PLR0915
     """Lambda handler for transitioning S3 files to new version.
 
     This lambda is used one-time to transition s3 files to new
@@ -14,19 +74,126 @@ def lambda_handler(event, context):
     Lambda code defined here will help with making sure
     dev and prod has same setup when transitioning.
     """
-    # First take on steps of transitioning S3 files to new version. TBD
-    # 1. Able to connect to s3 bucket and list files.
-    # 2. Able to download files from s3 bucket, either using s3 API or imap-data-access.
-    # 3. Able to rename files to new version and validate the new version
-    #    using imap-data-access.
-    # 4. Store in tmp location. TBD on details
-    # 5. Able to make query to DB and science table.
-    # 6. Verify the new version files record matches with what's in science table.
-    # 7. Once verified, switch to the new version files.
+    assert not all([COPY_FILES, MODIFY_ROWS]), "Please do this in stages!"
+
+    data_dir = imap_data_access.config["DATA_DIR"]
+
+    bucket = os.getenv("S3_BUCKET")
+    if not bucket:
+        raise ValueError("S3_BUCKET environment variable is not set")
+    logger.info(f"Listing objects in s3://{bucket}/imap/ ...")
+    s3_keys = get_s3_keys(bucket)
+    logger.info(f"Found {len(s3_keys)} objects in the bucket")
+
+    n_cdfs = 0
+
     with db.Session() as session:
-        # Query science table
-        session.query(models.ScienceFiles).all()
-        pass
+        count = session.query(models.ScienceFiles).count()
+        logger.info(f"Verifying file_path mapping for {count} records")
+
+        # (current_path, current_version_str) => (new_path, new_version_str)
+        path_mapping: dict[tuple[str, str], tuple[str, str]] = {}
+
+        for row in session.query(models.ScienceFiles):
+            # Construct the new filename from scratch using the table columns. Use the
+            # class of the existing path so the directory prefix (science, dependency,
+            # etc.) is preserved.
+            imap_file = generate_imap_file_path(row.file_path)
+            file_cls = type(imap_file)
+            if not issubclass(file_cls, ScienceFilePath):
+                raise ValueError(f"Unexpected file type: {file_cls}")
+
+            old_version = f"v{row.minor_version:03}"  # no help from Version() here
+            old_file = file_cls.generate_from_inputs(
+                instrument=row.instrument,
+                data_level=row.data_level,
+                descriptor=row.descriptor,
+                start_time=row.start_date.strftime("%Y%m%d"),
+                version=old_version,
+                extension=row.extension,
+                repointing=row.repointing,
+                cr=row.cr,
+            )
+
+            new_version = str(Version(row.major_version, row.minor_version))
+            # identical to old_file, but with new version
+            new_file = file_cls.generate_from_inputs(
+                instrument=row.instrument,
+                data_level=row.data_level,
+                descriptor=row.descriptor,
+                start_time=row.start_date.strftime("%Y%m%d"),
+                version=new_version,
+                extension=row.extension,
+                repointing=row.repointing,
+                cr=row.cr,
+            )
+
+            # construct_path() prepends DATA_DIR; strip it
+            old_file_path = str(old_file.construct_path().relative_to(data_dir))
+            new_file_path = str(new_file.construct_path().relative_to(data_dir))
+
+            # Sanity test - we should match naive str replacement
+            naive_file_path = old_file_path.replace(
+                f"_{old_version}.", f"_{new_version}.", 1
+            )
+            if naive_file_path != new_file_path:
+                raise ValueError(
+                    f"Mismatch for {old_file_path}: "
+                    f"naive={naive_file_path!r} vs from_scratch={new_file_path!r}"
+                )
+
+            if new_file_path.endswith(".cdf"):
+                n_cdfs += 1
+                if MAX_CDFS is None or n_cdfs <= MAX_CDFS:
+                    path_mapping[(old_file_path, old_version)] = (
+                        new_file_path,
+                        new_version,
+                    )
+
+        if REVERSE:
+            rename_map = {v: k for k, v in path_mapping.items()}
+        else:
+            rename_map = dict(path_mapping)
+
+        for (src_path, _), (dst_path, _) in rename_map.items():
+            logger.info(f"Mapping {src_path} -> {dst_path}")
+
+        dst_paths = list(rename_map.values())
+        assert len(set(dst_paths)) == len(dst_paths), "Duplicates in dst_paths!"
+
+        if COPY_FILES:
+            client = boto3.client("s3")
+            for (src_path, _), (dst_path, dst_version) in rename_map.items():
+                if src_path == dst_path:
+                    continue
+                if src_path not in s3_keys:
+                    raise ValueError(f"Cannot read missing object: {src_path}")
+
+                dst_key = f"{DEST_PREFIX}{dst_path}"
+                if dst_path.endswith(".cdf"):
+                    upload_cdf(client, bucket, src_path, dst_key, dst_version)
+                else:
+                    client.copy_object(
+                        Bucket=bucket,
+                        CopySource={"Bucket": bucket, "Key": src_path},
+                        Key=dst_key,
+                    )
+                    logger.info(f"Copied {src_path} -> {dst_key}")
+            logger.info("All destination files written")
+
+        # Updating rows does not use `dst_key` at all. It is assumed that after making
+        # a backup of the `imap/` path in the S3 bucket, files will be moved from
+        # DEST_PREFIX to the original path in bulk, and then this block will be run.
+        if MODIFY_ROWS:
+            for src_path, dst_path in rename_map.items():
+                session.query(models.ScienceFiles).filter(
+                    models.ScienceFiles.file_path == src_path
+                ).update(
+                    {models.ScienceFiles.file_path: dst_path},
+                    synchronize_session=False,
+                )
+            session.commit()
+            logger.info(f"Updated file_path for {len(rename_map)} records")
 
     return {
         "statusCode": 200,

--- a/sds_data_manager/lambda_code/SDSCode/database/s3_file_transition.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/s3_file_transition.py
@@ -1,54 +1,10 @@
 """Lambda to transition S3 files to new version."""
 
-import logging
-import os
-
-import boto3
-import imap_data_access
-from imap_data_access.file_validation import ScienceFilePath, Version
-
 from . import database as db
 from . import models
 
-# Copy files from the old path to the new path?
-COPY_FILES: bool = False
-# Destination prefix for copied files
-DEST_PREFIX: str = "renamed/"
-# Update the file_path column in the database?
-# Do this once all files are moved from `DEST_PREFIX` to the canonical path on S3
-# bucket (after making a backup of the canonical path on the S3 bucket, of course).
-MODIFY_ROWS: bool = True
 
-# Maximum number of CDFs/PKTs to process; None for all (for testing on dev)
-MAX_CDFS_PKTS: int | None = None
-# Reverse the sense of `old` vs `new` paths? (for testing on dev)
-REVERSE: bool = True
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-
-def upload_cdf(client, bucket: str, src_key: str, dst_key: str, dst_version: str):
-    """Upload a CDF file to S3."""
-    client.copy_object(
-        Bucket=bucket,
-        CopySource={"Bucket": bucket, "Key": src_key},
-        Key=dst_key,
-    )
-    logger.info(f"Copied CDF {src_key} -> s3://{bucket}/{dst_key}")
-
-
-def get_s3_keys(bucket, prefix="imap/"):
-    """Return the set of all object keys in ``bucket`` under ``prefix``."""
-    client = boto3.client("s3")
-    paginator = client.get_paginator("list_objects_v2")
-    keys = set()
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-        keys.update(obj["Key"] for obj in page.get("Contents", []))
-    return keys
-
-
-def lambda_handler(event, context):  # noqa: PLR0912
+def lambda_handler(event, context):
     """Lambda handler for transitioning S3 files to new version.
 
     This lambda is used one-time to transition s3 files to new
@@ -58,95 +14,19 @@ def lambda_handler(event, context):  # noqa: PLR0912
     Lambda code defined here will help with making sure
     dev and prod has same setup when transitioning.
     """
-    assert not all([COPY_FILES, MODIFY_ROWS]), "Please do this in stages!"
-
-    data_dir = imap_data_access.config["DATA_DIR"]
-
-    bucket = os.getenv("S3_BUCKET")
-    if not bucket:
-        raise ValueError("S3_BUCKET environment variable is not set")
-    logger.info(f"Listing objects in s3://{bucket}/imap/ ...")
-    s3_keys = get_s3_keys(bucket)
-    logger.info(f"Found {len(s3_keys)} objects in the bucket")
-
-    n_cdfs_pkts = 0
-
+    # First take on steps of transitioning S3 files to new version. TBD
+    # 1. Able to connect to s3 bucket and list files.
+    # 2. Able to download files from s3 bucket, either using s3 API or imap-data-access.
+    # 3. Able to rename files to new version and validate the new version
+    #    using imap-data-access.
+    # 4. Store in tmp location. TBD on details
+    # 5. Able to make query to DB and science table.
+    # 6. Verify the new version files record matches with what's in science table.
+    # 7. Once verified, switch to the new version files.
     with db.Session() as session:
-        count = session.query(models.ScienceFiles).count()
-        logger.info(f"Verifying file_path mapping for {count} records")
-
-        # (current_path, current_version_str) => (new_path, new_version_str)
-        path_mapping: dict[tuple[str, str], tuple[str, str]] = {}
-
-        for row in session.query(models.ScienceFiles):
-            old_version = str(Version(None, row.minor_version))
-            new_version = str(Version(row.major_version, row.minor_version))
-
-            old_suffix = f"_{old_version}.{row.extension}"
-            new_suffix = f"_{new_version}.{row.extension}"
-
-            # Construct the new filename from scratch using the table columns.
-            new_file = ScienceFilePath.generate_from_inputs(
-                instrument=row.instrument,
-                data_level=row.data_level,
-                descriptor=row.descriptor,
-                start_time=row.start_date.strftime("%Y%m%d"),
-                major_version=row.major_version,
-                minor_version=row.minor_version,
-                extension=row.extension,
-                repointing=row.repointing,
-                cr=row.cr,
-            )
-
-            # construct_path() prepends DATA_DIR; strip it
-            new_file_path = str(new_file.construct_path().relative_to(data_dir))
-            old_file_path = new_file_path[: -len(new_suffix)] + old_suffix
-
-            if new_file_path.endswith(".cdf") or new_file_path.endswith(".pkts"):
-                n_cdfs_pkts += 1
-                if MAX_CDFS_PKTS is None or n_cdfs_pkts <= MAX_CDFS_PKTS:
-                    path_mapping[(old_file_path, old_version)] = (
-                        new_file_path,
-                        new_version,
-                    )
-
-        if REVERSE:
-            rename_map = {v: k for k, v in path_mapping.items()}
-        else:
-            rename_map = dict(path_mapping)
-
-        for (src_path, _), (dst_path, _) in rename_map.items():
-            logger.info(f"Mapping {src_path} -> {dst_path}")
-
-        dst_paths = list(rename_map.values())
-        assert len(set(dst_paths)) == len(dst_paths), "Duplicates in dst_paths!"
-
-        if COPY_FILES:
-            client = boto3.client("s3")
-            for (src_path, _), (dst_path, dst_version) in rename_map.items():
-                if src_path == dst_path:
-                    continue
-                if src_path not in s3_keys:
-                    logger.error(f"Cannot read missing object: {src_path}")
-                    continue
-
-                dst_key = f"{DEST_PREFIX}{dst_path}"
-                upload_cdf(client, bucket, src_path, dst_key, dst_version)
-            logger.info("All destination files written")
-
-        # Updating rows does not use `dst_key` at all. It is assumed that after making
-        # a backup of the `imap/` path in the S3 bucket, files will be moved from
-        # DEST_PREFIX to the original path in bulk, and then this block will be run.
-        if MODIFY_ROWS:
-            for (src_path, _), (dst_path, _) in rename_map.items():
-                session.query(models.ScienceFiles).filter(
-                    models.ScienceFiles.file_path == src_path
-                ).update(
-                    {models.ScienceFiles.file_path: dst_path},
-                    synchronize_session=False,
-                )
-            session.commit()
-            logger.info(f"Updated file_path for {len(rename_map)} records")
+        # Query science table
+        session.query(models.ScienceFiles).all()
+        pass
 
     return {
         "statusCode": 200,


### PR DESCRIPTION
Modified the `lambda_handler` to:

- copy files from one S3 location to another (piping them through `write_cdf` so we can modify the dataset's `Data_version` attribute to match the destination version.
- Modify the `file_path` rows of the science file table to use the new version format.

The process might be:
- ensure `REVERSE` is `False` (is only used as a toggle for testing the script again and again on dev).
- set `COPY_FILES` as `True` but keep `MODIFY_ROWS` as `False` and run this - this copies files over to a `renamed/` folder.
- Ensure everything looks good. Make a backup and move files from `renamed/` to their final destination.
- set `MODIFY_ROWS` as `True` and `COPY_FILES` as `False` and run this - this modifies the db rows.