### PR TITLE
Updating SWE, HIT, and CoDICE dependencies to not require Mag L2.

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_codice_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_codice_dependencies.yaml
@@ -437,6 +437,7 @@ lo_l3a_dist_common: &lo_l3a_dist_common
     - source: mag
       data_type: l2
       descriptor: norm-dsrf
+      required: false
       trigger_job: false
     - source: codice
       data_type: l2

--- a/sds_data_manager/orchestration/dependencies/imap_hit_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_hit_dependencies.yaml
@@ -232,6 +232,7 @@ l0_data: &l0_data
     - source: mag
       data_type: l2
       descriptor: norm-dsrf
+      required: false
       trigger_job: false
   outputs:
     - source: hit

--- a/sds_data_manager/orchestration/dependencies/imap_swe_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_swe_dependencies.yaml
@@ -98,6 +98,7 @@
     - source: mag
       data_type: l2
       descriptor: norm-dsrf
+      required: false
       trigger_job: false
     - source: imap_frames
       data_type: spice


### PR DESCRIPTION
# Change Summary

## Overview
SWE, HIT, and CoDICE L3 products were incorrectly requiring Mag L2. The intention is to use L2 when available, but fall back to Mag L1d if L2 is not available.