### PR TITLE
add index to science the two science file tables

### DIFF
--- a/alembic/versions/00bb63a40cf1_science_files_version_index.py
+++ b/alembic/versions/00bb63a40cf1_science_files_version_index.py
@@ -1,0 +1,47 @@
+"""science_files_version_index.
+
+Revision ID: 00bb63a40cf1
+Revises: e5dee361947f
+Create Date: 2026-07-15 18:05:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "00bb63a40cf1"
+down_revision: str | Sequence[str] | None = "e5dee361947f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Speeds up the correlated "latest version" subqueries in query_api.py, which
+# scan for MAX(major_version)/MAX(minor_version) grouped by these columns.
+# See GitHub issue #1256.
+_VERSION_INDEX_COLUMNS = [
+    "instrument",
+    "data_level",
+    "descriptor",
+    "start_date",
+    "repointing",
+    "major_version",
+    "minor_version",
+]
+_TABLES = ("science_files", "quicklook_files")
+
+
+def upgrade() -> None:
+    """Upgrade schema: add composite version index to science/quicklook files."""
+    for table in _TABLES:
+        op.create_index(
+            f"idx_{table}_version",
+            table,
+            _VERSION_INDEX_COLUMNS,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema: drop composite version index."""
+    for table in _TABLES:
+        op.drop_index(f"idx_{table}_version", table_name=table)

--- a/sds_data_manager/lambda_code/SDSCode/database/models.py
+++ b/sds_data_manager/lambda_code/SDSCode/database/models.py
@@ -25,7 +25,7 @@ from sqlalchemy import (
 from sqlalchemy import (
     Enum as SqlEnum,
 )
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, declared_attr
 
 # Instrument name Enums for the ScienceFiles table
 INSTRUMENTS = SqlEnum(
@@ -174,10 +174,24 @@ class ScienceFileBase:
     crid = Column(String, nullable=True)
     released = Column(Boolean, nullable=False, default=False)
 
-    __table_args__ = (
-        CheckConstraint("major_version >= 0 AND major_version <= 999"),
-        CheckConstraint("minor_version >= 0 AND minor_version <= 9999"),
-    )
+    @declared_attr
+    def __table_args__(cls):  # noqa: N805
+        """Build table args with a version index named per subclass."""
+        return (
+            Index(
+                # separate name for index for each subclass
+                f"idx_{cls.__tablename__}_version",
+                "instrument",
+                "data_level",
+                "descriptor",
+                "start_date",
+                "repointing",
+                "major_version",
+                "minor_version",
+            ),
+            CheckConstraint("major_version >= 0 AND major_version <= 999"),
+            CheckConstraint("minor_version >= 0 AND minor_version <= 9999"),
+        )
 
 
 class ScienceFiles(ScienceFileBase, Base):


### PR DESCRIPTION
# Change Summary

## Overview
As pointed out in #1493, the recent versioning change made the queries really slow. See comments in #1256 for how we figured out the problem. It boils down to lacking an index on the table. So in this PR I added an index.

## File changes
- **`models.py`** — Added a composite `Index` on the shared `ScienceFileBase`
  mixin covering `instrument`, `data_level`, `descriptor`, `start_date`,
  `repointing`, `major_version`, and `minor_version`. Because both
  `ScienceFiles` and `QuicklookFiles` inherit from this mixin, `__table_args__`
  is built via `@declared_attr` so each subclass gets its own distinctly-named
  index (`idx_<tablename>_version`) rather than sharing a single Index object
  (which SQLAlchemy rejects). The existing `CheckConstraint`s are preserved.
- **`alembic/versions/00bb63a40cf1_science_files_version_index.py`** — New
  migration creating the two indexes on `science_files` and `quicklook_files`,
  with a matching `downgrade()` that drops them.

**Please review the alembic script in particular, I'm not sure I did that right.**

## Testing
There were no unit tests for `models.py` so I did not modify any tests.
