### PR TITLE
Ialirt bugfix lambda eip

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -275,6 +275,7 @@ class IalirtProcessing(Construct):
 
     def create_lambda_function(
         self,
+        asg_name: str,
     ) -> lambda_alpha_.PythonFunction:
         """Create and return the Lambda function."""
         lambda_role = iam.Role(
@@ -303,6 +304,7 @@ class IalirtProcessing(Construct):
             timeout=Duration.minutes(1),
             memory_size=1000,
             role=lambda_role,
+            environment={"ASG_NAME": asg_name},
         )
 
         # The resource is deleted when the stack is deleted.
@@ -334,7 +336,9 @@ class IalirtProcessing(Construct):
         )
 
         auto_scaling_group.apply_removal_policy(RemovalPolicy.DESTROY)
-        eip_lambda = self.create_lambda_function()
+        eip_lambda = self.create_lambda_function(
+            auto_scaling_group.auto_scaling_group_name
+        )
         self.create_autoscaling_event_rule(eip_lambda, auto_scaling_group)
 
         # Attach the AmazonSSMManagedInstanceCore policy for SSM access

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 
 import boto3
 
@@ -58,10 +59,20 @@ def assign_elastic_ip(instance_id: str, eip_allocation_id: str, eventtype: str):
     ec2_description = ec2.describe_instances(InstanceIds=[instance_id])
     logger.info("eventtype%s", eventtype)
 
-    if (
-        ec2_description["Reservations"][0]["Instances"][0]["PublicIpAddress"]
-        == eip_description["Addresses"][0]["PublicIp"]
-    ):
+    instance = ec2_description["Reservations"][0]["Instances"][0]
+    tags = {tag["Key"]: tag["Value"] for tag in instance.get("Tags", [])}
+    expected_asg = os.environ.get("ASG_NAME", "")
+    if tags.get("aws:autoscaling:groupName") != expected_asg:
+        logger.info(
+            "Instance %s belongs to ASG %r, not the I-ALiRT ASG (%r); "
+            "skipping EIP assignment.",
+            instance_id,
+            tags.get("aws:autoscaling:groupName"),
+            expected_asg,
+        )
+        return
+
+    if instance["PublicIpAddress"] == eip_description["Addresses"][0]["PublicIp"]:
         logger.info("Elastic IP is already associated with this instance.")
         return
     elif "AssociationId" in eip_description["Addresses"][0]:

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_eip.py
@@ -61,7 +61,12 @@ def assign_elastic_ip(instance_id: str, eip_allocation_id: str, eventtype: str):
 
     instance = ec2_description["Reservations"][0]["Instances"][0]
     tags = {tag["Key"]: tag["Value"] for tag in instance.get("Tags", [])}
-    expected_asg = os.environ.get("ASG_NAME", "")
+    expected_asg = os.environ.get("ASG_NAME")
+    if not expected_asg:
+        logger.error(
+            "ASG_NAME environment variable is not set; skipping EIP assignment."
+        )
+        return
     if tags.get("aws:autoscaling:groupName") != expected_asg:
         logger.info(
             "Instance %s belongs to ASG %r, not the I-ALiRT ASG (%r); "

--- a/tests/lambda_endpoints/test_ialirt_eip.py
+++ b/tests/lambda_endpoints/test_ialirt_eip.py
@@ -27,8 +27,10 @@ def test_get_or_allocate_eip():
 
 
 @mock_ec2
-def test_assign_elastic_ip(caplog):
+def test_assign_elastic_ip(caplog, monkeypatch):
     """Test the assign_elastic_ip function."""
+    monkeypatch.setenv("ASG_NAME", "test-ialirt-asg")
+
     # Mock EC2 client
     ec2_client = boto3.client("ec2", region_name="us-west-2")
 
@@ -37,6 +39,10 @@ def test_assign_elastic_ip(caplog):
         ImageId="ami-0abcdef1234567890", InstanceType="t2.micro", MinCount=1, MaxCount=1
     )
     instance_id = instance_response["Instances"][0]["InstanceId"]
+    ec2_client.create_tags(
+        Resources=[instance_id],
+        Tags=[{"Key": "aws:autoscaling:groupName", "Value": "test-ialirt-asg"}],
+    )
 
     # Allocate a new EIP and get the AllocationId
     eip_response = ec2_client.allocate_address(Domain="vpc")
@@ -51,8 +57,39 @@ def test_assign_elastic_ip(caplog):
 
 
 @mock_ec2
-def test_assign_elastic_ip_disassociate(caplog):
+def test_assign_elastic_ip_skips_other_asg(caplog, monkeypatch):
+    """Instances outside the I-ALiRT ASG must not get the EIP reassigned."""
+    monkeypatch.setenv("ASG_NAME", "test-ialirt-asg")
+
+    ec2_client = boto3.client("ec2", region_name="us-west-2")
+
+    instance_response = ec2_client.run_instances(
+        ImageId="ami-0abcdef1234567890", InstanceType="t2.micro", MinCount=1, MaxCount=1
+    )
+    instance_id = instance_response["Instances"][0]["InstanceId"]
+    ec2_client.create_tags(
+        Resources=[instance_id],
+        Tags=[{"Key": "aws:autoscaling:groupName", "Value": "some-other-asg"}],
+    )
+
+    eip_response = ec2_client.allocate_address(Domain="vpc")
+    eip_allocation_id = eip_response["AllocationId"]
+
+    with caplog.at_level("INFO"):
+        assign_elastic_ip(instance_id, eip_allocation_id, "deploy")
+        assert "skipping EIP assignment" in caplog.text
+
+    addresses = ec2_client.describe_addresses(AllocationIds=[eip_allocation_id])[
+        "Addresses"
+    ]
+    assert "AssociationId" not in addresses[0]
+
+
+@mock_ec2
+def test_assign_elastic_ip_disassociate(caplog, monkeypatch):
     """Test the Elastic IP disassociation functionality."""
+    monkeypatch.setenv("ASG_NAME", "test-ialirt-asg")
+
     # Mock EC2 client
     ec2_client = boto3.client("ec2", region_name="us-west-2")
 
@@ -61,6 +98,10 @@ def test_assign_elastic_ip_disassociate(caplog):
         ImageId="ami-0abcdef1234567890", InstanceType="t2.micro", MinCount=1, MaxCount=1
     )
     instance_id_1 = instance_response["Instances"][0]["InstanceId"]
+    ec2_client.create_tags(
+        Resources=[instance_id_1],
+        Tags=[{"Key": "aws:autoscaling:groupName", "Value": "test-ialirt-asg"}],
+    )
 
     # Create another mock EC2 instance for disassociation
     instance_response_2 = ec2_client.run_instances(
@@ -72,7 +113,8 @@ def test_assign_elastic_ip_disassociate(caplog):
     eip_response = ec2_client.allocate_address(Domain="vpc")
     eip_allocation_id = eip_response["AllocationId"]
 
-    # Associate the EIP with the second instance
+    # Associate the EIP with the second instance (simulates another
+    # instance, e.g. an unrelated one, holding the I-ALiRT EIP)
     ec2_client.associate_address(
         InstanceId=instance_id_2, AllocationId=eip_allocation_id
     )


### PR DESCRIPTION
This pull request updates the I-ALiRT EIP assignment logic to ensure that Elastic IPs are only associated with instances belonging to the intended Auto Scaling Group (ASG). It does this by passing the ASG name to the Lambda function and checking instance tags before assigning the EIP. The test suite is also updated to cover these scenarios.

**EIP Assignment Logic Improvements:**

* The `create_lambda_function` method now takes an `asg_name` argument and passes it as the `ASG_NAME` environment variable to the Lambda function, ensuring the function knows which ASG it should operate on. [[1]](diffhunk://#diff-70cdf2d6b6fcce4d1f76aeb6203d7c43f74cf53a87b0dee27b8a1b48da6a3b70R278) [[2]](diffhunk://#diff-70cdf2d6b6fcce4d1f76aeb6203d7c43f74cf53a87b0dee27b8a1b48da6a3b70R307) [[3]](diffhunk://#diff-70cdf2d6b6fcce4d1f76aeb6203d7c43f74cf53a87b0dee27b8a1b48da6a3b70L337-R341)
* The Lambda function (`ialirt_eip.py`) checks the `aws:autoscaling:groupName` tag of each instance against the expected ASG name before assigning the EIP, and skips assignment if the instance is not in the correct ASG.

**Testing Enhancements:**

* The tests for EIP assignment are updated to set the `ASG_NAME` environment variable and tag instances with their ASG name, ensuring the logic is properly exercised. [[1]](diffhunk://#diff-bec5a4d7c61dcd933b03a86900529c0272d1b69d25ccdcd693066d954f44f7d2L30-R33) [[2]](diffhunk://#diff-bec5a4d7c61dcd933b03a86900529c0272d1b69d25ccdcd693066d954f44f7d2R42-R45) [[3]](diffhunk://#diff-bec5a4d7c61dcd933b03a86900529c0272d1b69d25ccdcd693066d954f44f7d2R101-R104)
* A new test, `test_assign_elastic_ip_skips_other_asg`, is added to verify that instances outside the target ASG do not receive the EIP.
* Existing tests are adjusted to use the new environment variable and tagging scheme for consistency and correctness. [[1]](diffhunk://#diff-bec5a4d7c61dcd933b03a86900529c0272d1b69d25ccdcd693066d954f44f7d2R101-R104) [[2]](diffhunk://#diff-bec5a4d7c61dcd933b03a86900529c0272d1b69d25ccdcd693066d954f44f7d2L75-R117)

**Other Minor Changes:**

* Import of the `os` module is added to `ialirt_eip.py` for environment variable access.
