### PR TITLE
Make all L3 map jobs use the daily partition

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
@@ -908,16 +908,15 @@ sensor90_l1c_pset: &sensor90_l1c_pset
     - *spice_l2
     - *ancillary_90sensor_l2
     - *sensor90_l1c_pset
-
-# L3 Products - 45sensor
   outputs:
     - source: hi
       data_type: l2
       descriptor: h90-ena-h-sf-nsp-ram-hae-6deg-6mo
       major_version: 1
 
+# L3 Products - 45sensor
 (l3, h45-spx-h-hf-sp-anti-hae-4deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -929,7 +928,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h45-spx-h-hf-sp-anti-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -941,7 +940,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h45-spx-h-hf-sp-full-hae-4deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -953,7 +952,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h45-spx-h-hf-sp-full-hae-6deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -965,7 +964,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h45-spx-h-hf-sp-ram-hae-4deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -977,21 +976,20 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h45-spx-h-hf-sp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
       descriptor: h45-ena-h-hf-sp-ram-hae-6deg-1yr
-
-# L3 Products - Spectral Index - 90sensor
   outputs:
     - source: hi
       data_type: l3
       descriptor: h45-spx-h-hf-sp-ram-hae-6deg-1yr
       major_version: 1
 
+# L3 Products - Spectral Index - 90sensor
 (l3, h90-spx-h-hf-sp-anti-hae-4deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -1003,7 +1001,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h90-spx-h-hf-sp-anti-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -1015,7 +1013,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h90-spx-h-hf-sp-full-hae-4deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -1027,7 +1025,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h90-spx-h-hf-sp-full-hae-6deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -1039,7 +1037,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h90-spx-h-hf-sp-ram-hae-4deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -1051,21 +1049,20 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, h90-spx-h-hf-sp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
       descriptor: h90-ena-h-hf-sp-ram-hae-6deg-1yr
-
-# L3 products - hic
   outputs:
     - source: hi
       data_type: l3
       descriptor: h90-spx-h-hf-sp-ram-hae-6deg-1yr
       major_version: 1
 
+# L3 products - hic
 (l3, hic-spx-h-hf-sp-full-hae-4deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3
@@ -1077,7 +1074,7 @@ sensor90_l1c_pset: &sensor90_l1c_pset
       major_version: 1
 
 (l3, hic-spx-h-hf-sp-full-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: hi
       data_type: l3

--- a/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
@@ -431,16 +431,15 @@ lo_esa_fit_factors: &lo_esa_fit_factors
   inputs:
     - *spice_l2
     - *lo_90_pset
-
-# ======== Level L3 ========
   outputs:
     - source: lo
       data_type: l2
       descriptor: t090-isn-o-sf-nsp-ram-hae-6deg-1yr
       major_version: 1
 
+# ======== Level L3 ========
 (l3, l090-isn-h-sf-nsp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: lo
       data_type: l2
@@ -452,7 +451,7 @@ lo_esa_fit_factors: &lo_esa_fit_factors
       major_version: 1
 
 (l3, l090-isn-o-sf-nsp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: lo
       data_type: l2
@@ -464,7 +463,7 @@ lo_esa_fit_factors: &lo_esa_fit_factors
       major_version: 1
 
 (l3, l090-spx-h-hf-nsp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: lo
       data_type: l2
@@ -476,7 +475,7 @@ lo_esa_fit_factors: &lo_esa_fit_factors
       major_version: 1
 
 (l3, l090-spx-h-hf-sp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: lo
       data_type: l3
@@ -488,7 +487,7 @@ lo_esa_fit_factors: &lo_esa_fit_factors
       major_version: 1
 
 (l3, l090-spx-h-sf-nsp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: lo
       data_type: l2
@@ -500,7 +499,7 @@ lo_esa_fit_factors: &lo_esa_fit_factors
       major_version: 1
 
 (l3, l090-spx-h-sf-sp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: lo
       data_type: l3
@@ -512,7 +511,7 @@ lo_esa_fit_factors: &lo_esa_fit_factors
       major_version: 1
 
 (l3, l090-spxnbs-h-hk-nsp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: lo
       data_type: l2
@@ -524,7 +523,7 @@ lo_esa_fit_factors: &lo_esa_fit_factors
       major_version: 1
 
 (l3, l090-spxnbs-h-sf-nsp-ram-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: lo
       data_type: l2

--- a/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
@@ -1850,7 +1850,7 @@ de_inputs_90sensor: &de_inputs_90sensor
 # ======== L3 Products ========
 
 (l3, u45-spx-h-hf-sp-full-hae-2deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1865,7 +1865,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u45-spx-h-hf-sp-full-hae-2deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1880,7 +1880,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u45-spx-h-hf-sp-full-hae-2deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1895,7 +1895,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u45-spx-h-hf-sp-full-hae-4deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1910,7 +1910,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u45-spx-h-hf-sp-full-hae-4deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1925,7 +1925,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u45-spx-h-hf-sp-full-hae-4deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1940,7 +1940,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u45-spx-h-hf-sp-full-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1955,7 +1955,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u45-spx-h-hf-sp-full-hae-6deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1970,7 +1970,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u45-spx-h-hf-sp-full-hae-6deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -1985,7 +1985,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-2deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2000,7 +2000,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-2deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2015,7 +2015,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-2deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2030,7 +2030,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-4deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2045,7 +2045,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-4deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2060,7 +2060,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-4deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2075,7 +2075,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2090,7 +2090,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-6deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2105,7 +2105,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, u90-spx-h-hf-sp-full-hae-6deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2120,7 +2120,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-2deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2135,7 +2135,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-2deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2150,7 +2150,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-2deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2165,7 +2165,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-4deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2180,7 +2180,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-4deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2195,7 +2195,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-4deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2210,7 +2210,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-6deg-1yr):
-  partition: 1yr
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2225,7 +2225,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-6deg-3mo):
-  partition: 3mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3
@@ -2240,7 +2240,7 @@ de_inputs_90sensor: &de_inputs_90sensor
       major_version: 1
 
 (l3, ulc-spx-h-hf-sp-full-hae-6deg-6mo):
-  partition: 6mo
+  partition: daily
   inputs:
     - source: ultra
       data_type: l3


### PR DESCRIPTION
# Change Summary

## Overview
L3 map jobs fall in two categories:
- Jobs which are triggered every day and analyze the available data to determine if anything should be processed, e.g. Hi `sp-maps`
- Jobs which should be triggered by the upload of a single new file, e.g. spectral index jobs.

The second category are [not triggering as expected](https://github.com/IMAP-Science-Operations-Center/sds-data-manager/issues/1521). We would like to see if changing their `partition` configuration to `daily` helps.

## File changes
Changes all L3 map jobs to `partition: daily`


## Testing
N/A