### PR TITLE
Adding 'version' back to query result.

### DIFF
--- a/sds_data_manager/lambda_code/SDSCode/api_lambdas/query_api.py
+++ b/sds_data_manager/lambda_code/SDSCode/api_lambdas/query_api.py
@@ -196,6 +196,10 @@ def _format_search_results(search_results):
 
     """
     for result in search_results:
+        if "major_version" in result and "minor_version" in result:
+            result["version"] = (
+                f"v{result['major_version']:03d}.{result['minor_version']:04d}"
+            )
         result["start_date"] = result["start_date"].strftime("%Y%m%d")
         if result.get("end_date"):
             result["end_date"] = result["end_date"].strftime("%Y%m%d")

--- a/tests/lambda_endpoints/test_query_api.py
+++ b/tests/lambda_endpoints/test_query_api.py
@@ -53,6 +53,7 @@ def expected_response():
                 "repointing": None,
                 "major_version": 1,
                 "minor_version": 1,
+                "version": "v001.0001",
                 "extension": "pkts",
                 "ingestion_date": "20251107 10:13:12",
                 "cr": None,


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
On the website, I noticed that 'Version' column is showing up as empty because query result doesn't include 'version'. It only has major and minor version. Adding 'version' back into query return.

## File changes
<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->


## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
