### PR TITLE
ULTRA l3 maps add output major version

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
@@ -2264,54 +2264,71 @@ de_inputs_90sensor: &de_inputs_90sensor
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-2deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-2deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-4deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-4deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-6deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-6deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-2deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-2deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-4deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-4deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-6deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-6deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-2deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-2deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-4deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-4deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-hf-sp-full-hae-6deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u45-ena-h-sf-sp-full-hae-6deg-1yr
@@ -2327,54 +2344,71 @@ de_inputs_90sensor: &de_inputs_90sensor
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-2deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-2deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-4deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-4deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-6deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-6deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-2deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-2deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-4deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-4deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-6deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-6deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-2deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-2deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-4deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-4deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-hf-sp-full-hae-6deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: u90-ena-h-sf-sp-full-hae-6deg-1yr
@@ -2390,27 +2424,35 @@ de_inputs_90sensor: &de_inputs_90sensor
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-2deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-4deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-6deg-3mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-2deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-4deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-6deg-6mo
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-2deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-4deg-1yr
+      major_version: 1
     - source: ultra
       data_type: l3
       descriptor: ulc-ena-h-hf-sp-full-hae-6deg-1yr


### PR DESCRIPTION
# Change Summary

closes #1507 1507
## Overview
ULTRA l3 map runs were failing. 
E.G 
http://dagste-dagst-4md4wl7yswak-112189046.us-west-2.elb.amazonaws.com/runs/3d4f3066-3dce-48a0-a8f5-ae56603a4d5d

This is because the yaml did not have the major version specified for each output. 
