### PR TITLE
Update dependency YAML for L3 jobs with multiple output products

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_glows_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_glows_dependencies.yaml
@@ -157,8 +157,29 @@ hist_spice: &hist_spice
       data_type: l3c
       descriptor: sw-profile
     - source: glows
+      data_type: ancillary
+      descriptor: l3b-archive
+    - source: glows
       data_type: l3d
       descriptor: solar-hist
+    - source: glows
+      data_type: ancillary
+      descriptor: uv-anis
+    - source: glows
+      data_type: ancillary
+      descriptor: lya
+    - source: glows
+      data_type: ancillary
+      descriptor: e-dens
+    - source: glows
+      data_type: ancillary
+      descriptor: p-dens
+    - source: glows
+      data_type: ancillary
+      descriptor: speed
+    - source: glows
+      data_type: ancillary
+      descriptor: phion
     - source: glows
       data_type: l3e
       descriptor: survival-probability-hi-45
@@ -174,3 +195,18 @@ hist_spice: &hist_spice
     - source: glows
       data_type: l3e
       descriptor: survival-probability-ul-hf
+    - source: glows
+      data_type: ancillary
+      descriptor: survival-probability-hi-45-raw
+    - source: glows
+      data_type: ancillary
+      descriptor: survival-probability-hi-90-raw
+    - source: glows
+      data_type: ancillary
+      descriptor: survival-probability-lo-raw
+    - source: glows
+      data_type: ancillary
+      descriptor: survival-probability-ul-sf-raw
+    - source: glows
+      data_type: ancillary
+      descriptor: survival-probability-ul-hf-raw

--- a/sds_data_manager/orchestration/dependencies/imap_glows_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_glows_dependencies.yaml
@@ -153,3 +153,24 @@ hist_spice: &hist_spice
     - source: glows
       data_type: l3b
       descriptor: ion-rate-profile
+    - source: glows
+      data_type: l3c
+      descriptor: sw-profile
+    - source: glows
+      data_type: l3d
+      descriptor: solar-hist
+    - source: glows
+      data_type: l3e
+      descriptor: survival-probability-hi-45
+    - source: glows
+      data_type: l3e
+      descriptor: survival-probability-hi-90
+    - source: glows
+      data_type: l3e
+      descriptor: survival-probability-lo
+    - source: glows
+      data_type: l3e
+      descriptor: survival-probability-ul-sf
+    - source: glows
+      data_type: l3e
+      descriptor: survival-probability-ul-hf

--- a/sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
@@ -1013,7 +1013,70 @@ sensor90_l1c_pset: &sensor90_l1c_pset
   outputs:
     - source: hi
       data_type: l3
-      descriptor: h90-spx-h-hf-sp-full-hae-6deg-6mo
+      descriptor: h45-ena-h-sf-sp-ram-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-sf-sp-anti-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-sf-sp-ram-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-sf-sp-anti-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-sf-sp-full-hae-4deg-6mo
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-sf-sp-ram-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-sf-sp-anti-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-sf-sp-ram-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-sf-sp-anti-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-sf-sp-full-hae-6deg-6mo
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-ram-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-anti-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-ram-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-anti-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-full-hae-4deg-6mo
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-full-hae-4deg-6mo
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-ram-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-anti-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-ram-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-anti-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: h45-ena-h-hf-sp-full-hae-6deg-6mo
+    - source: hi
+      data_type: l3
+      descriptor: h90-ena-h-hf-sp-full-hae-6deg-6mo
 
 (l3, hic-maps):
   partition: daily
@@ -1025,3 +1088,12 @@ sensor90_l1c_pset: &sensor90_l1c_pset
     - source: hi
       data_type: l3
       descriptor: hic-ena-h-hf-nsp-full-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: hic-ena-h-hf-sp-full-hae-6deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: hic-ena-h-hf-nsp-full-hae-4deg-1yr
+    - source: hi
+      data_type: l3
+      descriptor: hic-ena-h-hf-sp-full-hae-4deg-1yr

--- a/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
@@ -481,3 +481,6 @@ lo_esa_fit_factors: &lo_esa_fit_factors
     - source: lo
       data_type: l3
       descriptor: l090-ena-h-hf-sp-ram-hae-6deg-1yr
+    - source: lo
+      data_type: l3
+      descriptor: l090-ena-h-sf-sp-ram-hae-6deg-1yr

--- a/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
@@ -1782,6 +1782,57 @@ de_inputs_90sensor: &de_inputs_90sensor
   outputs:
     - source: ultra
       data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-sf-sp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-sf-sp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-sf-sp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-sf-sp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-sf-sp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-sf-sp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-sf-sp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-4deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-sf-sp-full-hae-4deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: u45-ena-h-hf-sp-full-hae-6deg-1yr
+    - source: ultra
+      data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-6deg-1yr
 
 (l3, u90-maps):
@@ -1791,6 +1842,57 @@ de_inputs_90sensor: &de_inputs_90sensor
       data_type: repoint
       descriptor: historical
   outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-sf-sp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-sf-sp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-sf-sp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-sf-sp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-sf-sp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-sf-sp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-sf-sp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-4deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-sf-sp-full-hae-4deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: u90-ena-h-hf-sp-full-hae-6deg-1yr
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-6deg-1yr
@@ -1804,6 +1906,30 @@ de_inputs_90sensor: &de_inputs_90sensor
   outputs:
     - source: ultra
       data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-sp-full-hae-4deg-1yr
+    - source: ultra
+      data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-6deg-1yr
 
 (l3, ulc-nsp-maps):
@@ -1813,6 +1939,30 @@ de_inputs_90sensor: &de_inputs_90sensor
       data_type: repoint
       descriptor: historical
   outputs:
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-nsp-full-hae-2deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-nsp-full-hae-4deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-nsp-full-hae-6deg-3mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-nsp-full-hae-2deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-nsp-full-hae-4deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-nsp-full-hae-6deg-6mo
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-nsp-full-hae-2deg-1yr
+    - source: ultra
+      data_type: l3
+      descriptor: ulc-ena-h-hf-nsp-full-hae-4deg-1yr
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-nsp-full-hae-6deg-1yr


### PR DESCRIPTION
# Change Summary
Updated dependency yaml to reflect L3 jobs with multiple outputs to address GH issue #1449 

## File changes
imap_glows_dependencies.yaml

- Updated output descriptors for (l3b, ion-rate-profile)

imap_hi_dependencies.yaml

- Updated output descriptors for (l3, sp-maps)
- Updated output descriptors for (l3, hic-maps)

imap_lo_dependencies.yaml

- Updated output descriptors for (l3, all-maps)

imap_ultra_dependencies.yaml

- Updated output descriptors for (l3, u45-maps)
- Updated output descriptors for (l3, u90-maps)
- Updated output descriptors for (l3, ulc-sp-maps)
- Updated output descriptors for (l3, ulc-nsp-maps)

