### PR TITLE
I-ALiRT - add cidr

### DIFF
--- a/sds_data_manager/utils/ialirt_noaa_vpn.py
+++ b/sds_data_manager/utils/ialirt_noaa_vpn.py
@@ -176,10 +176,14 @@ def build_noaa_vpn_tgw(
         transit_gateway_attachment_id=ialirt_vpc_attachment.attr_id,
     )
 
-    # If it's a private address (10.x, 172.16-31.x, 192.168.x),
-    # go back through the TGW instead of the public internet.
+    # If it's a private address (10.x, 172.16-31.x, 192.168.x) or the VPN
+    # tunnel's own link-local inside address (169.254.x), go back through
+    # the TGW instead of the public internet. The link-local range is
+    # needed because NAT Gateway restores the tunnel's own link-local
+    # inside IP as the destination when un-NATting return traffic,
+    # regardless of what prefix is advertised to AWS via BGP.
     def _add_return_routes(subnet_group: str, subnets: list) -> None:
-        for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"):
+        for cidr in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16"):
             cidr_suffix = cidr.split("/")[0].replace(".", "")
             for i, subnet in enumerate(subnets):
                 route = ec2.CfnRoute(


### PR DESCRIPTION
This pull request updates the logic for routing return traffic through the Transit Gateway (TGW) in the `build_noaa_vpn_tgw` function. The main change is to ensure that traffic destined for the VPN tunnel's own link-local inside addresses (169.254.x.x) is routed through the TGW, in addition to existing private address ranges. This helps handle cases where the NAT Gateway restores the link-local address as the destination for return traffic.

Routing logic improvements:

* The `_add_return_routes` helper now includes the `169.254.0.0/16` link-local range in its list of CIDRs, ensuring that return traffic to the VPN tunnel's own link-local inside addresses is routed through the TGW. This addresses an issue where the NAT Gateway may set the destination to the tunnel's link-local address when un-NATting return traffic.
* The code comments have been updated to explain the reason for including the link-local range and its relation to NAT Gateway behavior.


## Testing
This was a result of my StrongSwan test.