### PR TITLE
imap_processing version bump

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1659,20 +1659,20 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "imap-processing"
-version = "1.0.34"
+version = "1.0.35"
 description = "IMAP Science Operations Center Processing"
 optional = false
 python-versions = "<3.13,>=3.10"
 groups = ["layer-idex-processing", "layer-processing"]
 files = [
-    {file = "imap_processing-1.0.34-py3-none-any.whl", hash = "sha256:ad2a2c4c2f0a868afb9bdf41c74d54ec0b8bdfb2828b7fb97c564ef8db73b3dd"},
-    {file = "imap_processing-1.0.34.tar.gz", hash = "sha256:d47baf8e1debb562cd62214b16b5163f8c232be271c9b0b459e74fefd1d92ad1"},
+    {file = "imap_processing-1.0.35-py3-none-any.whl", hash = "sha256:21f344b2d2783764be8de5575e7097917912973d1a1a4e5714a05c3e9035a45f"},
+    {file = "imap_processing-1.0.35.tar.gz", hash = "sha256:1e4605da3d3ac453a7d667e3f94cfe5355935b6a81541873e5914a9f3ee1455c"},
 ]
 
 [package.dependencies]
 astropy-healpix = ">=1.0"
 cdflib = ">=1.3.11"
-imap-data-access = ">=0.37.0"
+imap-data-access = ">=0.42.0"
 numpy = ">=2,<3"
 sammi-cdf = ">=1.0,<2"
 scipy = ">=1.13,<2"
@@ -4831,4 +4831,4 @@ tool = ["alembic"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "92113c18105f98453149510fa9e0f4eb3d952caeefbd7e1cbfb8b9bb0c40cc0d"
+content-hash = "6c155bcb1cddd26455f959f7bacbcfb439ff0c820bf762501b2c271561a24c77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,12 +82,12 @@ requests = "^2.28.2"
 spiceypy = "^6.0.0"
 
 [tool.poetry.group.layer-processing.dependencies]
-imap-processing = "1.0.34"
+imap-processing = "1.0.35"
 pandas = ">=3.0.3,<4.0.0"
 
 
 [tool.poetry.group.layer-idex-processing.dependencies]
-imap-processing = "^1.0.34"
+imap-processing = "^1.0.35"
 spiceypy = "^6.0.0"
 sqlalchemy = "^2.0.49"
 psycopg2-binary = "^2.9.12"

--- a/sds_data_manager/lambda_code/idex_processing/requirements.txt
+++ b/sds_data_manager/lambda_code/idex_processing/requirements.txt
@@ -261,9 +261,9 @@ idna==3.18 ; python_version >= "3.11" and python_version < "3.13" \
 imap-data-access==0.42.0 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:5eb6081dd9e6bcac2be60d5bb288a66d8d52922124d52e6d1ac7020beff2bc4b \
     --hash=sha256:64dbd378dbe57e35eee157b513ee4929b279056983c19bd1481eeb90dac07fbf
-imap-processing==1.0.34 ; python_version >= "3.11" and python_version < "3.13" \
-    --hash=sha256:ad2a2c4c2f0a868afb9bdf41c74d54ec0b8bdfb2828b7fb97c564ef8db73b3dd \
-    --hash=sha256:d47baf8e1debb562cd62214b16b5163f8c232be271c9b0b459e74fefd1d92ad1
+imap-processing==1.0.35 ; python_version >= "3.11" and python_version < "3.13" \
+    --hash=sha256:1e4605da3d3ac453a7d667e3f94cfe5355935b6a81541873e5914a9f3ee1455c \
+    --hash=sha256:21f344b2d2783764be8de5575e7097917912973d1a1a4e5714a05c3e9035a45f
 jmespath==1.1.0 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/sds_data_manager/lambda_code/processing/requirements.txt
+++ b/sds_data_manager/lambda_code/processing/requirements.txt
@@ -261,9 +261,9 @@ idna==3.18 ; python_version >= "3.11" and python_version < "3.13" \
 imap-data-access==0.42.0 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:5eb6081dd9e6bcac2be60d5bb288a66d8d52922124d52e6d1ac7020beff2bc4b \
     --hash=sha256:64dbd378dbe57e35eee157b513ee4929b279056983c19bd1481eeb90dac07fbf
-imap-processing==1.0.34 ; python_version >= "3.11" and python_version < "3.13" \
-    --hash=sha256:ad2a2c4c2f0a868afb9bdf41c74d54ec0b8bdfb2828b7fb97c564ef8db73b3dd \
-    --hash=sha256:d47baf8e1debb562cd62214b16b5163f8c232be271c9b0b459e74fefd1d92ad1
+imap-processing==1.0.35 ; python_version >= "3.11" and python_version < "3.13" \
+    --hash=sha256:1e4605da3d3ac453a7d667e3f94cfe5355935b6a81541873e5914a9f3ee1455c \
+    --hash=sha256:21f344b2d2783764be8de5575e7097917912973d1a1a4e5714a05c3e9035a45f
 jmespath==1.1.0 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64


### PR DESCRIPTION
This pull request updates the `imap-processing` dependency to version 1.0.35 across multiple parts of the project to ensure consistency and incorporate the latest improvements or bug fixes. The change affects both the main dependency management files and the specific requirements for lambda code.

Dependency version updates:

* Bumped `imap-processing` from version 1.0.34 to 1.0.35 in the `[tool.poetry.group.layer-processing.dependencies]` and `[tool.poetry.group.layer-idex-processing.dependencies]` sections of `pyproject.toml` for Poetry-managed environments.
* Updated `imap-processing` from 1.0.34 to 1.0.35 in `sds_data_manager/lambda_code/processing/requirements.txt`, including new hash values for integrity checks.
* Updated `imap-processing` from 1.0.34 to 1.0.35 in `sds_data_manager/lambda_code/idex_processing/requirements.txt`, also with new hash values.
