### PR TITLE
I-ALiRT - add ability for user to add event time

### DIFF
--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -359,7 +359,12 @@ def generate_and_upload_30_days(
     outages = {"Kiel": [("2026-09-22T13:50:00.00Z", "2026-09-22T14:10:00.00Z")]}
     dsn = {"DSS-55": [("2026-09-22T08:00:00.00Z", "2026-09-22T09:00:00.00Z")]}
     """
-    today = start_date or datetime.now(timezone.utc)
+    if start_date is None:
+        today = datetime.now(timezone.utc)
+    else:
+        if start_date.tzinfo is None:
+            start_date = start_date.replace(tzinfo=timezone.utc)
+        today = start_date.astimezone(timezone.utc)
 
     for i in range(30):
         day = today + timedelta(days=i)

--- a/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
+++ b/sds_data_manager/lambda_code/IAlirtCode/ialirt_coverage.py
@@ -334,6 +334,7 @@ def generate_and_upload_30_days(
     outages: dict,
     dsn: dict,
     uksa: list | None = None,
+    start_date: datetime | None = None,
 ):
     """Upload new coverage json files to S3.
 
@@ -349,6 +350,8 @@ def generate_and_upload_30_days(
         Dictionary containing DSN data.
     uksa : list, optional
         List of UKSA contact windows as (start, end) tuples.
+    start_date : datetime, optional
+        First day of the 30-day window to (re)generate.
 
     Notes
     -----
@@ -356,7 +359,7 @@ def generate_and_upload_30_days(
     outages = {"Kiel": [("2026-09-22T13:50:00.00Z", "2026-09-22T14:10:00.00Z")]}
     dsn = {"DSS-55": [("2026-09-22T08:00:00.00Z", "2026-09-22T09:00:00.00Z")]}
     """
-    today = datetime.now(timezone.utc)
+    today = start_date or datetime.now(timezone.utc)
 
     for i in range(30):
         day = today + timedelta(days=i)
@@ -417,4 +420,15 @@ def lambda_handler(event, context):
             "No outage files found in bucket %s. Using empty outages dict.", bucket
         )
 
-    generate_and_upload_30_days(bucket, region, outages, dsn, uksa)
+    # Optional override to backfill a past 30-day window, e.g. after an
+    # outage file is uploaded for a day that has already passed.
+    start_date_str = event.get("start_date")
+    start_date = (
+        datetime.strptime(start_date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        if start_date_str
+        else None
+    )
+
+    generate_and_upload_30_days(
+        bucket, region, outages, dsn, uksa, start_date=start_date
+    )


### PR DESCRIPTION
This pull request adds support for regenerating and uploading 30-day coverage windows starting from a user-specified date, making it easier to backfill data after outages or late file uploads. The main changes include updating the `generate_and_upload_30_days` function to accept an optional `start_date` parameter and modifying the Lambda handler to parse this from the event input.

**Enhancements for backfilling and flexibility:**

* `generate_and_upload_30_days` now accepts an optional `start_date` parameter, allowing the 30-day window to start from a specified date instead of always using the current date.
* The function docstring is updated to document the new `start_date` parameter, explaining its purpose for regenerating past windows.
* The logic inside `generate_and_upload_30_days` uses `start_date` if provided; otherwise, it defaults to the current date.

**Lambda handler improvements:**

* The `lambda_handler` function now reads an optional `start_date` from the event payload, parses it, and passes it to `generate_and_upload_30_days`, enabling backfill operations via Lambda event input.