### PR TITLE
Removed trigger_jobs for pointing_attitude and attitude_history (ie set to True)

### DIFF
--- a/sds_data_manager/orchestration/dependencies/imap_glows_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_glows_dependencies.yaml
@@ -32,7 +32,6 @@ hist_spice: &hist_spice
   - source: pointing_attitude
     data_type: spice
     descriptor: historical
-    trigger_job: false
 
 # ======== Product-specific dependencies ===========
 (l1a, all):

--- a/sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
@@ -29,7 +29,6 @@ spice_common: &spice_common
   - source: attitude_history
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: ephemeris_reconstructed
     data_type: spice
     descriptor: historical
@@ -50,7 +49,6 @@ spice_l1b: &spice_l1b
   - source: spin
     data_type: spin
     descriptor: historical
-    trigger_job: false
 
 spice_l1c: &spice_l1c
   - *spice_common
@@ -68,7 +66,6 @@ spice_l1c: &spice_l1c
   - source: spin
     data_type: spin
     descriptor: historical
-    trigger_job: false
 
 
 spice_l2: &spice_l2

--- a/sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
@@ -49,6 +49,7 @@ spice_l1b: &spice_l1b
   - source: spin
     data_type: spin
     descriptor: historical
+    trigger_job: false
 
 spice_l1c: &spice_l1c
   - *spice_common
@@ -66,6 +67,7 @@ spice_l1c: &spice_l1c
   - source: spin
     data_type: spin
     descriptor: historical
+    trigger_job: false
 
 
 spice_l2: &spice_l2

--- a/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
@@ -33,7 +33,6 @@ spice_common: &spice_common
   - source: attitude_history
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: ephemeris_reconstructed
     data_type: spice
     descriptor: historical

--- a/sds_data_manager/orchestration/dependencies/imap_spacecraft_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_spacecraft_dependencies.yaml
@@ -13,7 +13,6 @@
     - source: attitude_history
       data_type: spice
       descriptor: historical
-      trigger_job: false
     - source: leapseconds
       data_type: spice
       descriptor: historical

--- a/sds_data_manager/orchestration/dependencies/imap_swe_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_swe_dependencies.yaml
@@ -127,7 +127,6 @@
     - source: pointing_attitude
       data_type: spice
       descriptor: historical
-      trigger_job: false
     - source: planetary_ephemeris
       data_type: spice
       descriptor: historical

--- a/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
@@ -107,6 +107,7 @@ spice_l1c_common: &spice_l1c_common
   - source: spin
     data_type: spin
     descriptor: historical
+    trigger_job: false
 
 
 spice_l1c_spacecraft: &spice_l1c_spacecraft
@@ -136,6 +137,7 @@ spice_l1c_spacecraft: &spice_l1c_spacecraft
   - source: spin
     data_type: spin
     descriptor: historical
+    trigger_job: false
   - source: attitude_history
     data_type: spice
     descriptor: historical

--- a/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
+++ b/sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml
@@ -42,7 +42,6 @@ spice_l1b_de: &spice_l1b_de
   - source: attitude_history
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: imap_frames
     data_type: spice
     descriptor: historical
@@ -58,7 +57,6 @@ spice_l1b_de: &spice_l1b_de
   - source: pointing_attitude
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: repoint
     data_type: repoint
     descriptor: historical
@@ -91,7 +89,6 @@ spice_l1c_common: &spice_l1c_common
   - source: attitude_history
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: imap_frames
     data_type: spice
     descriptor: historical
@@ -107,11 +104,9 @@ spice_l1c_common: &spice_l1c_common
   - source: pointing_attitude
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: spin
     data_type: spin
     descriptor: historical
-    trigger_job: false
 
 
 spice_l1c_spacecraft: &spice_l1c_spacecraft
@@ -134,7 +129,6 @@ spice_l1c_spacecraft: &spice_l1c_spacecraft
   - source: pointing_attitude
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: science_frames
     data_type: spice
     descriptor: historical
@@ -142,11 +136,9 @@ spice_l1c_spacecraft: &spice_l1c_spacecraft
   - source: spin
     data_type: spin
     descriptor: historical
-    trigger_job: false
   - source: attitude_history
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: ephemeris_reconstructed
     data_type: spice
     descriptor: historical
@@ -173,7 +165,6 @@ spice_l2: &spice_l2
   - source: pointing_attitude
     data_type: spice
     descriptor: historical
-    trigger_job: false
   - source: imap_frames
     data_type: spice
     descriptor: historical
@@ -892,7 +883,6 @@ de_inputs_90sensor: &de_inputs_90sensor
     - source: pointing_attitude
       data_type: spice
       descriptor: historical
-      trigger_job: false
     - source: ephemeris_reconstructed
       data_type: spice
       descriptor: historical
@@ -1055,7 +1045,6 @@ de_inputs_90sensor: &de_inputs_90sensor
     - source: pointing_attitude
       data_type: spice
       descriptor: historical
-      trigger_job: false
     - source: ephemeris_reconstructed
       data_type: spice
       descriptor: historical


### PR DESCRIPTION
# Updated products that depend on the pointing_attitude and DPS kernels to be True 

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

Made changes to the yaml files to remove all `trigger_jobs: false` found under `pointing_attitude` and `attitude_history` depend-ees.
closes #1476

The ticket also mentions coordinating with Margaret and the MOC/POC to get brand new pointing_attitude files, so just putting that here so it doesn't slip through. 

## File changes
<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- sds_data_manager/orchestration/dependencies/imap_glows_dependencies.yaml
- sds_data_manager/orchestration/dependencies/imap_hi_dependencies.yaml
- sds_data_manager/orchestration/dependencies/imap_lo_dependencies.yaml
- sds_data_manager/orchestration/dependencies/imap_spacecraft_dependencies.yaml
- sds_data_manager/orchestration/dependencies/imap_swe_dependencies.yaml
- sds_data_manager/orchestration/dependencies/imap_ultra_dependencies.yaml


## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
