### PR TITLE
Make reconstructed ephemeris optional for SWE L3 and SWAPI L3a

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_swapi_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_swapi_dependencies.yaml
@@ -19,6 +19,7 @@ l3a_spice_common: &l3a_spice_common
   - source: ephemeris_reconstructed
     data_type: spice
     descriptor: historical
+    required: false
     trigger_job: false
   - source: ephemeris_predicted
     data_type: spice

--- a/sds_data_manager/orchestration/dependencies/imap_swe_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_swe_dependencies.yaml
@@ -111,6 +111,7 @@
     - source: ephemeris_reconstructed
       data_type: spice
       descriptor: historical
+      required: false
       trigger_job: false
     - source: ephemeris_predicted
       data_type: spice


### PR DESCRIPTION
# Change Summary

## Overview
When dependency configuration was translated from CSV into YAML, reconstructed ephemeris was mistakenly made required for SWE L3 and SWAPI L3a. This makes it optional again by adding the flag `required: false`, allowing these products to be triggered with only predicted ephemeris.

Fixes #1523 
