### PR TITLE
Increase mag job timeout

### DIFF
--- a/sds_data_manager/constructs/processing_construct.py
+++ b/sds_data_manager/constructs/processing_construct.py
@@ -138,11 +138,15 @@ class ProcessingConstruct(Construct):
             # fargate_cpu_architecture=ecs.CpuArchitecture.ARM64,
             # fargate_operating_system_family=ecs.OperatingSystemFamily.LINUX
         )
-
+        # Mag l1d jobs need a longer timeout
+        if "mag" in job_name:
+            timeout = cdk.Duration.hours(4)
+        else:
+            timeout = cdk.Duration.hours(3)
         batch.EcsJobDefinition(
             self,
             f"ProcessingJob-{job_name}",
             job_definition_name=f"ProcessingJob-{job_name}",
             container=container_definition,
-            timeout=cdk.Duration.hours(3),
+            timeout=timeout,
         )

--- a/sds_data_manager/orchestration/dependencies/imap_mag_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_mag_dependencies.yaml
@@ -277,6 +277,18 @@
       data_type: l1d
       descriptor: burst-rtn
       major_version: 1
+    - source: mag
+      data_type: l1d
+      descriptor: spin-offsets
+      major_version: 1
+    - source: mag
+      data_type: l1d
+      descriptor: gradiometry-offsets-norm
+      major_version: 1
+    - source: mag
+      data_type: l1d
+      descriptor: gradiometry-offsets-burst
+      major_version: 1
 
 (l2, burst-srf):
   partition: daily


### PR DESCRIPTION
# Change Summary

closes #3346
## Overview
Mag l1d jobs were hitting the batch job timeout. The simplest solution is to increase the timeout for all Mag jobs. 

## File changes
- sds_data_manager/constructs/processing_construct.py
