### PR TITLE
Update batch job retry strategy

### DIFF
--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -57,9 +57,10 @@ BATCH_JOB_RETRY_STRATEGY = {
     "attempts": 10,
     "evaluateOnExit": [
         {
-            "onStatusReason": "Your Spot Task was interrupted.",
+            "onExitCode": "75",
             "action": "RETRY",
-        },
+        },  # retry jobs that failed with the rerunable exit code.
+        {"onReason": "CannotPullContainerError*", "action": "RETRY"},
         {"onReason": "*", "action": "EXIT"},
     ],
 }

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -60,7 +60,7 @@ BATCH_JOB_RETRY_STRATEGY = {
             "onExitCode": "75",
             "action": "RETRY",
         },  # retry jobs that failed with the rerunable exit code.
-        {"onReason": "CannotPullContainerError*", "action": "RETRY"},
+        {"onStatusReason": "CannotPullContainerError*", "action": "RETRY"},
         {"onReason": "*", "action": "EXIT"},
     ],
 }

--- a/sds_data_manager/orchestration/imap_job.py
+++ b/sds_data_manager/orchestration/imap_job.py
@@ -59,7 +59,7 @@ BATCH_JOB_RETRY_STRATEGY = {
         {
             "onExitCode": "75",
             "action": "RETRY",
-        },  # retry jobs that failed with the rerunable exit code.
+        },  # retry jobs that failed with the rerunnable exit code.
         {"onStatusReason": "CannotPullContainerError*", "action": "RETRY"},
         {"onReason": "*", "action": "EXIT"},
     ],


### PR DESCRIPTION
# Change Summary

closes #1472

## Overview

We no longer need the "spot task was interrupted" retry because we are using on demand instances now. I also added a retry when the exit code is 75. This is the exit code that specifies this job should be retried. For example, when there was an imap-data-access 503 error we should retry the job. We should also retry the job when the job could not pull the container. E.g the status reason was "CannotPullContainerError".

## File changes
- sds_data_manager/orchestration/imap_job.py
   - Update retry strategy 
