### PR TITLE
Improve dagster logging when there are missing upstream dependencies

### DIFF
--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -219,11 +219,8 @@ class IMAPJobHandler:
                 dependency_inputs = self.get_dependencies(
                     session, context, target_start, target_end
                 )
-
-                if not dependency_inputs:
-                    return SkipReason("Dependency inputs were missing.")
-
             except MissingDependenciesError as e:
+                context.log.info(f"Skipping job: {e}")
                 return SkipReason(str(e))
 
             context.log.info(
@@ -836,8 +833,10 @@ class IMAPJobHandler:
         )
         if not spice_files and self.job_config.spice_inputs:
             # If no SPICE files are returned, but there are SPICE inputs, raise failure
-            raise MissingDependenciesError(f"""Missing SPICE files between
-                                           {target_start} and {target_end}""")
+            raise MissingDependenciesError(
+                f"Missing SPICE files ({', '.join(self.job_config.spice_types)}) "
+                f"between {target_start} and {target_end}"
+            )
 
         return spice_files
 
@@ -886,8 +885,8 @@ class IMAPJobHandler:
         if not science_processing_inputs:
             # Return right away if we have zero science files.
             raise MissingDependenciesError(
-                "No science files were discovered. "
-                "All jobs require at least one science file."
+                f"No science files were discovered between {target_start} and "
+                f"{target_end}. All jobs require at least one science file."
             )
 
         return science_processing_inputs


### PR DESCRIPTION
Improved dagster logging when there are missing upstream dependencies:

  1. Removed the dead branch (if not dependency_inputs: in run_job) — confirmed unreachable since ProcessingInputCollection has no __bool__/__len__.                                                                                                            
  2. SPICE error now names the missing kernel types: Missing SPICE files ({spice_types}) between {start} and {end}.                                                                                                                                             
  3. Generic science-file error now includes the time range: No science files were discovered between {start} and {end}....


Closes: #1511 