### PR TITLE
Implement triggering scheme for attitude_history and pointing_attitude kernels

### DIFF
--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -646,11 +646,14 @@ class IMAPJobHandler:
                 trigger_ranges = spice.get_growing_kernel_trigger_ranges(
                     session, dependency.source, new_files
                 )
+                partition_set = set()
                 for min_dt, max_dt in trigger_ranges:
-                    partitions = dagster_utilities.get_affected_partitions(
-                        context, self.partitions_def, min_dt, max_dt
+                    partition_set.update(
+                        dagster_utilities.get_affected_partitions(
+                            context, self.partitions_def, min_dt, max_dt
+                        )
                     )
-                    partitions_to_run.extend(partitions)
+                partitions_to_run.extend(list(partition_set))
             else:
                 for file in new_files:
                     min_dt = getattr(file, datetime_start_column)

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -635,6 +635,22 @@ class IMAPJobHandler:
                     datetime.datetime.fromisoformat(config.MISSION_END_TIME),
                 )
                 partitions_to_run.extend(partitions)
+            elif dependency.source in spice.GROWING_KERNEL_TYPES:
+                # Attitude history and pointing attitude kernels grow over time
+                # (new segments are appended to the same file series). Using
+                # each new file's full min/max coverage here would re-trigger
+                # reprocessing of the entire kernel span on every delivery.
+                # Instead, narrow the range down to only the coverage that is
+                # actually new. See spice.get_growing_kernel_trigger_ranges for
+                # the full rules.
+                trigger_ranges = spice.get_growing_kernel_trigger_ranges(
+                    session, dependency.source, new_files
+                )
+                for min_dt, max_dt in trigger_ranges:
+                    partitions = dagster_utilities.get_affected_partitions(
+                        context, self.partitions_def, min_dt, max_dt
+                    )
+                    partitions_to_run.extend(partitions)
             else:
                 for file in new_files:
                     min_dt = getattr(file, datetime_start_column)

--- a/sds_data_manager/orchestration/spice.py
+++ b/sds_data_manager/orchestration/spice.py
@@ -7,6 +7,7 @@ import logging
 import imap_data_access
 
 from sds_data_manager.lambda_code.SDSCode.api_lambdas import spice_metakernel_api
+from sds_data_manager.lambda_code.SDSCode.database import models
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -175,3 +176,173 @@ def get_upstream_dependency_inputs_spice(
 
     logger.info(f"Found metakernel files: {metakernel_files}. Adding to collection.")
     return metakernel_files
+
+
+def _parse_interval_list(
+    raw_intervals: list[list[str]] | None,
+) -> list[list[datetime.datetime]]:
+    """Convert a list of ISO-formatted [start, end] pairs to datetime pairs.
+
+    Parameters
+    ----------
+    raw_intervals : list[list[str]] | None
+        The `file_intervals_datetime` value from a SPICEFiles row: a list of
+        [start, end] pairs of ISO-formatted datetime strings.
+
+    Returns
+    -------
+    list[list[datetime.datetime]]
+        The same intervals, parsed to datetime objects.
+    """
+    if not raw_intervals:
+        return []
+    return [
+        [datetime.datetime.fromisoformat(start), datetime.datetime.fromisoformat(end)]
+        for start, end in raw_intervals
+    ]
+
+
+def subtract_intervals(
+    new_intervals: list[list[datetime.datetime]],
+    old_intervals: list[list[datetime.datetime]],
+) -> list[list[datetime.datetime]]:
+    """Return the portions of new_intervals not covered by old_intervals.
+
+    Both inputs are lists of [start, end] datetime pairs. This is used to find
+    the segments of a new attitude history kernel's SPICE-derived coverage
+    that were not already covered by its predecessor kernel, so that only
+    genuinely new time coverage gets reprocessed.
+
+    Parameters
+    ----------
+    new_intervals : list[list[datetime.datetime]]
+        The [start, end] segments of the new kernel's coverage.
+    old_intervals : list[list[datetime.datetime]]
+        The [start, end] segments already covered by the predecessor kernel.
+
+    Returns
+    -------
+    list[list[datetime.datetime]]
+        The leftover [start, end] segments of new_intervals not covered by
+        old_intervals.
+
+    Notes
+    -----
+    Neither `new_intervals` nor `old_intervals` needs to be pre-sorted, and
+    `old_intervals` is allowed to contain overlapping entries: each new
+    interval is handled independently (sorting the relevant slice of
+    `old_intervals` itself, below), so ordering of the inputs doesn't affect
+    correctness. The one thing that does depend on input order is the
+    ordering of the *output*: leftover segments are appended in the order
+    `new_intervals` was given, so pass a chronologically sorted
+    `new_intervals` if you want a chronologically sorted result.
+    """
+    leftover = []
+    for new_start, new_end in new_intervals:
+        # Old intervals that don't overlap this new interval at all can't
+        # subtract anything from it, so drop them. Sort what's left by start
+        # time so the sweep below can walk left to right in one pass.
+        overlaps = sorted(
+            (o for o in old_intervals if o[0] < new_end and o[1] > new_start),
+            key=lambda o: o[0],
+        )
+        # `cursor` tracks how far into [new_start, new_end) we've accounted
+        # for so far - everything before it has already been covered by an
+        # old interval already processed, or emitted as leftover, else emit
+        # the gap before it as leftover.
+        cursor = new_start
+        for old_start, old_end in overlaps:
+            if old_start > cursor:
+                # Gap between what we've covered so far and this old
+                # interval's start: that gap is new (uncovered) coverage.
+                leftover.append([cursor, min(old_start, new_end)])
+            # Advance the cursor past this old interval. max() (rather than
+            # plain assignment) handles old intervals that overlap each
+            # other, where old_end could be behind the cursor already.
+            cursor = max(cursor, old_end)
+            if cursor >= new_end:
+                break
+        if cursor < new_end:
+            # Anything left after the last old interval is a trailing
+            # leftover, e.g. brand new segments appended past old_end.
+            leftover.append([cursor, new_end])
+    return leftover
+
+
+# Kernel types whose coverage grows by appending segments to the same file
+# series over time (attitude_history: MOC-delivered AH kernels; pointing_attitude:
+# the DPS kernel produced by the spacecraft l1a pointing-attitude job). Both use
+# the same start-date_end-date_version filename convention and the same
+# ingestion-time SPICE segment decomposition, so the same trigger-range rules
+# apply to both.
+GROWING_KERNEL_TYPES = ("attitude_history", "pointing_attitude")
+
+
+def get_growing_kernel_trigger_ranges(
+    session, kernel_type: str, new_files: list["models.SPICEFiles"]
+) -> list[tuple[datetime.datetime, datetime.datetime]]:
+    """Determine the time ranges that require reprocessing for new AH/DPS kernels.
+
+    Newly ingested attitude_history or pointing_attitude kernels are handled
+    with one of three rules:
+
+    1. Same coverage as an existing kernel, but a higher version number (a
+       correction to already-delivered data) -> the entire coverage range is
+       reprocessed, since previously processed data can no longer be assumed
+       to be valid.
+    2. Coverage that extends an existing kernel with the same start date
+       (the normal append-only growth pattern, since new segments are only
+       ever appended) -> only the segments of coverage that are new are
+       reprocessed. Per-segment coverage was already computed with SPICE
+       tools (spiceypy ckcov) at ingestion time and is stored on each file's
+       `file_intervals_datetime`.
+    3. A new start date, meaning no earlier kernel shares it (the kernel has
+       "rolled over" to a new coverage window) -> the entire coverage range
+       is reprocessed, since none of it has been processed before.
+
+    Parameters
+    ----------
+    session : orm session
+        Database session used to look up existing kernels of this type.
+    kernel_type : str
+        One of `GROWING_KERNEL_TYPES` ("attitude_history" or
+        "pointing_attitude").
+    new_files : list[models.SPICEFiles]
+        Newly ingested SPICEFiles rows of the given kernel_type.
+
+    Returns
+    -------
+    list[tuple[datetime.datetime, datetime.datetime]]
+        The time ranges that require reprocessing.
+    """
+    ranges = []
+    for new_file in sorted(new_files, key=lambda f: f.max_date_datetime):
+        predecessor = (
+            session.query(models.SPICEFiles)
+            .filter(
+                models.SPICEFiles.kernel_type == kernel_type,
+                models.SPICEFiles.file_name != new_file.file_name,
+                models.SPICEFiles.min_date_datetime == new_file.min_date_datetime,
+                models.SPICEFiles.max_date_datetime <= new_file.max_date_datetime,
+            )
+            .order_by(models.SPICEFiles.max_date_datetime.desc())
+            .first()
+        )
+
+        if predecessor is None:
+            # Case 3: new start date - nothing to diff against.
+            ranges.append((new_file.min_date_datetime, new_file.max_date_datetime))
+        elif predecessor.max_date_datetime == new_file.max_date_datetime:
+            # Case 1: version increment with identical coverage.
+            ranges.append((new_file.min_date_datetime, new_file.max_date_datetime))
+        else:
+            # Case 2: coverage extended - only trigger the new segments.
+            new_intervals = _parse_interval_list(new_file.file_intervals_datetime)
+            if not new_intervals:
+                # Defensive fallback: no segment data to diff against.
+                ranges.append((new_file.min_date_datetime, new_file.max_date_datetime))
+                continue
+            old_intervals = _parse_interval_list(predecessor.file_intervals_datetime)
+            new_segments = subtract_intervals(new_intervals, old_intervals)
+            ranges.extend((seg[0], seg[1]) for seg in new_segments)
+    return ranges

--- a/tests/orchestration/test_spice_dependency_triggers.py
+++ b/tests/orchestration/test_spice_dependency_triggers.py
@@ -1,0 +1,378 @@
+"""Tests for narrowing the reprocessing range triggered by growing SPICE kernels.
+
+Attitude history and pointing attitude kernels grow over time by appending new
+segments to the same file series, occasionally get a version bump for corrected
+data, and occasionally roll over to a new start date. These tests cover:
+
+  - `spice.subtract_intervals`, the pure interval-diffing helper.
+  - `spice.get_growing_kernel_trigger_ranges`, which applies the three
+    detection rules (version bump, extends coverage, new start date).
+  - The wiring of that logic into
+    `IMAPJobHandler.trigger_from_new_non_science_inputs`, verifying that a
+    growing kernel only triggers reprocessing for genuinely new coverage.
+"""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from dagster import DagsterInstance, build_sensor_context
+
+from sds_data_manager.lambda_code.SDSCode.database import database as db
+from sds_data_manager.lambda_code.SDSCode.database import models
+from sds_data_manager.orchestration import spice
+from sds_data_manager.orchestration.imap_dagster import dependency_config
+from sds_data_manager.orchestration.imap_job import IMAPJobHandler
+
+UTC = datetime.timezone.utc
+
+
+def _dt(s):
+    return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=UTC)
+
+
+def _iso_intervals(pairs):
+    """Build [start, end] ISO string pairs like those stored in the DB."""
+    return [[start.isoformat(), end.isoformat()] for start, end in pairs]
+
+
+def _file(file_name, min_dt, max_dt, intervals=None):
+    """Build a lightweight stand-in for a SPICEFiles row."""
+    return SimpleNamespace(
+        file_name=file_name,
+        min_date_datetime=min_dt,
+        max_date_datetime=max_dt,
+        file_intervals_datetime=_iso_intervals(intervals)
+        if intervals is not None
+        else _iso_intervals([[min_dt, max_dt]]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# subtract_intervals
+# ---------------------------------------------------------------------------
+
+
+class TestSubtractIntervals:
+    """Tests for the pure interval-subtraction helper."""
+
+    def test_fully_covered_returns_nothing(self):
+        """No leftover when the new interval exactly matches the old one."""
+        new = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-02T00:00:00")]]
+        old = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-02T00:00:00")]]
+        assert spice.subtract_intervals(new, old) == []
+
+    def test_no_overlap_returns_entire_new_interval(self):
+        """The entire new interval is leftover when nothing overlaps it."""
+        new = [[_dt("2025-01-02T00:00:00"), _dt("2025-01-03T00:00:00")]]
+        old = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-01T12:00:00")]]
+        assert spice.subtract_intervals(new, old) == new
+
+    def test_new_trailing_segment_appended(self):
+        """A brand new segment appended after the old coverage ends."""
+        new = [
+            [_dt("2025-01-01T00:00:00"), _dt("2025-01-02T00:00:00")],
+            [_dt("2025-01-02T00:00:00"), _dt("2025-01-03T00:00:00")],
+        ]
+        old = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-02T00:00:00")]]
+        result = spice.subtract_intervals(new, old)
+        assert result == [[_dt("2025-01-02T00:00:00"), _dt("2025-01-03T00:00:00")]]
+
+    def test_partial_extension_of_last_segment(self):
+        """The last old segment's end grew slightly further in the new file."""
+        new = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-02T12:00:00")]]
+        old = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-02T00:00:00")]]
+        result = spice.subtract_intervals(new, old)
+        assert result == [[_dt("2025-01-02T00:00:00"), _dt("2025-01-02T12:00:00")]]
+
+    def test_partial_extension_plus_new_segment_with_gap(self):
+        """Combines a partial extension of the last segment with a brand new one."""
+        new = [
+            [_dt("2025-01-01T00:00:00"), _dt("2025-01-02T12:00:00")],
+            [_dt("2025-01-03T00:00:00"), _dt("2025-01-04T00:00:00")],
+        ]
+        old = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-02T00:00:00")]]
+        result = spice.subtract_intervals(new, old)
+        assert result == [
+            [_dt("2025-01-02T00:00:00"), _dt("2025-01-02T12:00:00")],
+            [_dt("2025-01-03T00:00:00"), _dt("2025-01-04T00:00:00")],
+        ]
+
+    def test_multiple_old_intervals_with_gap_between(self):
+        """Old coverage has a gap; only the gap and the tail are new."""
+        new = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-05T00:00:00")]]
+        old = [
+            [_dt("2025-01-01T00:00:00"), _dt("2025-01-02T00:00:00")],
+            [_dt("2025-01-03T00:00:00"), _dt("2025-01-04T00:00:00")],
+        ]
+        result = spice.subtract_intervals(new, old)
+        assert result == [
+            [_dt("2025-01-02T00:00:00"), _dt("2025-01-03T00:00:00")],
+            [_dt("2025-01-04T00:00:00"), _dt("2025-01-05T00:00:00")],
+        ]
+
+    def test_empty_old_intervals_returns_all_new(self):
+        """No predecessor coverage at all means everything is leftover."""
+        new = [[_dt("2025-01-01T00:00:00"), _dt("2025-01-02T00:00:00")]]
+        assert spice.subtract_intervals(new, []) == new
+
+
+# ---------------------------------------------------------------------------
+# get_growing_kernel_trigger_ranges
+# ---------------------------------------------------------------------------
+
+
+class TestGetGrowingKernelTriggerRanges:
+    """Tests for the three-case detection logic, using a mocked DB session."""
+
+    def _mock_session(self, predecessor):
+        """Return a mock session whose predecessor lookup returns `predecessor`."""
+        session = MagicMock()
+        first_mock = (
+            session.query.return_value.filter.return_value.order_by.return_value.first
+        )
+        first_mock.return_value = predecessor
+        return session
+
+    def test_no_predecessor_triggers_full_range(self):
+        """Case 3: a new start date - nothing shares it, so trigger everything."""
+        new_file = _file(
+            "imap_2025_100_2025_150_01.ah.bc",
+            _dt("2025-04-10T00:00:00"),
+            _dt("2025-05-30T00:00:00"),
+        )
+        session = self._mock_session(None)
+        ranges = spice.get_growing_kernel_trigger_ranges(
+            session, "attitude_history", [new_file]
+        )
+        assert ranges == [(new_file.min_date_datetime, new_file.max_date_datetime)]
+
+    def test_version_bump_same_coverage_triggers_full_range(self):
+        """Case 1: identical coverage, higher version -> full range."""
+        min_dt = _dt("2025-01-01T00:00:00")
+        max_dt = _dt("2025-03-01T00:00:00")
+        predecessor = _file("imap_2025_001_2025_060_01.ah.bc", min_dt, max_dt)
+        new_file = _file("imap_2025_001_2025_060_02.ah.bc", min_dt, max_dt)
+
+        session = self._mock_session(predecessor)
+        ranges = spice.get_growing_kernel_trigger_ranges(
+            session, "attitude_history", [new_file]
+        )
+        assert ranges == [(min_dt, max_dt)]
+
+    def test_extends_coverage_triggers_only_new_segment(self):
+        """Case 2: coverage extended - only the new segment is triggered."""
+        min_dt = _dt("2025-01-01T00:00:00")
+        old_max = _dt("2025-01-05T00:00:00")
+        new_max = _dt("2025-01-10T00:00:00")
+
+        predecessor = _file(
+            "imap_2025_001_2025_005_01.ah.bc",
+            min_dt,
+            old_max,
+            intervals=[[min_dt, old_max]],
+        )
+        new_file = _file(
+            "imap_2025_001_2025_010_01.ah.bc",
+            min_dt,
+            new_max,
+            intervals=[[min_dt, old_max], [old_max, new_max]],
+        )
+
+        session = self._mock_session(predecessor)
+        ranges = spice.get_growing_kernel_trigger_ranges(
+            session, "attitude_history", [new_file]
+        )
+        assert ranges == [(old_max, new_max)]
+
+    def test_extends_coverage_with_no_interval_data_falls_back_to_full_range(self):
+        """Defensive fallback: missing segment data still triggers reprocessing."""
+        min_dt = _dt("2025-01-01T00:00:00")
+        old_max = _dt("2025-01-05T00:00:00")
+        new_max = _dt("2025-01-10T00:00:00")
+
+        predecessor = _file("imap_2025_001_2025_005_01.ah.bc", min_dt, old_max)
+        new_file = _file("imap_2025_001_2025_010_01.ah.bc", min_dt, new_max)
+        new_file.file_intervals_datetime = []
+
+        session = self._mock_session(predecessor)
+        ranges = spice.get_growing_kernel_trigger_ranges(
+            session, "attitude_history", [new_file]
+        )
+        assert ranges == [(min_dt, new_max)]
+
+    def test_pointing_attitude_kernel_type_uses_same_rules(self):
+        """The generalized logic also applies to pointing_attitude kernels."""
+        min_dt = _dt("2025-01-01T00:00:00")
+        old_max = _dt("2025-01-05T00:00:00")
+        new_max = _dt("2025-01-10T00:00:00")
+
+        predecessor = _file(
+            "imap_dps_2025_001_2025_005_01.ah.bc",
+            min_dt,
+            old_max,
+            intervals=[[min_dt, old_max]],
+        )
+        new_file = _file(
+            "imap_dps_2025_001_2025_010_01.ah.bc",
+            min_dt,
+            new_max,
+            intervals=[[min_dt, old_max], [old_max, new_max]],
+        )
+
+        session = self._mock_session(predecessor)
+        ranges = spice.get_growing_kernel_trigger_ranges(
+            session, "pointing_attitude", [new_file]
+        )
+        assert ranges == [(old_max, new_max)]
+
+
+# ---------------------------------------------------------------------------
+# Wiring into IMAPJobHandler.trigger_from_new_non_science_inputs
+# ---------------------------------------------------------------------------
+
+
+def _mag_job_handler():
+    """Return a job handler for a real job with default-triggering AH/DPS inputs.
+
+    Uses the (mag, l1d, norm-srf) job, which lists both attitude_history and
+    pointing_attitude as spice inputs without trigger_job=false overrides.
+    """
+    return IMAPJobHandler(dependency_config._config[("mag", "l1d", "norm-srf")])
+
+
+def _session_returning(new_files, predecessor):
+    """Return a mock session returning `new_files` and predecessor `predecessor`."""
+    session = MagicMock()
+    session.query.return_value.filter.return_value.all.return_value = new_files
+    first_mock = (
+        session.query.return_value.filter.return_value.order_by.return_value.first
+    )
+    first_mock.return_value = predecessor
+    return session
+
+
+class TestTriggerFromNewNonScienceInputsWiring:
+    """Verifies the generic sensor logic narrows growing-kernel trigger ranges."""
+
+    def test_attitude_history_only_triggers_new_daily_partitions(self):
+        """Only the newly appended segment's daily partitions are triggered."""
+        instance = DagsterInstance.ephemeral()
+        instance.add_dynamic_partitions(
+            "daily_partitions",
+            [
+                "daily_2025-01-01T00:00:00_to_2025-01-02T00:00:00",
+                "daily_2025-01-02T00:00:00_to_2025-01-03T00:00:00",
+                "daily_2025-01-03T00:00:00_to_2025-01-04T00:00:00",
+            ],
+        )
+        context = build_sensor_context(instance=instance)
+
+        job_handler = _mag_job_handler()
+        dependency = next(
+            d
+            for d in job_handler.job_config.spice_inputs
+            if d.source == "attitude_history"
+        )
+
+        min_dt = _dt("2025-01-01T00:00:00")
+        old_max = _dt("2025-01-02T00:00:00")
+        new_max = _dt("2025-01-04T00:00:00")
+
+        predecessor = _file(
+            "imap_2025_001_2025_002_01.ah.bc",
+            min_dt,
+            old_max,
+            intervals=[[min_dt, old_max]],
+        )
+        new_file = _file(
+            "imap_2025_001_2025_004_01.ah.bc",
+            min_dt,
+            new_max,
+            intervals=[[min_dt, old_max], [old_max, new_max]],
+        )
+        new_file.ingestion_date = datetime.datetime.now(UTC)
+
+        session = _session_returning([new_file], predecessor)
+        cursors = {dependency.to_dagster_name(): "2024-01-01T00:00:00"}
+
+        with patch.object(db, "Session") as mock_cls:
+            mock_cls.return_value.__enter__.return_value = session
+            mock_cls.return_value.__exit__.return_value = False
+            partitions = job_handler.trigger_from_new_non_science_inputs(
+                context,
+                dependency,
+                cursors,
+                models.SPICEFiles,
+                models.SPICEFiles.kernel_type,
+                None,
+                "min_date_datetime",
+                "max_date_datetime",
+            )
+
+        # Only the two days after the predecessor's coverage should be
+        # affected - the already-processed Jan 1 -> Jan 2 partition must not
+        # be re-triggered.
+        assert set(partitions) == {
+            "daily_2025-01-02T00:00:00_to_2025-01-03T00:00:00",
+            "daily_2025-01-03T00:00:00_to_2025-01-04T00:00:00",
+        }
+
+    def test_pointing_attitude_also_narrows_trigger_range(self):
+        """Confirms pointing_attitude dependencies get the same narrowing."""
+        instance = DagsterInstance.ephemeral()
+        instance.add_dynamic_partitions(
+            "daily_partitions",
+            [
+                "daily_2025-01-01T00:00:00_to_2025-01-02T00:00:00",
+                "daily_2025-01-02T00:00:00_to_2025-01-03T00:00:00",
+            ],
+        )
+        context = build_sensor_context(instance=instance)
+
+        job_handler = _mag_job_handler()
+        dependency = next(
+            d
+            for d in job_handler.job_config.spice_inputs
+            if d.source == "pointing_attitude"
+        )
+
+        min_dt = _dt("2025-01-01T00:00:00")
+        old_max = _dt("2025-01-01T12:00:00")
+        new_max = _dt("2025-01-03T00:00:00")
+
+        predecessor = _file(
+            "imap_dps_2025_001_2025_001_01.ah.bc",
+            min_dt,
+            old_max,
+            intervals=[[min_dt, old_max]],
+        )
+        new_file = _file(
+            "imap_dps_2025_001_2025_003_01.ah.bc",
+            min_dt,
+            new_max,
+            intervals=[[min_dt, old_max], [old_max, new_max]],
+        )
+        new_file.ingestion_date = datetime.datetime.now(UTC)
+
+        session = _session_returning([new_file], predecessor)
+        cursors = {dependency.to_dagster_name(): "2024-01-01T00:00:00"}
+
+        with patch.object(db, "Session") as mock_cls:
+            mock_cls.return_value.__enter__.return_value = session
+            mock_cls.return_value.__exit__.return_value = False
+            partitions = job_handler.trigger_from_new_non_science_inputs(
+                context,
+                dependency,
+                cursors,
+                models.SPICEFiles,
+                models.SPICEFiles.kernel_type,
+                None,
+                "min_date_datetime",
+                "max_date_datetime",
+            )
+
+        assert set(partitions) == {
+            "daily_2025-01-01T00:00:00_to_2025-01-02T00:00:00",
+            "daily_2025-01-02T00:00:00_to_2025-01-03T00:00:00",
+        }


### PR DESCRIPTION
**Narrow the reprocessing range triggered by new attitude/pointing kernels

Problem

Attitude history (AH) and pointing attitude (DPS) kernels grow by appending new segments to the same file series over time, occasionally reaching ~3 months of coverage. The generic sensor logic (trigger_from_new_non_science_inputs) used each new kernel's entire [min_date, max_date] coverage to decide which downstream partitions to reprocess — so every new delivery re-triggered reprocessing across the whole multi-month span, even when only a few days of new coverage had actually been added.

Fix

trigger_from_new_non_science_inputs now special-cases attitude_history and pointing_attitude dependencies and computes a narrower set of trigger ranges based on three rules:
1. Version bump, same coverage (a correction) → reprocess the full range.
2. Extends coverage, same start date (normal append growth) → diff the new kernel's SPICE-derived segments (file_intervals_datetime, already computed via spiceypy at ingestion) against its predecessor's, and reprocess only the leftover (new) segments.
3. New start date (kernel rolled to a new window) → reprocess the full range.

Changes

- orchestration/spice.py: added subtract_intervals (pure interval-diff helper, with comments on the sweep algorithm and a note on input-sort requirements), GROWING_KERNEL_TYPES, and get_growing_kernel_trigger_ranges implementing the three rules above.
- orchestration/imap_job.py: wired the new logic into trigger_from_new_non_science_inputs for attitude_history/pointing_attitude dependencies; all other spice kernel types are unaffected.
- tests/orchestration/test_spice_dependency_triggers.py: new test coverage for the interval-diff helper, the three-case detection logic (including the pointing_attitude generalization), and end-to-end wiring through the sensor logic.**


Closes: #596 