### PR TITLE
I-ALiRT - add mopra

### DIFF
--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -93,7 +93,7 @@ class IalirtProcessing(Construct):
         partner_config = {
             "lasp": {  # used for testing only
                 "params": ["lasp"],
-                "ports": [7526, 7563, 7564, 7565, 7566, 7567, 7568],
+                "ports": [7526, 7563, 7564, 7565, 7566, 7567, 7568, 7569],
             },
             "bluenet": {  # tlm relay
                 "params": ["bluenet"],

--- a/sds_data_manager/constructs/ialirt_processing_construct.py
+++ b/sds_data_manager/constructs/ialirt_processing_construct.py
@@ -119,6 +119,10 @@ class IalirtProcessing(Construct):
                 "params": ["sansa-1", "sansa-2"],
                 "ports": [7568],
             },
+            "mopra": {
+                "params": ["mopra"],
+                "ports": [7569],
+            },
         }
 
         for partner, config in partner_config.items():


### PR DESCRIPTION
This pull request adds configuration for a new partner, "mopra", to the ECS security group setup in `ialirt_processing_construct.py`.

Security group configuration update:

* Added a new entry for the "mopra" partner, specifying its parameters and port (7569) in the `partner_config` dictionary in `create_ecs_security_group`.