### PR TITLE
Better Batch Job monitoring in Dagster

### DIFF
--- a/sds_data_manager/constructs/indexer_lambda_construct.py
+++ b/sds_data_manager/constructs/indexer_lambda_construct.py
@@ -126,23 +126,8 @@ class IndexerLambda(Construct):
             ),
         )
 
-        # Uses batch job status
-        # to update status in the database and
-        # update ingested time if status was success
-        batch_job_status_rule = events.Rule(
-            self,
-            "batchJobStatus",
-            rule_name="batch-job-status",
-            event_pattern=events.EventPattern(
-                source=["aws.batch"],
-                detail_type=["Batch Job State Change"],
-                detail={"status": ["SUCCEEDED", "FAILED"]},
-            ),
-        )
-
         # Add the Lambda function as the target for the rules
         imap_data_arrival_rule.add_target(targets.LambdaFunction(indexer_lambda))
-        batch_job_status_rule.add_target(targets.LambdaFunction(indexer_lambda))
 
 
 class SPICEIndexerLambda(Construct):

--- a/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/indexer.py
+++ b/sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/indexer.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 
 import boto3
 import imap_data_access
@@ -236,118 +236,6 @@ def s3_event_handler(event):
     return http_response(status_code=200, body="Success")
 
 
-def batch_event_handler(event):
-    r"""Batch event handler.
-
-    Parameters
-    ----------
-    event : dict
-        The JSON formatted document with the data required for the
-        lambda function to process
-
-    Example event input:
-    Kept only parameter of interest
-    event = {
-        "detail-type": "Batch Job State Change",
-        "source": "aws.batch",
-        "time": "2025-04-11T18:48:16Z",
-        "detail": {
-            "jobArn": (
-                "arn:aws:batch:us-west-2:012345678910:"
-                "job/26242c7e-3d49-4e41-9387-74fcaf9630bb"
-            ),
-            "jobName": "swe-l0-job",
-            "jobId": "26242c7e-3d49-4e41-9387-74fcaf9630bb",
-            "jobQueue": (
-                "arn:aws:batch:us-west-2:012345678910:"
-                "job-queue/swe-fargate-batch-job-queue"
-            ),
-            "status": "FAILED",
-            "statusReason": "some error message",
-            "createdAt": 1744396985534,
-            "startedAt": 1744397031734,
-            "stoppedAt": 1744397296519,
-            "jobDefinition": (
-                "arn:aws:batch:us-west-2:012345678910:"
-                "job-definition/fargate-batch-job-definitionswe:1"
-            ),
-            "container": {
-                "image": (
-                    "123456789012.dkr.ecr.us-west-2.amazonaws.com/" "swapi-repo:latest"
-                ),
-                "command": [
-                    "--instrument", "swapi",
-                    "--data-level", "l1",
-                    "--descriptor", "sci",
-                    "--start-date", "20230724",
-                    "--version", "v001",
-                    "--dependency", \"""[
-                        {
-                            'instrument': 'swapi',
-                            'level': 'l0',
-                            'start_date': 20230724,
-                            'version': 'v001'
-                        }
-                    ]\""",
-                    "--upload-to-sdc",
-                ],
-                "logStreamName": (
-                    "fargate-batch-job-definitionswe/default/"
-                    "8a2b784c7bd342f69ea5dac3adaed26f"
-                ),
-            },
-        }
-    }
-
-    Returns
-    -------
-    dict
-        HTTP response
-
-    """
-    # Get job status
-    job_status = (
-        models.Status.SUCCEEDED
-        if event["detail"]["status"] == "SUCCEEDED"
-        else models.Status.FAILED
-    )
-
-    # We injected our table ID into the job name
-    job_id = event["detail"]["jobName"].split("-")[-1]
-
-    # Convert startedAt and stoppedAt to datetime with timezone
-    # These fields may not always be present, so use .get() and handle None
-    # Default to startedAt and fallback to createdAt if the job never started
-    started_at_timestamp = event["detail"].get(
-        "startedAt", event["detail"].get("createdAt")
-    )
-    stopped_at_timestamp = event["detail"].get("stoppedAt")
-    started_at = (
-        datetime.fromtimestamp(started_at_timestamp / 1000, tz=timezone.utc)
-        if started_at_timestamp is not None
-        else None
-    )
-    stopped_at = (
-        datetime.fromtimestamp(stopped_at_timestamp / 1000, tz=timezone.utc)
-        if stopped_at_timestamp is not None
-        else None
-    )
-
-    with db.Session() as session:
-        # Get the batch job by its ID
-        job = session.get(models.ProcessingJob, job_id)
-        # Make the updates
-        job.status = job_status
-        job.job_definition = event["detail"]["jobDefinition"]
-        job.job_log_stream_id = event["detail"]["container"]["logStreamName"]
-        job.container_image = event["detail"]["container"]["image"]
-        job.started_at = started_at
-        job.stopped_at = stopped_at
-        session.commit()
-
-    return http_response(status_code=200, body="Success")
-
-
 def lambda_handler(event, context):
     """Create metadata and add it to the database.
 
@@ -371,8 +259,6 @@ def lambda_handler(event, context):
 
     if source == "aws.s3":
         return s3_event_handler(event)
-    elif source == "aws.batch":
-        return batch_event_handler(event)
     else:
         logger.error("Unknown event source")
         return http_response(status_code=400, body="Unknown event source")

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -65,6 +65,9 @@ BATCH_JOB_RETRY_STRATEGY = {
 }
 # Create an sqs client
 SQS_CLIENT = boto3.client("sqs", region_name="us-west-2")
+# Create a client to access Cloudwatch
+LOGS_CLIENT = boto3.client("logs", region_name="us-west-2")
+LOG_GROUP_NAME = "/aws/batch/job"
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -113,6 +116,7 @@ class BatchJobSubmit:
     message: str
     # the ProcessingJob information as a dictionary.
     job: dict | None = None
+    response: dict | None = None
 
 
 class IMAPJobHandler:
@@ -249,14 +253,16 @@ class IMAPJobHandler:
 
             if submit_response.status == "submitted":
                 batch_status = self.wait_for_batch_job(
+                    context,
                     session,
-                    submit_response.job,
+                    submit_response.response,
                     batch_job_timeout,
                     time_to_wait_after_batch_query,
                 )
                 time.sleep(
                     time_to_wait_after_batch_query
                 )  # Give the indexer time to pick up the files
+
                 output_files = self.find_outputs(
                     context,
                     session,
@@ -270,13 +276,6 @@ class IMAPJobHandler:
                 if batch_status == models.Status.FAILED.value:
                     raise Failure(
                         description="Batch Job Failure. View logs for details."
-                    )
-                if batch_status is None:
-                    raise Failure(
-                        description=f"""Timeout Error.
-                                        Dagster has waited {batch_job_timeout}
-                                        seconds for the job to complete,
-                                        and it did not finish."""
                     )
             elif submit_response.status == "skipped":
                 # If we skipped the job, let us materialize any previous outputs
@@ -295,39 +294,99 @@ class IMAPJobHandler:
                 raise Failure(description=submit_response.message)
 
     def wait_for_batch_job(
-        self, session: db.Session, job_info: dict, timeout: int, wait_time: int
+        self,
+        context,
+        session: db.Session,
+        job_response: dict,
+        timeout: int,
+        wait_time: int,
     ):
         """Wait for a Batch job to complete, and return the status."""
+        final_status = models.Status.FAILED
         timeout_start = time.time()
         while time.time() < timeout_start + timeout:
-            job_completed = (
-                session.query(models.ProcessingJob)
-                .filter(
-                    models.ProcessingJob.instrument == job_info["instrument"],
-                    models.ProcessingJob.data_level == job_info["data_level"],
-                    models.ProcessingJob.descriptor == job_info["descriptor"],
-                    models.ProcessingJob.start_date == job_info["start_date"],
-                    models.ProcessingJob.repointing == job_info["repointing"],
-                    models.ProcessingJob.dependency_hash == job_info["dependency_hash"],
-                    models.ProcessingJob.major_version == job_info["major_version"],
-                    models.ProcessingJob.minor_version == job_info["minor_version"],
-                    models.ProcessingJob.status.in_(
-                        [models.Status.FAILED.value, models.Status.SUCCEEDED.value]
-                    ),
-                )
-                .order_by(
-                    models.ProcessingJob.major_version.desc(),
-                    models.ProcessingJob.minor_version.desc(),
-                )
-                .first()
-            )
-            if not job_completed:
-                time.sleep(wait_time)
+            # We injected our table ID into the job name
+            job_database_id = job_response["jobName"].split("-")[-1]
+            describe_response = BATCH_CLIENT.describe_jobs(jobs=[job_response["jobId"]])
+            if not describe_response.get("jobs"):
+                context.log.info("Job not found. It may have been deleted.")
+                break
+            job_info = describe_response["jobs"][0]
+            if job_info["status"] == "SUCCEEDED":
+                final_status = models.Status.SUCCEEDED
+                break
+            elif job_info["status"] == "FAILED":
+                break
             else:
-                return job_completed.status.name
+                time.sleep(wait_time)
+                continue
 
-        # If we time out, return nothing
-        return
+        # Print out some logs
+        container_info = job_info.get("container", {})
+        log_stream_name = container_info.get("logStreamName")
+        if log_stream_name:
+            context.log.info(
+                f"\nFetching the last 100 lines from log stream: {log_stream_name}"
+            )
+            try:
+                # Fetch the latest 100 log events
+                log_response = LOGS_CLIENT.get_log_events(
+                    logGroupName=LOG_GROUP_NAME,
+                    logStreamName=log_stream_name,
+                    limit=100,
+                    startFromHead=False,
+                )
+
+                events = log_response.get("events", [])
+
+                if not events:
+                    context.log.info("No logs found in the stream.")
+                else:
+                    context.log.info("-" * 40)
+                    for event in events:
+                        context.log.info(event["message"])
+                    context.log.info("-" * 40)
+
+            except Exception as e:
+                context.log.info(f"Failed to fetch logs: {e}")
+        else:
+            context.log.info(
+                "No logStreamName found. "
+                "The job may have failed before the container could start."
+            )
+
+        # Gather information about start/stop timing
+        started_at_timestamp = job_info.get("startedAt", job_info.get("createdAt"))
+        stopped_at_timestamp = job_info.get("stoppedAt")
+        started_at = (
+            datetime.datetime.fromtimestamp(
+                started_at_timestamp / 1000, tz=datetime.timezone.utc
+            )
+            if started_at_timestamp is not None
+            else None
+        )
+        stopped_at = (
+            datetime.datetime.fromtimestamp(
+                stopped_at_timestamp / 1000, tz=datetime.timezone.utc
+            )
+            if stopped_at_timestamp is not None
+            else None
+        )
+
+        # Fetch the row in the database
+        job = session.get(models.ProcessingJob, job_database_id)
+
+        # Make updates to the database table
+        job.status = final_status
+        job.job_definition = job_info["jobDefinition"]
+        job.job_log_stream_id = log_stream_name
+        job.container_image = container_info.get("image", "")
+        job.started_at = started_at
+        job.stopped_at = stopped_at
+        session.commit()
+
+        # Return either Success or Failure
+        return final_status
 
     def find_outputs(
         self,
@@ -1378,7 +1437,7 @@ class IMAPJobHandler:
         )
         job_queue = "ProcessingJobQueue"
 
-        BATCH_CLIENT.submit_job(
+        response = BATCH_CLIENT.submit_job(
             jobName=job_name,
             jobQueue=job_queue,
             jobDefinition=job_definition,
@@ -1387,11 +1446,13 @@ class IMAPJobHandler:
             },
             retryStrategy=BATCH_JOB_RETRY_STRATEGY,
         )
+
         logger.info(f"Submitted job {job_name} with this command: {batch_command}")
         return BatchJobSubmit(
             status="submitted",
             message="Job submitted successfully.",
             job=processing_job.to_dict(),
+            response=response,
         )
 
     def upload_dependency_file(

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -282,7 +282,7 @@ class IMAPJobHandler:
                 )
                 for f in output_files:
                     yield f
-                if batch_status == models.Status.FAILED.value:
+                if batch_status == models.Status.FAILED:
                     raise Failure(
                         description="Batch Job Failure. View logs for details."
                     )

--- a/tests/lambda_endpoints/test_indexer_lambda.py
+++ b/tests/lambda_endpoints/test_indexer_lambda.py
@@ -1,133 +1,14 @@
 """Tests for the indexer lambda."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 from imap_data_access import ScienceFilePath
-from sqlalchemy import select
 
 from sds_data_manager.lambda_code.SDSCode.database import models
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas import indexer
 from sds_data_manager.lambda_code.SDSCode.pipeline_lambdas.indexer import (
     send_event_from_indexer,
 )
-
-
-def test_batch_job_event(session, events_client):
-    """Test batch job event."""
-    # Write to Processing job table with current batch job event info
-    job_params = {
-        "status": models.Status.INPROGRESS,
-        "instrument": "swapi",
-        "data_level": "l1",
-        "descriptor": "sci-1min",
-        "start_date": datetime.strptime("20230724", "%Y%m%d"),
-        "major_version": 1,
-        "minor_version": 1,
-    }
-    processing_job = models.ProcessingJob(**job_params)
-    session.add(processing_job)
-    session.commit()
-    job_id = processing_job.id
-
-    # TODO: Will update this test further
-    # when I extend batch job event handler.
-    event = {
-        "detail-type": "Batch Job State Change",
-        "source": "aws.batch",
-        "detail": {
-            "jobArn": (
-                "arn:aws:batch:us-west-2:012345678910:"
-                "job/26242c7e-3d49-4e41-9387-74fcaf9630bb"
-            ),
-            "jobName": f"swe-l0-job-{job_id}",  # NOTE: We need to add job_id to jobName
-            "jobId": "26242c7e-3d49-4e41-9387-74fcaf9630bb",
-            "jobQueue": (
-                "arn:aws:batch:us-west-2:012345678910:"
-                "job-queue/swe-fargate-batch-job-queue"
-            ),
-            "status": "FAILED",
-            "statusReason": "some error message",
-            "startedAt": 1744397031734,
-            "stoppedAt": 1744397296519,
-            "jobDefinition": (
-                "arn:aws:batch:us-west-2:012345678910:"
-                "job-definition/fargate-batch-job-definitionswe:1"
-            ),
-            "container": {
-                "image": (
-                    "123456789012.dkr.ecr.us-west-2.amazonaws.com/swapi-repo:latest"
-                ),
-                "command": [
-                    "--instrument",
-                    "swapi",
-                    "--level",
-                    "l1",
-                    "--descriptor",
-                    "sci-1min",
-                    "--start-date",
-                    "20230724",
-                    "--version",
-                    "v001",
-                    "--dependency",
-                    """[
-                        {
-                            'instrument': 'swapi',
-                            'level': 'l0',
-                            'start_date': 20230724,
-                            'version': 'v001'
-                        }
-                    ]""",
-                    "--use-remote",
-                ],
-                "logStreamName": (
-                    "fargate-batch-job-definitionswe/default/"
-                    "8a2b784c7bd342f69ea5dac3adaed26f"
-                ),
-            },
-        },
-    }
-    returned_value = indexer.lambda_handler(event=event, context={})
-    assert returned_value["statusCode"] == 200
-
-    # check that data was written to status table
-    query = select(models.ProcessingJob.__table__).where(
-        models.ProcessingJob.instrument == job_params["instrument"],
-        models.ProcessingJob.data_level == job_params["data_level"],
-        models.ProcessingJob.major_version == job_params["major_version"],
-        models.ProcessingJob.minor_version == job_params["minor_version"],
-    )
-
-    processing_job = session.execute(query).first()
-    assert processing_job.id == job_id
-    assert processing_job.status == models.Status.FAILED
-    # Processing time should be 2025-04-11 18:48:16.519000+00:00.
-    # Had to do replace timezone info to be None because test's db
-    # looses timezone info. This shouldn't happen in production.
-    expected_started_at = datetime.fromtimestamp(
-        event["detail"]["startedAt"] / 1000, tz=timezone.utc
-    ).replace(tzinfo=None)
-    expected_stopped_at = datetime.fromtimestamp(
-        event["detail"]["stoppedAt"] / 1000, tz=timezone.utc
-    ).replace(tzinfo=None)
-
-    assert processing_job.started_at == expected_started_at
-    assert processing_job.stopped_at == expected_stopped_at
-
-    # Test for succeeded case
-    event["detail"]["status"] = "SUCCEEDED"
-    returned_value = indexer.lambda_handler(event=event, context={})
-    assert returned_value["statusCode"] == 200
-
-    query = select(models.ProcessingJob.__table__).where(
-        models.ProcessingJob.instrument == job_params["instrument"],
-        models.ProcessingJob.data_level == job_params["data_level"],
-        models.ProcessingJob.major_version == job_params["major_version"],
-        models.ProcessingJob.minor_version == job_params["minor_version"],
-    )
-
-    processing_job = session.execute(query).first()
-    assert processing_job.id == job_id
-    assert processing_job.status == models.Status.SUCCEEDED
 
 
 def test_s3_sci_event(session, s3_client, events_client):

--- a/tests/orchestration/conftest.py
+++ b/tests/orchestration/conftest.py
@@ -139,9 +139,38 @@ def batch_client():
 
     # Mock describe_job_definitions to return a valid job definition
     mock_batch_client.describe_job_definitions.side_effect = get_job_definition
-    with (
-        patch.object(imap_job, "BATCH_CLIENT", mock_batch_client),
+
+    def return_job_info(
+        jobName,  # noqa: N803
+        jobQueue,  # noqa: N803
+        jobDefinition,  # noqa: N803
+        containerOverrides,  # noqa: N803
+        retryStrategy,  # noqa: N803
     ):
+        return {
+            "jobId": "mock-test-job-id-123",
+            "jobName": jobName,
+            "jobDefinition": jobDefinition,
+            "jobQueue": jobQueue,
+        }
+
+    # Mock submit_job to safely return a dummy job ID
+    mock_batch_client.submit_job.side_effect = return_job_info
+
+    # Mock describe_jobs
+    mock_batch_client.describe_jobs.return_value = {
+        "jobs": [
+            {
+                "jobId": "mock-test-job-id-123",
+                "status": "SUCCEEDED",
+                "stoppedAt": 1480460816500,
+                "container": {"logStreamName": "mock/log/stream/123"},
+                "jobDefinition": "testDef",
+            }
+        ]
+    }
+
+    with patch.object(imap_job, "BATCH_CLIENT", mock_batch_client):
         yield mock_batch_client
 
 

--- a/tests/orchestration/conftest.py
+++ b/tests/orchestration/conftest.py
@@ -172,10 +172,10 @@ def batch_client():
     mock_logs_client = Mock()
     mock_logs_client.get_log_events.return_value = {"events": []}
     with (
-         patch.object(imap_job, "BATCH_CLIENT", mock_batch_client),
-         patch.object(imap_job, "LOGS_CLIENT", mock_logs_client),
+        patch.object(imap_job, "BATCH_CLIENT", mock_batch_client),
+        patch.object(imap_job, "LOGS_CLIENT", mock_logs_client),
     ):
-         yield mock_batch_client
+        yield mock_batch_client
 
 
 @pytest.fixture

--- a/tests/orchestration/conftest.py
+++ b/tests/orchestration/conftest.py
@@ -169,9 +169,13 @@ def batch_client():
             }
         ]
     }
-
-    with patch.object(imap_job, "BATCH_CLIENT", mock_batch_client):
-        yield mock_batch_client
+    mock_logs_client = Mock()
+    mock_logs_client.get_log_events.return_value = {"events": []}
+    with (
+         patch.object(imap_job, "BATCH_CLIENT", mock_batch_client),
+         patch.object(imap_job, "LOGS_CLIENT", mock_logs_client),
+    ):
+         yield mock_batch_client
 
 
 @pytest.fixture

--- a/tests/orchestration/test_end_to_end.py
+++ b/tests/orchestration/test_end_to_end.py
@@ -97,7 +97,7 @@ def test_glows_l1a_end_to_end(
     # So nothing is returned
     yielded_files = list(glows_l1a_job.run_job(context, 1, 1))
     assert len(mock_db_session.query(models.ProcessingJob).all()) == 1
-    assert len(list(yielded_files)) == 0
+    assert len(yielded_files) == 0
 
     # TEST 4: Run the job again.
     # We expect it to simply exit,

--- a/tests/orchestration/test_end_to_end.py
+++ b/tests/orchestration/test_end_to_end.py
@@ -6,11 +6,9 @@
 # poetry run pytest tests/orchestration/test_end_to_end.py -s
 import datetime
 
-import pytest
 from dagster import (
     AssetKey,
     AssetMaterialization,
-    Failure,
     MaterializeResult,
     build_asset_context,
     build_sensor_context,
@@ -94,14 +92,18 @@ def test_glows_l1a_end_to_end(
     assert glows_l1a_job is not None, (
         "glows_l1a_all_processing_job was not found in job_handlers"
     )
-    # TEST 3: Run the asset and verify there is a timeout error.
-    with pytest.raises(Failure, match="Timeout"):
-        yielded_files = list(glows_l1a_job.run_job(context, 1, 1))
+    # TEST 3: Run the asset and verify that a job was submitted
+    # We expect a job to have been submitted, but no files exist in the DB
+    # So nothing is returned
+    yielded_files = list(glows_l1a_job.run_job(context, 1, 1))
+    assert len(mock_db_session.query(models.ProcessingJob).all()) == 1
+    assert len(list(yielded_files)) == 0
 
     # TEST 4: Run the job again.
     # We expect it to simply exit,
-    # because there is still an "INPROGRESS" job in the database.
+    # because this exact job was run previously
     yielded_files = glows_l1a_job.run_job(context, 1, 1)
+    assert len(mock_db_session.query(models.ProcessingJob).all()) == 1
     assert len(list(yielded_files)) == 0
 
     # Insert pretend data into ScienceFiles
@@ -149,3 +151,5 @@ def test_glows_l1a_end_to_end(
             "imap_glows_l1a_de_20260102_v001.0001.cdf",
             "imap_glows_l1a_hist_20260102_v001.0001.cdf",
         )
+    # Assert only one job has ever been submitted still
+    assert len(mock_db_session.query(models.ProcessingJob).all()) == 1

--- a/tests/orchestration/test_spacecraft.py
+++ b/tests/orchestration/test_spacecraft.py
@@ -15,7 +15,6 @@ import imap_data_access
 import pytest
 from dagster import (
     AssetObservation,
-    Failure,
     build_asset_context,
     build_sensor_context,
 )

--- a/tests/orchestration/test_spacecraft.py
+++ b/tests/orchestration/test_spacecraft.py
@@ -14,7 +14,6 @@ import datetime
 import imap_data_access
 import pytest
 from dagster import (
-    Failure,
     build_asset_context,
     build_sensor_context,
 )
@@ -139,6 +138,7 @@ def test_spacecraft_l1a_no_spice(mock_db_session, ephemeral_instance):
     # Verify nothing has happened still, because SPICE is still missing.
     yielded_files = list(spacecraft_l1a_job.run_job(context, 1, 1))
     assert len(yielded_files) == 0
+    assert len(mock_db_session.query(models.ProcessingJob).all()) == 0
 
 
 def test_spacecraft_l1a_submits(
@@ -177,7 +177,8 @@ def test_spacecraft_l1a_submits(
     _insert_spice_file(mock_db_session, "imap_120.tf", [[1, 10000000000000]])
     _insert_spice_file(mock_db_session, "imap_science_120.tf", [[1, 10000000000000]])
 
-    # Run the asset and verify an error is thrown because there is a timeout
-    # The fact that it gets to timeout means that the job has submitted!
-    with pytest.raises(Failure, match="Timeout"):
-        list(spacecraft_l1a_job.run_job(context, 1, 1))
+    # Run the asset and verify we get to the end, showing a batch job was submitted
+    list(spacecraft_l1a_job.run_job(context, 1, 1))
+
+    # Show that a Batch job was submitted
+    assert len(mock_db_session.query(models.ProcessingJob).all()) == 1


### PR DESCRIPTION
# Change Summary

## Overview
This code started as a way for to print out some logs from the Batch jobs, to enable better debugging from within the Dagster interface. However, I realized we could just move the entire Batch job monitoring out of the file indexer and into Dagster. Since a dagster container is already sitting there waiting for changes in job status, it can also just be the one that inserts status into the DB. 


## File changes
sds_data_manager/constructs/indexer_lambda_construct.py
- Removing AWS Batch job status triggers from the indexer

sds_data_manager/lambda_code/SDSCode/pipeline_lambdas/indexer.py
- Removing Batch job status handling code

sds_data_manager/orchestration/imap_job.py
- Moved Batch job status handling into Dagster. 
- During the Asset creation, we'll now print out the last 100 lines from the cloudwatch logs. This will cause those logs to show up in Dagster. 

## Testing
Several of the unit tests had to be modified to accompany these changes. But they do confirm that the batch job submission and subsequent modification work as intended. 