### PR TITLE
noaa needed to change this

### DIFF
--- a/sds_data_manager/constructs/ialirt_vpn_construct.py
+++ b/sds_data_manager/constructs/ialirt_vpn_construct.py
@@ -114,14 +114,14 @@ class IalirtVpnConstruct(Construct):
         self.vpn_connections: dict[str, ec2.CfnVPNConnection] = {}
         for site, ip in {"WASH": wash_ip, "DENV": denv_ip}.items():
             # AWS needs to know the router's public IP and ASN to establish the tunnel.
-            # bgp_asn=64583 is NOAA's ASN per the ICD. This must match the ASN
+            # bgp_asn=64893 is NOAA's ASN per the ICD. This must match the ASN
             # configured on NOAA's actual router — AWS silently rejects the BGP
             # session (not the tunnel itself) if the peer AS doesn't match what's
             # registered here.
             cgw = ec2.CfnCustomerGateway(
                 self,
                 f"NoaaCustomerGateway{site}",
-                bgp_asn=64583,
+                bgp_asn=64893,
                 ip_address=ip,
                 type="ipsec.1",
             )


### PR DESCRIPTION
This pull request updates the BGP ASN configuration for NOAA's customer gateway in the `ialirt_vpn_construct.py` file to ensure it matches the value specified in the ICD and on NOAA's actual router. This change is necessary for successful BGP session establishment.

Networking configuration update:

* Changed the `bgp_asn` value from `64583` to `64893` for NOAA's customer gateway in the VPN construct to match the ICD and NOAA's router configuration.
