### PR TITLE
A few improvements to dagster

### DIFF
--- a/sds_data_manager/orchestration/config.py
+++ b/sds_data_manager/orchestration/config.py
@@ -11,22 +11,22 @@ VALID_CADENCE_STRS = ["1mo", "3mo", "6mo", "1yr"]
 FIRST_MAP_START_DATE = datetime.datetime(2026, 1, 17, tzinfo=datetime.timezone.utc)
 
 sensor_schedules = {
-    "l0": 900,
-    "l1": 900,
-    "l1a": 900,
-    "l1b": 900,
-    "l1c": 900,
-    "l1d": 900,
-    "l2": 900,
-    "l2a": 900,
-    "l2b": 900,
-    "l2c": 900,
-    "l2d": 900,
-    "l3": 900,
-    "l3a": 900,
-    "l3b": 900,
-    "l3c": 900,
-    "l3d": 900,
+    "l0": 300,
+    "l1": 300,
+    "l1a": 300,
+    "l1b": 300,
+    "l1c": 300,
+    "l1d": 300,
+    "l2": 300,
+    "l2a": 300,
+    "l2b": 300,
+    "l2c": 300,
+    "l2d": 300,
+    "l3": 300,
+    "l3a": 300,
+    "l3b": 300,
+    "l3c": 300,
+    "l3d": 300,
 }
 
 

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -231,7 +231,7 @@ class IMAPJobHandler:
                             "missing_files": str(e),
                         },
                     )
-                return SkipReason(str(e))
+                return
 
             context.log.info(
                 f"Using the following dependencies: {dependency_inputs.serialize()}"

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -15,6 +15,7 @@ import requests
 from botocore.exceptions import ClientError
 from dagster import (
     AssetExecutionContext,
+    AssetObservation,
     AssetOut,
     DagsterEventType,
     DagsterRunStatus,
@@ -126,7 +127,7 @@ class IMAPJobHandler:
         job : ProcessingJobNode
             The job node to process.
         """
-        self.BATCH_JOB_TIMEOUT_SECONDS = 3600  # 1 hour, can be adjusted as needed.
+        self.BATCH_JOB_TIMEOUT_SECONDS = 18000  # 5 hours
         self.WAIT_TIME_AFTER_BATCH_SECONDS = (
             60  # time to wait after a batch job completes to search for files.
         )
@@ -221,6 +222,15 @@ class IMAPJobHandler:
                 )
             except MissingDependenciesError as e:
                 context.log.info(f"Skipping job: {e}")
+                for output in self.job_config.outputs:
+                    yield AssetObservation(
+                        asset_key=output.to_dagster_asset(),
+                        partition=context.partition_key,
+                        metadata={
+                            "status": "Skipped - Missing Dependencies",
+                            "missing_files": str(e),
+                        },
+                    )
                 return SkipReason(str(e))
 
             context.log.info(
@@ -1292,35 +1302,6 @@ class IMAPJobHandler:
 
         if repoint is not None:
             batch_command.extend(["--repointing", f"repoint{repoint:05d}"])
-
-        # We will check here if this job has already failed with these
-        # exact dependencies
-        conditions = [
-            models.ProcessingJob.instrument == self.job_config.source,
-            models.ProcessingJob.data_level == self.job_config.data_type,
-            models.ProcessingJob.descriptor == self.job_config.descriptor,
-            models.ProcessingJob.dependency_hash == dep_hash,
-            models.ProcessingJob.start_date == start_date.date(),
-        ]
-        conditions.append(models.ProcessingJob.status.in_([models.Status.FAILED.value]))
-        if repoint is not None:
-            conditions.append(models.ProcessingJob.repointing == repoint)
-
-        already_failed_job = (
-            session.query(models.ProcessingJob)
-            .filter(*conditions)
-            .order_by(
-                models.ProcessingJob.major_version.desc(),
-                models.ProcessingJob.minor_version.desc(),
-            )
-            .first()
-        )
-        if already_failed_job:
-            return BatchJobSubmit(
-                status="failed",
-                message="""This exact job has been submitted previously,
-                           and has already failed. No need to run it again.""",
-            )
 
         # Get the necessary AWS information
         # NOTE: These are here for easier mocking in tests rather than at the

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -25,7 +25,6 @@ from dagster import (
     RunRequest,
     RunsFilter,
     SensorEvaluationContext,
-    SkipReason,
     define_asset_job,
     multi_asset,
     sensor,

--- a/tests/orchestration/test_spacecraft.py
+++ b/tests/orchestration/test_spacecraft.py
@@ -14,6 +14,7 @@ import datetime
 import imap_data_access
 import pytest
 from dagster import (
+    AssetObservation,
     Failure,
     build_asset_context,
     build_sensor_context,
@@ -136,9 +137,9 @@ def test_spacecraft_l1a_no_spice(mock_db_session, ephemeral_instance):
         )
     )
 
-    # Verify nothing has happened still, because SPICE is still missing.
+    # Verify that we have only returned an asset observation
     yielded_files = list(spacecraft_l1a_job.run_job(context, 1, 1))
-    assert len(yielded_files) == 0
+    assert isinstance(yielded_files[0], AssetObservation)
 
 
 def test_spacecraft_l1a_submits(


### PR DESCRIPTION
# Change Summary

## Overview
These are a few small unrelated changes, but related to the discussions we had about dagster the other day:

1) The default sensor time is now 5 minutes instead of 15. It was largely 15 just to stop the system from being overwhelmed by the initial processing efforts when dagster turned on for the first time, but 5 minutes should be plenty now 

2) Removed the code the code that prevented failed jobs from running again with no changes. This again was something to help prevent a boatload of processing runs from occurring during the early deployment steps, but now this is causing a hassle and should just be better to re-run. 

3) Increased the allowed batch job timeout to 5 hours. Leaving it at 1 hour caused an issues where the job completed successfully, but Dagster didn't know about it. 

4) Perhaps the nicest one - instead of skipping an asset when we don't have the dependencies, instead we return an "AssetObservation". This keeps the little icon "grey", but it actually returns metadata about the asset at that partition. Now you can click on a grey partition for an asset, and the metadata tells you exactly what dependency it failed to retrieve.  

## File changes
sds_data_manager/orchestration/config.py
- Setting a 5 minute sensor timer instead of 15

sds_data_manager/orchestration/imap_job.py
- 5 hour timeout 
- Added AssetObservation
- Removed "Already Failed" batch job checking 

## Testing
tests/orchestration/test_spacecraft.py
- Fixed a unit test to verify that an AssetObservation is returned instead of nothing if we don't meet the dependencies. 
