### PR TITLE
Fix problems with the Lo dependency yaml

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
@@ -122,6 +122,14 @@ lo_esa_fit_factors: &lo_esa_fit_factors
       major_version: 1
     - source: lo
       data_type: l1b
+      descriptor: nhk
+      major_version: 1
+    - source: lo
+      data_type: l1b
+      descriptor: shk
+      major_version: 1
+    - source: lo
+      data_type: l1b
       descriptor: instrument-status-summary
       major_version: 1
 
@@ -157,22 +165,6 @@ lo_esa_fit_factors: &lo_esa_fit_factors
     - source: lo
       data_type: l1b
       descriptor: monitorrates
-      major_version: 1
-    - source: lo
-      data_type: l1b
-      descriptor: nhk
-      major_version: 1
-    - source: lo
-      data_type: l1b
-      descriptor: shk
-      major_version: 1
-    - source: lo
-      data_type: l1b
-      descriptor: goodtimes
-      major_version: 1
-    - source: lo
-      data_type: l1b
-      descriptor: bgrates
       major_version: 1
 
 (l1b, badtimes):
@@ -269,14 +261,41 @@ lo_esa_fit_factors: &lo_esa_fit_factors
     - source: lo
       data_type: l1b
       descriptor: nhk
-
-# ======== Level L1C ========
   outputs:
     - source: lo
       data_type: l1b
       descriptor: prostar
       major_version: 1
 
+(l1b, goodtimes):
+  partition: repoint
+  inputs:
+    - source: lo
+      data_type: l1b
+      descriptor: histrates
+    - source: lo
+      data_type: l1b
+      descriptor: de
+      required: false
+    - source: lo
+      data_type: l1b
+      descriptor: nhk
+      required: false
+    - source: lo
+      data_type: ancillary
+      descriptor: bg-rates-anti-ram-overrides
+      required: false
+  outputs:
+    - source: lo
+      data_type: l1b
+      descriptor: goodtimes
+      major_version: 1
+    - source: lo
+      data_type: l1b
+      descriptor: bgrates
+      major_version: 1
+
+# ======== Level L1C ========
 (l1c, pset):
   partition: repoint
   inputs:


### PR DESCRIPTION
It seems that the dagster refactor really hosed the Lo dependency yaml. I compared to the pre-dagster version and also to the Lo pipeline to make sure that the L1A and L1B sections match the pipeline.

Closes: #1524 